### PR TITLE
Allow bidirectional conversion of length <-> float and length to string.

### DIFF
--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -679,7 +679,9 @@ fn compile_expression(e: &Expression, component: &Rc<Component>) -> TokenStream 
         Expression::Cast { from, to } => {
             let f = compile_expression(&*from, &component);
             match (from.ty(), to) {
-                (Type::Float32, Type::String) | (Type::Int32, Type::String) => {
+                (Type::Length, Type::String)
+                | (Type::Float32, Type::String)
+                | (Type::Int32, Type::String) => {
                     quote!(sixtyfps::re_exports::SharedString::from(format!("{}", #f).as_str()))
                 }
                 (Type::Float32, Type::Model) | (Type::Int32, Type::Model) => quote!((0..#f as i32)),

--- a/sixtyfps_compiler/typeregister.rs
+++ b/sixtyfps_compiler/typeregister.rs
@@ -244,6 +244,7 @@ impl Type {
                     | (Type::Int32, Type::Model)
                     | (Type::Length, Type::LogicalLength)
                     | (Type::Length, Type::Float32)
+                    | (Type::Length, Type::String)
                     | (Type::Float32, Type::Length)
                     | (Type::LogicalLength, Type::Length)
             )

--- a/sixtyfps_compiler/typeregister.rs
+++ b/sixtyfps_compiler/typeregister.rs
@@ -243,6 +243,8 @@ impl Type {
                     | (Type::Float32, Type::Model)
                     | (Type::Int32, Type::Model)
                     | (Type::Length, Type::LogicalLength)
+                    | (Type::Length, Type::Float32)
+                    | (Type::Float32, Type::Length)
                     | (Type::LogicalLength, Type::Length)
             )
     }


### PR DESCRIPTION
Allows to debug size of elements and visualization of such `Length` variables.

![Screen Capture_select-area_20200830192338](https://user-images.githubusercontent.com/1215497/91670793-0f231300-eaf7-11ea-955b-4a47283b61ed.gif)
