### PR TITLE
Improve parser API

### DIFF
--- a/sixtyfps_compiler/parser.rs
+++ b/sixtyfps_compiler/parser.rs
@@ -378,6 +378,10 @@ impl Token {
     pub fn as_str(&self) -> &str {
         self.text.as_str()
     }
+
+    pub fn kind(&self) -> SyntaxKind {
+        self.kind
+    }
 }
 
 mod parser_trait {

--- a/sixtyfps_compiler/parser.rs
+++ b/sixtyfps_compiler/parser.rs
@@ -420,7 +420,7 @@ mod parser_trait {
         );
         fn peek(&mut self) -> Token;
         /// Peek the n'th token, not including whitespaces and comments
-        fn nth(&mut self, n: usize) -> SyntaxKind;
+        fn nth(&mut self, n: usize) -> Token;
         fn consume(&mut self);
         fn error(&mut self, e: impl Into<String>);
 
@@ -536,7 +536,7 @@ impl Parser for DefaultParser {
     }
 
     /// Peek the n'th token, not including whitespaces and comments
-    fn nth(&mut self, mut n: usize) -> SyntaxKind {
+    fn nth(&mut self, mut n: usize) -> Token {
         self.consume_ws();
         let mut c = self.cursor;
         while n > 0 {
@@ -548,7 +548,7 @@ impl Parser for DefaultParser {
                 c += 1;
             }
         }
-        self.tokens.get(c).map_or(SyntaxKind::Eof, |x| x.kind)
+        self.tokens.get(c).cloned().unwrap_or_default()
     }
 
     /// Consume the current token

--- a/sixtyfps_compiler/parser.rs
+++ b/sixtyfps_compiler/parser.rs
@@ -436,7 +436,7 @@ mod parser_trait {
 
         /// If the token if of this type, consume it and return true, otherwise return false
         fn test(&mut self, kind: SyntaxKind) -> bool {
-            if self.nth(0) != kind {
+            if self.nth(0).kind() != kind {
                 return false;
             }
             self.consume();
@@ -447,7 +447,7 @@ mod parser_trait {
         fn until(&mut self, kind: SyntaxKind) {
             // FIXME! match {} () []
             while {
-                let k = self.nth(0);
+                let k = self.nth(0).kind();
                 k != kind && k != SyntaxKind::Eof
             } {
                 self.consume();

--- a/sixtyfps_compiler/parser/document.rs
+++ b/sixtyfps_compiler/parser/document.rs
@@ -35,7 +35,7 @@ pub fn parse_document(p: &mut impl Parser) -> bool {
                 }
             }
             _ => {
-                if p.peek().as_str() == "component" && p.nth(1) != SyntaxKind::ColonEqual {
+                if p.peek().as_str() == "component" && p.nth(1).kind() != SyntaxKind::ColonEqual {
                     p.expect(SyntaxKind::Identifier);
                 }
 
@@ -45,7 +45,7 @@ pub fn parse_document(p: &mut impl Parser) -> bool {
             }
         }
 
-        if p.nth(0) == SyntaxKind::Eof {
+        if p.nth(0).kind() == SyntaxKind::Eof {
             return true;
         }
     }
@@ -100,10 +100,10 @@ pub fn parse_element(p: &mut impl Parser) -> bool {
 /// ```
 fn parse_element_content(p: &mut impl Parser) {
     loop {
-        match p.nth(0) {
+        match p.nth(0).kind() {
             SyntaxKind::RBrace => return,
             SyntaxKind::Eof => return,
-            SyntaxKind::Identifier => match p.nth(1) {
+            SyntaxKind::Identifier => match p.nth(1).kind() {
                 SyntaxKind::Colon => parse_property_binding(&mut *p),
                 SyntaxKind::ColonEqual | SyntaxKind::LBrace => parse_sub_element(&mut *p),
                 SyntaxKind::FatArrow => parse_signal_connection(&mut *p),
@@ -164,7 +164,7 @@ fn parse_element_content(p: &mut impl Parser) {
 /// Must consume at least one token
 fn parse_sub_element(p: &mut impl Parser) {
     let mut p = p.start_node(SyntaxKind::SubElement);
-    if p.nth(1) == SyntaxKind::ColonEqual {
+    if p.nth(1).kind() == SyntaxKind::ColonEqual {
         assert!(p.expect(SyntaxKind::Identifier));
         p.expect(SyntaxKind::ColonEqual);
     }
@@ -182,11 +182,11 @@ fn parse_repeated_element(p: &mut impl Parser) {
     debug_assert_eq!(p.peek().as_str(), "for");
     let mut p = p.start_node(SyntaxKind::RepeatedElement);
     p.consume(); // "for"
-    if p.nth(0) == SyntaxKind::Identifier {
+    if p.nth(0).kind() == SyntaxKind::Identifier {
         let mut p = p.start_node(SyntaxKind::DeclaredIdentifier);
         p.expect(SyntaxKind::Identifier);
     }
-    if p.nth(0) == SyntaxKind::LBracket {
+    if p.nth(0).kind() == SyntaxKind::LBracket {
         let mut p = p.start_node(SyntaxKind::RepeatedIndex);
         p.expect(SyntaxKind::LBracket);
         p.expect(SyntaxKind::Identifier);
@@ -235,7 +235,7 @@ pub fn parse_qualified_name(p: &mut impl Parser) -> bool {
     }
 
     loop {
-        if p.nth(0) != SyntaxKind::Dot {
+        if p.nth(0).kind() != SyntaxKind::Dot {
             break;
         }
         p.consume();
@@ -266,7 +266,7 @@ fn parse_property_binding(p: &mut impl Parser) {
 /// ```
 fn parse_binding_expression(p: &mut impl Parser) {
     let mut p = p.start_node(SyntaxKind::BindingExpression);
-    if p.nth(0) == SyntaxKind::LBrace && p.nth(2) != SyntaxKind::Colon {
+    if p.nth(0).kind() == SyntaxKind::LBrace && p.nth(2).kind() != SyntaxKind::Colon {
         parse_code_block(&mut *p);
         p.test(SyntaxKind::Semicolon);
     } else {
@@ -287,7 +287,7 @@ pub fn parse_code_block(p: &mut impl Parser) {
     let mut p = p.start_node(SyntaxKind::CodeBlock);
     p.expect(SyntaxKind::LBrace); // Or assert?
 
-    while p.nth(0) != SyntaxKind::RBrace {
+    while p.nth(0).kind() != SyntaxKind::RBrace {
         if !parse_statement(&mut *p) {
             break;
         }
@@ -338,7 +338,7 @@ fn parse_property_declaration(p: &mut impl Parser) {
         let mut p = p.start_node(SyntaxKind::DeclaredIdentifier);
         p.expect(SyntaxKind::Identifier);
     }
-    if p.nth(0) == SyntaxKind::Colon {
+    if p.nth(0).kind() == SyntaxKind::Colon {
         p.consume();
         parse_binding_expression(&mut *p);
     } else {
@@ -356,11 +356,11 @@ fn parse_property_animation(p: &mut impl Parser) {
     debug_assert_eq!(p.peek().as_str(), "animate");
     let mut p = p.start_node(SyntaxKind::PropertyAnimation);
     p.consume(); // animate
-    if p.nth(0) == SyntaxKind::Star {
+    if p.nth(0).kind() == SyntaxKind::Star {
         p.consume();
     } else {
         parse_qualified_name(&mut *p);
-        while p.nth(0) == SyntaxKind::Comma {
+        while p.nth(0).kind() == SyntaxKind::Comma {
             p.consume();
             parse_qualified_name(&mut *p);
         }
@@ -368,13 +368,13 @@ fn parse_property_animation(p: &mut impl Parser) {
     p.expect(SyntaxKind::LBrace);
 
     loop {
-        match p.nth(0) {
+        match p.nth(0).kind() {
             SyntaxKind::RBrace => {
                 p.consume();
                 return;
             }
             SyntaxKind::Eof => return,
-            SyntaxKind::Identifier => match p.nth(1) {
+            SyntaxKind::Identifier => match p.nth(1).kind() {
                 SyntaxKind::Colon => parse_property_binding(&mut *p),
                 _ => {
                     p.consume();
@@ -409,7 +409,7 @@ fn parse_states(p: &mut impl Parser) {
 /// foo when bar == 1:  { color: blue; foo.color: red;   }
 /// ```
 fn parse_state(p: &mut impl Parser) -> bool {
-    if p.nth(0) != SyntaxKind::Identifier {
+    if p.nth(0).kind() != SyntaxKind::Identifier {
         return false;
     }
     let mut p = p.start_node(SyntaxKind::State);
@@ -427,7 +427,7 @@ fn parse_state(p: &mut impl Parser) -> bool {
     }
 
     loop {
-        match p.nth(0) {
+        match p.nth(0).kind() {
             SyntaxKind::RBrace => {
                 p.consume();
                 return true;
@@ -453,7 +453,7 @@ fn parse_transitions(p: &mut impl Parser) {
     let mut p = p.start_node(SyntaxKind::Transitions);
     p.consume(); // "transitions"
     p.expect(SyntaxKind::LBracket);
-    while p.nth(0) != SyntaxKind::RBracket && parse_transition(&mut *p) {}
+    while p.nth(0).kind() != SyntaxKind::RBracket && parse_transition(&mut *p) {}
     p.expect(SyntaxKind::RBracket);
 }
 
@@ -480,7 +480,7 @@ fn parse_transition(p: &mut impl Parser) -> bool {
     }
 
     loop {
-        match p.nth(0) {
+        match p.nth(0).kind() {
             SyntaxKind::RBrace => {
                 p.consume();
                 return true;
@@ -510,7 +510,7 @@ fn parse_export(p: &mut impl Parser) -> bool {
     if p.test(SyntaxKind::LBrace) {
         loop {
             parse_export_specifier(&mut *p);
-            match p.nth(0) {
+            match p.nth(0).kind() {
                 SyntaxKind::RBrace => {
                     p.consume();
                     return true;
@@ -595,7 +595,7 @@ fn parse_import_identifier_list(p: &mut impl Parser) -> bool {
     }
     loop {
         parse_import_identifier(&mut *p);
-        match p.nth(0) {
+        match p.nth(0).kind() {
             SyntaxKind::RBrace => {
                 p.consume();
                 return true;
@@ -625,7 +625,7 @@ fn parse_import_identifier(p: &mut impl Parser) -> bool {
             return false;
         }
     }
-    if p.nth(0) == SyntaxKind::Identifier && p.peek().as_str() == "as" {
+    if p.nth(0).kind() == SyntaxKind::Identifier && p.peek().as_str() == "as" {
         p.consume();
         let mut p = p.start_node(SyntaxKind::InternalName);
         if !p.expect(SyntaxKind::Identifier) {

--- a/sixtyfps_compiler/parser/expressions.rs
+++ b/sixtyfps_compiler/parser/expressions.rs
@@ -56,9 +56,9 @@ enum OperatorPrecedence {
 fn parse_expression_helper(p: &mut impl Parser, precedence: OperatorPrecedence) {
     let mut p = p.start_node(SyntaxKind::Expression);
     let checkpoint = p.checkpoint();
-    match p.nth(0) {
+    match p.nth(0).kind() {
         SyntaxKind::Identifier => {
-            if p.nth(1) == SyntaxKind::Bang {
+            if p.nth(1).kind() == SyntaxKind::Bang {
                 parse_bang_expression(&mut *p)
             } else {
                 parse_qualified_name(&mut *p);
@@ -95,7 +95,7 @@ fn parse_expression_helper(p: &mut impl Parser, precedence: OperatorPrecedence) 
         }
     }
 
-    match p.nth(0) {
+    match p.nth(0).kind() {
         SyntaxKind::LParent => {
             {
                 let _ = p.start_node_at(checkpoint.clone(), SyntaxKind::Expression);
@@ -112,7 +112,7 @@ fn parse_expression_helper(p: &mut impl Parser, precedence: OperatorPrecedence) 
         return;
     }
 
-    while matches!(p.nth(0), SyntaxKind::Star | SyntaxKind::Div) {
+    while matches!(p.nth(0).kind(), SyntaxKind::Star | SyntaxKind::Div) {
         {
             let _ = p.start_node_at(checkpoint.clone(), SyntaxKind::Expression);
         }
@@ -125,7 +125,7 @@ fn parse_expression_helper(p: &mut impl Parser, precedence: OperatorPrecedence) 
         return;
     }
 
-    while matches!(p.nth(0), SyntaxKind::Plus | SyntaxKind::Minus) {
+    while matches!(p.nth(0).kind(), SyntaxKind::Plus | SyntaxKind::Minus) {
         {
             let _ = p.start_node_at(checkpoint.clone(), SyntaxKind::Expression);
         }
@@ -139,7 +139,7 @@ fn parse_expression_helper(p: &mut impl Parser, precedence: OperatorPrecedence) 
     }
 
     if matches!(
-        p.nth(0),
+        p.nth(0).kind(),
         SyntaxKind::LessEqual
             | SyntaxKind::GreaterEqual
             | SyntaxKind::EqualEqual
@@ -164,14 +164,14 @@ fn parse_expression_helper(p: &mut impl Parser, precedence: OperatorPrecedence) 
     }
 
     let mut prev_logical_op = None;
-    while matches!(p.nth(0), SyntaxKind::AndAnd | SyntaxKind::OrOr) {
+    while matches!(p.nth(0).kind(), SyntaxKind::AndAnd | SyntaxKind::OrOr) {
         if let Some(prev) = prev_logical_op {
-            if prev != p.nth(0) {
+            if prev != p.nth(0).kind() {
                 p.error("Use parentheses to disambiguate between && and ||");
                 prev_logical_op = None;
             }
         } else {
-            prev_logical_op = Some(p.nth(0));
+            prev_logical_op = Some(p.nth(0).kind());
         }
 
         {
@@ -182,7 +182,7 @@ fn parse_expression_helper(p: &mut impl Parser, precedence: OperatorPrecedence) 
         parse_expression_helper(&mut *p, OperatorPrecedence::Logical);
     }
 
-    match p.nth(0) {
+    match p.nth(0).kind() {
         SyntaxKind::Question => {
             {
                 let _ = p.start_node_at(checkpoint.clone(), SyntaxKind::Expression);
@@ -224,7 +224,7 @@ fn parse_array(p: &mut impl Parser) {
     let mut p = p.start_node(SyntaxKind::Array);
     p.expect(SyntaxKind::LBracket);
 
-    while p.nth(0) != SyntaxKind::RBracket {
+    while p.nth(0).kind() != SyntaxKind::RBracket {
         parse_expression(&mut *p);
         if !p.test(SyntaxKind::Comma) {
             break;
@@ -244,7 +244,7 @@ fn parse_object_notation(p: &mut impl Parser) {
     let mut p = p.start_node(SyntaxKind::ObjectLiteral);
     p.expect(SyntaxKind::LBrace);
 
-    while p.nth(0) != SyntaxKind::RBrace {
+    while p.nth(0).kind() != SyntaxKind::RBrace {
         let mut p = p.start_node(SyntaxKind::ObjectMember);
         p.expect(SyntaxKind::Identifier);
         p.expect(SyntaxKind::Colon);

--- a/sixtyfps_compiler/parser/statements.rs
+++ b/sixtyfps_compiler/parser/statements.rs
@@ -20,7 +20,7 @@ use super::prelude::*;
 /// if (true) { foo = bar; } else { bar = foo;  }
 /// ```
 pub fn parse_statement(p: &mut impl Parser) -> bool {
-    if p.nth(0) == SyntaxKind::RBrace {
+    if p.nth(0).kind() == SyntaxKind::RBrace {
         return false;
     }
     if p.test(SyntaxKind::Semicolon) {
@@ -28,7 +28,7 @@ pub fn parse_statement(p: &mut impl Parser) -> bool {
     }
     let checkpoint = p.checkpoint();
 
-    if p.peek().as_str() == "if" && p.nth(1) == SyntaxKind::LParent {
+    if p.peek().as_str() == "if" && p.nth(1).kind() == SyntaxKind::LParent {
         let mut p = p.start_node(SyntaxKind::Expression);
         parse_if_statement(&mut *p);
         return true;
@@ -36,7 +36,7 @@ pub fn parse_statement(p: &mut impl Parser) -> bool {
 
     parse_expression(p);
     if matches!(
-        p.nth(0),
+        p.nth(0).kind(),
         SyntaxKind::MinusEqual
             | SyntaxKind::PlusEqual
             | SyntaxKind::StarEqual


### PR DESCRIPTION
The actual `peek` and `nth` functions of `Parser` are a bit trick, both should return the same object since they are an index based access (`peek` == `nth(0)` IMO).
The PR changes `nth` to return `Token` (like the `peek` function) and also adds the `kind` function of `Token` to allows access of the `kind` property. The final result is a much more flexible API, where the user will be able to access `nth` `Token` object and `SyntaxKind` property, otherwise it's only possible to access the current `Token` and the `nth` `SyntaxKind`.

PS: This change is helping me a lot to develop/debug some functionalities since `Token` also derives `Debug`.
