### PR TITLE
Update memory example to use row and column count properties

### DIFF
--- a/examples/memory/memory.60
+++ b/examples/memory/memory.60
@@ -90,8 +90,12 @@ export MainWindow := Window {
     property<length> tile_size: 80px;
     property<length> tile_spacing: 10px;
 
-    width: 4 * tile_size + 5 * tile_spacing;
-    height: 4 * tile_size + 5 * tile_spacing;
+    property <int> row_count: 4;
+    property <int> column_count: 4;
+
+    // "column_count + 1" and "row_count + 1" are the number of gaps between the tiles.
+    width: (column_count * tile_size) + ((column_count + 1) * tile_spacing);
+    height: (row_count * tile_size) + ((row_count + 1) * tile_spacing);
 
     property<[TileData]> memory_tiles : [
         { image: img!"icons/at.png" },
@@ -105,8 +109,8 @@ export MainWindow := Window {
     ];
 
     for tile[i] in memory_tiles: MemoryTile {
-        x: tile_spacing + mod(i, 4) * (tile_size + tile_spacing);
-        y: tile_spacing + floor(i / 4) * (tile_size + tile_spacing);
+        x: tile_spacing + mod(i, column_count) * (tile_size + tile_spacing);
+        y: tile_spacing + floor(i / row_count) * (tile_size + tile_spacing);
         width: tile_size;
         height: tile_size;
 


### PR DESCRIPTION
Using row and column count properties improves the readability, extensibility, and maintainability by removing the magic numbers for the other calculated properties. Previously, it took me some time to understand what these numbers represented and this change should remove this difficulty.

As this is a non-breaking refactor, the game still appears the same:

![memory](https://user-images.githubusercontent.com/57526088/103093821-66dc1180-45f3-11eb-9300-2e9e81dfbb8b.png)