### PR TITLE
GL backend: new box drop shadow implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ All notable changes to this project will be documented in this file.
  - In Rust, the generated component implements `Clone` and acts like an `Rc`. `sixtyfps::Weak` can be used to hold weak references.
  - `ARGBColor` was renamed `RgbaColor`
  - `width and `height` of some builtin elements now default to 100% of the parent element.
+ - `drop-shadow-blur` was changed to describe the blur level, not the size of the blur area.
 
 ### Added
  - Allow dashes in identifiers (#52)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,11 +68,6 @@ default-members = [
 
 resolver = "2"
 
-[patch.crates-io]
-# Pull in https://github.com/femtovg/femtovg/commit/14424393276f23a5105192fdb179db2a03e42d0d to
-# shrink our (wasm) binaries (post 0.1.3)
-femtovg = { git = "https://github.com/femtovg/femtovg", rev = "14424393276f23a5105192fdb179db2a03e42d0d" }
-
 [profile.release]
 lto = true
 panic = "abort"

--- a/docs/builtin_elements.md
+++ b/docs/builtin_elements.md
@@ -25,7 +25,8 @@ an element, it is possible to set the following `drop-shadow` properties:
   of the shadow from the element's frame. A negative value places the shadow left / above of the element.
 * **`drop-shadow-color`** (*color*): The base color of the shadow to use. Typically that color is the starting color
   of a gradient that fades into transparency.
-* **`drop-shadow-blur`** (*length*): The size of the blurred area, over which the shadow color is drawn, possibly shaded.
+* **`drop-shadow-blur`** (*float*): The level of blur applied to the shadow. Negative values are ignored and zero means
+  no blur (default).
 
 The `drop-shadow` effect is supported for `Rectangle` and `Clip` elements.
 

--- a/examples/iot-dashboard/iot-dashboard.60
+++ b/examples/iot-dashboard/iot-dashboard.60
@@ -227,7 +227,7 @@ Box := Rectangle {
     background: Skin.palette.box;
     drop-shadow-offset-x: 6px;
     drop-shadow-offset-y: 6px;
-    drop-shadow-blur: 6px;
+    drop-shadow-blur: 6;
     drop-shadow-color: Skin.palette.shadow;
     VerticalLayout {
         if (root.title != "") : Text {

--- a/examples/slide_puzzle/slide_puzzle.60
+++ b/examples/slide_puzzle/slide_puzzle.60
@@ -306,7 +306,7 @@ export MainWindow := Window {
 
             drop-shadow-offset-x: 1px;
             drop-shadow-offset-y: 1px;
-            drop-shadow-blur: 6px;
+            drop-shadow-blur: 6;
             drop-shadow-color: #00000080;
             border-radius: current-theme.piece-radius;
             clip: true;

--- a/sixtyfps_compiler/builtins.60
+++ b/sixtyfps_compiler/builtins.60
@@ -161,7 +161,7 @@ export BoxShadow := _ {
     property <length> offset_x;
     property <length> offset_y;
     property <color> color;
-    property <length> blur;
+    property <float> blur;
     //-default_size_binding:expands_to_parent_geometry
     //-is_internal
 }

--- a/sixtyfps_compiler/typeregister.rs
+++ b/sixtyfps_compiler/typeregister.rs
@@ -52,7 +52,7 @@ const RESERVED_OTHER_PROPERTIES: &'static [(&'static str, Type)] = &[
 pub(crate) const RESERVED_DROP_SHADOW_PROPERTIES: &'static [(&'static str, Type)] = &[
     ("drop_shadow_offset_x", Type::LogicalLength),
     ("drop_shadow_offset_y", Type::LogicalLength),
-    ("drop_shadow_blur", Type::LogicalLength),
+    ("drop_shadow_blur", Type::Float32),
     ("drop_shadow_color", Type::Color),
 ];
 

--- a/sixtyfps_runtime/corelib/Cargo.toml
+++ b/sixtyfps_runtime/corelib/Cargo.toml
@@ -42,7 +42,7 @@ weak-table =  "0.3"
 scopeguard = "1.1.0"
 cfg-if = "1"
 # Optional dependency to have conversion trait between femtovg::Color and sixtyfps-corelib::Color
-femtovg = { version = "0.1.3", optional = true }
+femtovg = { version = "0.2.0", optional = true, git = "https://github.com/tronical/femtovg", branch = "simon/filter" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 instant = { version = "0.1", features = [ "wasm-bindgen", "now" ] }

--- a/sixtyfps_runtime/rendering_backends/gl/Cargo.toml
+++ b/sixtyfps_runtime/rendering_backends/gl/Cargo.toml
@@ -25,7 +25,7 @@ rgb = "0.8"
 imgref = "1.6.1"
 vtable = { version = "0.1", path = "../../../helper_crates/vtable" }
 by_address = "1.0.4"
-femtovg = { version = "0.1.3" }
+femtovg = { version = "0.2.0", git = "https://github.com/tronical/femtovg", branch = "simon/filter" }
 euclid = "0.22.1"
 pin-weak = "1"
 scoped-tls-hkt = "0.1"

--- a/tests/cases/examples/box_shadow_use.60
+++ b/tests/cases/examples/box_shadow_use.60
@@ -27,10 +27,11 @@ TestCase := Window {
 
         Rectangle {
             background: blue;
+            border-radius: 10px;
             drop-shadow-offset-x: 10px;
             drop-shadow-offset-y: 10px;
             drop-shadow-color: #00000080;
-            drop-shadow-blur: 5px;
+            drop-shadow-blur: 5;
         }
 
         for r[i] in [
@@ -41,7 +42,28 @@ TestCase := Window {
             drop-shadow-offset-x: 10px;
             drop-shadow-offset-y: 10px;
             drop-shadow-color: #00000080;
-            drop-shadow-blur: 5px;
+            drop-shadow-blur: 5;
+        }
+
+        Rectangle {
+            clip: true;
+            border-color: black;
+            border-width: 1px;
+            border-radius: 2px;
+
+            Rectangle {
+                x: parent.width / 2;
+                y: parent.height / 2;
+                width: parent.width / 2;
+                height: parent.height / 4;
+
+                background: blue;
+
+                drop-shadow-offset-x: 10px;
+                drop-shadow-offset-y: 10px;
+                drop-shadow-color: #249a04;
+                drop-shadow-blur: 3;
+            }
         }
     }
 
@@ -58,7 +80,7 @@ TestCase := Window {
         drop-shadow-offset-x: 5px;
         drop-shadow-offset-y: 5px;
         drop-shadow-color: #00000080;
-        drop-shadow-blur: 5px;
+        drop-shadow-blur: 5;
     }
 }
 

--- a/tools/syntax_updater/from_0_0_6.rs
+++ b/tools/syntax_updater/from_0_0_6.rs
@@ -39,11 +39,11 @@ pub(crate) fn fold_node(
                     }
                 }
             }
-            prop @ "drop-shadow-blur" => {
+            prop @ "drop_shadow_blur" | prop @ "drop-shadow-blur" => {
                 let expr = binding.BindingExpression();
                 write!(
                     file,
-                    "{}: ({}) / 1px; // CHANGED BY SYNTAX UPDATER: drop-shadow-blur is now an abstract blur level, this is just an approximation.",
+                    "{}: ({}) / 1px; /* CHANGED BY SYNTAX UPDATER: drop-shadow-blur is now an abstract blur level, this is just an approximation. */",
                     prop,
                     expr.CodeBlock()
                         .map(|block| block.to_string())


### PR DESCRIPTION
This replaces the box gradient with a new implementation that
behaves like the HTML Canvas element, by applying a gaussian
blur to the alpha of the rectangle to shadow.

The drop-shadow-blur property is changed to be now just a "level", like
the HTML Canvas shadowBlur property, which is defined to be half of the
standard deviation of the gaussian blur to be applied.