### PR TITLE
Fix build on Windows with warm cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,16 @@ jobs:
       with:
         version: '5.12.9'
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
+    - name: Setup Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12' # Make sure to bump the version in the cache key below
+    - name: Cache native node libraries
+      uses: actions/cache@v2
+      if: matrix.os == 'windows-latest'
+      with:
+        path: ~/node-gyp/cache
+        key: ${{ runner.os }}-${{ github.job }}-12
     - name: Cache cargo registry
       uses: actions/cache@v2
       with:
@@ -154,7 +164,13 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: '12'
+        node-version: '12' # Make sure to bump the version in the cache key below
+    - name: Cache native node libraries
+      uses: actions/cache@v2
+      if: matrix.os == 'windows-latest'
+      with:
+        path: ~/node-gyp/cache
+        key: ${{ runner.os }}-${{ github.job }}-12
     - name: Compile sixtyfps-wasm-interpreter
       run: wasm-pack build --release --target web -- --features console_error_panic_hook
       working-directory: api/sixtyfps-wasm-interpreter


### PR DESCRIPTION
With a cold cache, neon-sys will be compiled as a dependency of the
nodejs buildings, which in turn will install node-gyp and run it to
build its bindings. On Windows, linkage against the nodejs import
library is needed for the correct symbol ordinals from nodejs.dll.
node-gyp takes care of downloading the header files and import library
into %HOMEPATH%\AppData\Local\node-gyp\Cache\<version>.

In a warm cache scenario, neon-sys is not rebuilt, node-gyp is not run
and the node.lib import library is not installed.

However neon-sys also propagates the path to node.lib (and the import
lib name) by parsing the node-gyp output, saving it to an environment
variable, exporting that via links=neon to neon-build and then
neon-build persists it into files its out directory. Finally we call
neon-build's setup() function, which reads those files and tries to link
sixtyfps-node-native also against node.lib. The absence of the import
library causes the build to fail.

This patch solves that by adding the node-gyp cache to the github
actions cache, and also installs a specific nodejs version. That way
we can avoid the cache being out of sync with the system nodejs if the
github vm is upgraded.