### PR TITLE
Create format function for .60

### DIFF
--- a/examples/gallery/gallery.60
+++ b/examples/gallery/gallery.60
@@ -59,7 +59,7 @@ App := Window {
         }
         Row {
             GroupBox {
-                title: "SpinBox";
+                title: format("SpinBox {} ", 1);
                 SpinBox {
                     maximum_width: 120lx;
                     value: 42;

--- a/sixtyfps_compiler/expression_tree.rs
+++ b/sixtyfps_compiler/expression_tree.rs
@@ -43,6 +43,7 @@ impl Hash for NamedReference {
 pub enum BuiltinFunction {
     GetWindowScaleFactor,
     Debug,
+    Format,
     SetFocusItem,
 }
 
@@ -54,6 +55,9 @@ impl BuiltinFunction {
             }
             BuiltinFunction::Debug => {
                 Type::Function { return_type: Box::new(Type::Void), args: vec![Type::String] }
+            }
+            BuiltinFunction::Format => {
+                Type::Function { return_type: Box::new(Type::String), args: vec![Type::String, Type::String] }
             }
             BuiltinFunction::SetFocusItem => Type::Function {
                 return_type: Box::new(Type::Void),

--- a/sixtyfps_compiler/generator/cpp.rs
+++ b/sixtyfps_compiler/generator/cpp.rs
@@ -1068,6 +1068,9 @@ fn compile_expression(e: &crate::expression_tree::Expression, component: &Rc<Com
                 "[](auto... args){ (std::cout << ... << args) << std::endl; return nullptr; }"
                     .into()
             }
+            BuiltinFunction::Format => {
+                panic!("Not supported for cpp builds.");
+            }
             BuiltinFunction::SetFocusItem => {
                 format!("{}.set_focus_item", window_ref_expression(component))
             }

--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -883,6 +883,7 @@ fn compile_expression(e: &Expression, component: &Rc<Component>) -> TokenStream 
                 quote!(#window_ref.scale_factor)
             }
             BuiltinFunction::Debug => quote!((|x| println!("{:?}", x))),
+            BuiltinFunction::Format => quote!(|x| format!("{:?}", x)),
             BuiltinFunction::SetFocusItem => panic!("internal error: SetFocusItem is handled directly in CallFunction")
         },
         Expression::ElementReference(_) => todo!("Element references are only supported in the context of built-in function calls at the moment"),

--- a/sixtyfps_compiler/passes/resolving.rs
+++ b/sixtyfps_compiler/passes/resolving.rs
@@ -495,6 +495,10 @@ impl Expression {
             return Expression::BuiltinFunctionReference(BuiltinFunction::Debug);
         }
 
+        if first_str == "format" {
+            return Expression::BuiltinFunctionReference(BuiltinFunction::Format);
+        }
+
         ctx.diag.push_error(format!("Unknown unqualified identifier '{}'", first_str), &node);
 
         Self::Invalid

--- a/sixtyfps_runtime/interpreter/eval.rs
+++ b/sixtyfps_runtime/interpreter/eval.rs
@@ -277,6 +277,10 @@ pub fn eval_expression(
                 println!("{:?}", a);
                 Value::Void
             }
+            Expression::BuiltinFunctionReference(BuiltinFunction::Format) => {
+                let a = arguments.iter().map(|e| eval_expression(e, component, local_context));
+                format!("{:#?}", a)
+            }
             Expression::BuiltinFunctionReference(BuiltinFunction::SetFocusItem) => {
                 if arguments.len() != 1 {
                     panic!("internal error: incorrect argument count to SetFocusItem")


### PR DESCRIPTION
I was unable to come up with something easy to implement related to this, so I'm opening the patch as a draft to seek help.
My idea is to create a format function that works like rust `format!` macro for .60 templates, any tip ?

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>