### PR TITLE
Fix disappearing text in vertical layouts with word-wrap and alignment

### DIFF
--- a/sixtyfps_runtime/corelib/graphics.rs
+++ b/sixtyfps_runtime/corelib/graphics.rs
@@ -173,6 +173,8 @@ impl FontRequest {
 pub trait FontMetrics {
     /// Returns the size of the given string in logical pixels.
     fn text_size(&self, text: &str) -> Size;
+    /// Returns the height of a line of text.
+    fn line_height(&self) -> f32;
     /// Returns the (UTF-8) byte offset in the given text that refers to the character that contributed to
     /// the glyph cluster that's visually nearest to the given x coordinate. This is used for hit-testing,
     /// for example when receiving a mouse click into a text field. Then this function returns the "cursor"

--- a/sixtyfps_runtime/corelib/items/text.rs
+++ b/sixtyfps_runtime/corelib/items/text.rs
@@ -143,7 +143,7 @@ impl Item for Text {
         };
         match self.overflow() {
             TextOverflow::elide => {
-                min_size.width = font_metrics.text_size("…").width;
+                min_size.width = min_size.width.min(font_metrics.text_size("…").width);
             }
             TextOverflow::clip => {}
         }

--- a/sixtyfps_runtime/rendering_backends/gl/fonts.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/fonts.rs
@@ -325,6 +325,10 @@ impl FontMetricsTrait for FontMetrics {
         self.font.text_size(self.letter_spacing.unwrap_or_default(), text, None) / self.scale_factor
     }
 
+    fn line_height(&self) -> f32 {
+        self.font.height()
+    }
+
     fn text_offset_for_x_position<'a>(&self, text: &'a str, x: f32) -> usize {
         let x = x * self.scale_factor;
         let metrics = self.font.measure(self.letter_spacing.unwrap_or_default(), text);

--- a/sixtyfps_runtime/rendering_backends/qt/qt_window.rs
+++ b/sixtyfps_runtime/rendering_backends/qt/qt_window.rs
@@ -1253,6 +1253,13 @@ impl sixtyfps_corelib::graphics::FontMetrics for QFont {
         sixtyfps_corelib::graphics::Size::new(size.width as _, size.height as _)
     }
 
+    fn line_height(&self) -> f32 {
+        cpp! { unsafe [self as "const QFont*"]
+                -> f32 as "float"{
+            return QFontMetricsF(*self).height();
+        }}
+    }
+
     fn text_offset_for_x_position<'a>(&self, text: &'a str, x: f32) -> usize {
         let string = qttypes::QString::from(text);
         cpp! { unsafe [self as "const QFont*", string as "QString", x as "float"] -> usize as "long long" {

--- a/sixtyfps_runtime/rendering_backends/testing/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/testing/lib.rs
@@ -159,6 +159,10 @@ impl FontMetrics for TestingFontMetrics {
         Size::new(text.len() as f32 * 10., 10.)
     }
 
+    fn line_height(&self) -> f32 {
+        10.
+    }
+
     fn text_offset_for_x_position(&self, _text: &str, _x: f32) -> usize {
         0
     }

--- a/tests/cases/layout/text_preferred_size.60
+++ b/tests/cases/layout/text_preferred_size.60
@@ -1,0 +1,45 @@
+/* LICENSE BEGIN
+    This file is part of the SixtyFPS Project -- https://sixtyfps.io
+    Copyright (c) 2020 Olivier Goffart <olivier.goffart@sixtyfps.io>
+    Copyright (c) 2020 Simon Hausmann <simon.hausmann@sixtyfps.io>
+
+    SPDX-License-Identifier: GPL-3.0-only
+    This file is also available under commercial licensing terms.
+    Please contact info@sixtyfps.io for more information.
+LICENSE END */
+TestCase := Window {
+    width: 400px;
+    height: 640px;
+    VerticalLayout {
+        padding: 0px;
+        alignment: center;
+        text := Text {
+            text: "This line needs to be broken into multiple lines of text and yet be centered.";
+            font_size: 20px;
+            wrap: word-wrap;
+        }
+    }
+
+    property <bool> test: text.height > 0 && text.width == root.width;
+}
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+
+```rust
+let instance = TestCase::new();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new sixtyfps.TestCase({});
+assert(instance.test);
+```
+
+*/


### PR DESCRIPTION
When a Text element has wrapping enabled, it should not have zero
minimum size. Otherwise the layout will give it a height of zero in the
layout in the test case and that'll make the text disappear. There are
different options but this patch goes for minimum height as if no
wrapping was enabled (so at least one line plus forced line breaks).

Fixes #246