### PR TITLE
Fix initial rendering of widget gallery with GL backend

### DIFF
--- a/sixtyfps_runtime/rendering_backends/gl/graphics_window.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/graphics_window.rs
@@ -184,6 +184,9 @@ impl GraphicsWindow {
                 layout_info.preferred_height.max(layout_info.min_height),
             );
             if s.width > 0. && s.height > 0. {
+                // Make sure that the window's inner size is in sync with the root window item's
+                // width/height.
+                self.set_geometry(s.width, s.height);
                 window_builder.with_inner_size(s)
             } else {
                 window_builder


### PR DESCRIPTION
This issue is not quite specific to the gallery, a simpler test case is
this:

```
App := Window {
    preferred-width: 500px;
    preferred-height: 750px;
    HorizontalLayout {
        Rectangle {
            background: blue;
        }
    }
}
```

As there is no fixed width/height set, the size is calculated by layout and
apply_window_properties() sets the inner size correctly on the winit window.
However the width/height properties on the root Window item are not set, remain
zero and thus lead to incorrect rendering. They are not set because they are
identical with what window.inner_size() reports - we assume no change and that
they are in sync.

The bug however is in the creation phase, when we decide on an initial size to
pass to the window_builder, we should also set those on the root item. This is
where window.inner_size() and the root item's width/height get out of sync.