### PR TITLE
Fix cache build issues on macOS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,6 +67,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-${{ github.job }}-node-
     - name: Cache cargo build
+      if: matrix.os != 'macos-latest'
       uses: actions/cache@v2
       with:
         path: target
@@ -103,7 +104,7 @@ jobs:
       with:
         cmakeListsTxtPath: CMakeLists.txt
     - name: Clean cache # Otherwise the cache is much too big
-      if: matrix.os != 'windows-latest'
+      if: matrix.os == 'ubuntu-20.04'
       run: |
           du -hs target
           rm -rf target/*/incremental

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,11 @@ jobs:
       with:
         path: ~/node-gyp/cache
         key: ${{ runner.os }}-${{ github.job }}-12
+    - name: Ensure node-gyp cache is populated
+      if: matrix.os == 'windows-latest'
+      run: |
+          npm install -g node-gyp
+          node-gyp install      
     - name: Cache cargo registry
       uses: actions/cache@v2
       with:


### PR DESCRIPTION
I give up, the build failures on macOS due to the cache seem resistant to workarounds such as pinning or disabling the manual cache cleaning.

In addition one of the failures in the CI check for this PR surfaced the issue that the node-gyp cache may not be populated fully, so this also includes a commit to ensure that it is populated.