### PR TITLE
Rework Cargo.toml license checking

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,4 +13,4 @@ test_driver_lib = { path = "../tests/driver_lib" }
 anyhow = "1.0"
 lazy_static = "1.4.0"
 regex = "1.3.9"
-cargo-toml2 = "1.3.2"
+toml_edit = "0.2.0"


### PR DESCRIPTION
Switch back to toml_edit for the Cargo.toml check, as that makes it easy
to also apply fixes -- the formatting is preserved.

This also removes the indirect serde_derive dependency that may be
causing problems on macOS sometimes.

Also, now that the cargo test doesn't trigger a build anymore, the use
of toml_edit here should not cause the problem mentioned in commit
ab89fcb69a78023afea368ebb0f1161cd40f43a0 anymore -- fingers crossed.