### PR TITLE
Add Image::size()

### DIFF
--- a/api/sixtyfps-cpp/include/sixtyfps_image.h
+++ b/api/sixtyfps-cpp/include/sixtyfps_image.h
@@ -15,6 +15,20 @@ LICENSE END */
 
 namespace sixtyfps {
 
+#if !defined(DOXYGEN)
+using cbindgen_private::types::Size;
+#else
+/// The Size structure is used to represent a two-dimensional size
+/// with width and height.
+struct Size
+{
+    /// The width of the size
+    float width;
+    /// The height of the size
+    float height;
+};
+#endif
+
 /// An image type that can be displayed by the Image element
 struct Image
 {
@@ -22,7 +36,8 @@ public:
     Image() : data(Data::None()) { }
 
     /// Load an image from an image file
-    static Image load_from_path(const SharedString &file_path) {
+    static Image load_from_path(const SharedString &file_path)
+    {
         Image img;
         img.data = Data::AbsoluteFilePath(file_path);
         return img;
@@ -35,12 +50,12 @@ public:
         return img;
     }
     */
-    friend bool operator==(const Image &a, const Image &b) {
-        return a.data == b.data;
-    }
-    friend bool operator!=(const Image &a, const Image &b) {
-        return a.data != b.data;
-    }
+
+    /// Returns the size of the Image in pixels.
+    Size size() const { return cbindgen_private::types::sixtyfps_image_size(&data); }
+
+    friend bool operator==(const Image &a, const Image &b) { return a.data == b.data; }
+    friend bool operator!=(const Image &a, const Image &b) { return a.data != b.data; }
 
 private:
     using Tag = cbindgen_private::types::ImageInner::Tag;

--- a/api/sixtyfps-cpp/tests/datastructures.cpp
+++ b/api/sixtyfps-cpp/tests/datastructures.cpp
@@ -13,6 +13,7 @@ LICENSE END */
 #include "catch2/catch.hpp"
 
 #include <sixtyfps.h>
+#include <sixtyfps_image.h>
 
 SCENARIO("SharedString API")
 {
@@ -72,3 +73,24 @@ TEST_CASE("Property Tracker")
     REQUIRE(!tracker1.is_dirty());
 }
 
+TEST_CASE("Image")
+{
+    using namespace sixtyfps;
+
+    // ensure a backend exists, using private api
+    private_api::ComponentWindow wnd;
+
+    Image img;
+    {
+        auto size = img.size();
+        REQUIRE(size.width == 0.);
+        REQUIRE(size.height == 0.);
+    }
+
+    img = Image::load_from_path(SOURCE_DIR "/../../vscode_extension/extension-logo.png");
+    {
+        auto size = img.size();
+        REQUIRE(size.width == 128.);
+        REQUIRE(size.height == 128.);
+    }
+}

--- a/sixtyfps_runtime/corelib/backend.rs
+++ b/sixtyfps_runtime/corelib/backend.rs
@@ -13,6 +13,7 @@ The backend is the abstraction for crates that need to do the actual drawing and
 
 use std::path::Path;
 
+use crate::graphics::{Image, Size};
 use crate::window::ComponentWindow;
 
 /// Behavior describing how the event loop should terminate.
@@ -56,6 +57,8 @@ pub trait Backend: Send + Sync {
 
     /// Send an user event to from another thread that should be run in the GUI event loop
     fn post_event(&'static self, event: Box<dyn FnOnce() + Send>);
+
+    fn image_size(&'static self, image: &Image) -> Size;
 }
 
 static PRIVATE_BACKEND_INSTANCE: once_cell::sync::OnceCell<Box<dyn Backend + 'static>> =

--- a/sixtyfps_runtime/corelib/graphics.rs
+++ b/sixtyfps_runtime/corelib/graphics.rs
@@ -42,7 +42,7 @@ pub use path::*;
 mod brush;
 pub use brush::*;
 
-mod image;
+pub(crate) mod image;
 pub use self::image::*;
 
 /// CachedGraphicsData allows the graphics backend to store an arbitrary piece of data associated with

--- a/sixtyfps_runtime/corelib/graphics/image.rs
+++ b/sixtyfps_runtime/corelib/graphics/image.rs
@@ -80,3 +80,16 @@ impl Image {
         }
     }
 }
+
+#[cfg(feature = "ffi")]
+pub(crate) mod ffi {
+    #![allow(unsafe_code)]
+
+    use super::super::Size;
+    use super::*;
+
+    #[no_mangle]
+    pub unsafe extern "C" fn sixtyfps_image_size(image: &Image) -> Size {
+        image.size()
+    }
+}

--- a/sixtyfps_runtime/corelib/graphics/image.rs
+++ b/sixtyfps_runtime/corelib/graphics/image.rs
@@ -48,7 +48,6 @@ pub struct LoadImageError(());
 /// An image type that can be displayed by the Image element
 #[repr(transparent)]
 #[derive(Default, Clone, Debug, PartialEq, derive_more::From)]
-// FIXME: the inner should be private
 pub struct Image(ImageInner);
 
 impl Image {
@@ -72,4 +71,12 @@ impl Image {
         }
     }
     */
+
+    /// Returns the size of the Image in pixels.
+    pub fn size(&self) -> crate::graphics::Size {
+        match crate::backend::instance() {
+            Some(backend) => backend.image_size(&self),
+            None => panic!("sixtyfps::Image::size() called too early (before a graphics backend was chosen). You need to create a component first."),
+        }
+    }
 }

--- a/sixtyfps_runtime/corelib/items/image.rs
+++ b/sixtyfps_runtime/corelib/items/image.rs
@@ -74,9 +74,9 @@ impl Item for ImageItem {
     fn layouting_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        window: &ComponentWindow,
+        _window: &ComponentWindow,
     ) -> LayoutInfo {
-        let natural_size = window.0.image_size((&self.source()).into());
+        let natural_size = self.source().size();
         LayoutInfo {
             preferred: match orientation {
                 Orientation::Horizontal => natural_size.width,
@@ -151,9 +151,9 @@ impl Item for ClippedImage {
     fn layouting_info(
         self: Pin<&Self>,
         orientation: Orientation,
-        window: &ComponentWindow,
+        _window: &ComponentWindow,
     ) -> LayoutInfo {
-        let natural_size = window.0.image_size((&self.source()).into());
+        let natural_size = self.source().size();
         LayoutInfo {
             preferred: match orientation {
                 Orientation::Horizontal => natural_size.width,

--- a/sixtyfps_runtime/corelib/lib.rs
+++ b/sixtyfps_runtime/corelib/lib.rs
@@ -90,6 +90,7 @@ pub fn use_modules() -> usize {
             + component::ffi::sixtyfps_component_init_items as usize
             + timers::ffi::sixtyfps_timer_start as usize
             + graphics::color::ffi::sixtyfps_color_brighter as usize
+            + graphics::image::ffi::sixtyfps_image_size as usize
     }
     #[cfg(not(feature = "ffi"))]
     {

--- a/sixtyfps_runtime/corelib/window.rs
+++ b/sixtyfps_runtime/corelib/window.rs
@@ -15,7 +15,6 @@ use crate::input::{KeyEvent, MouseEvent, MouseInputState, TextCursorBlinker};
 use crate::items::{ItemRc, ItemRef, ItemWeak};
 use crate::properties::PropertyTracker;
 use crate::slice::Slice;
-use crate::ImageInner;
 use crate::{
     component::{ComponentRc, ComponentWeak},
     SharedString,
@@ -66,9 +65,6 @@ pub trait PlatformWindow {
         unresolved_font_request_getter: &dyn Fn() -> crate::graphics::FontRequest,
         reference_text: Pin<&crate::properties::Property<SharedString>>,
     ) -> Box<dyn crate::graphics::FontMetrics>;
-
-    /// Return the size of the image referenced by the specified resource.
-    fn image_size(&self, source: &ImageInner) -> crate::graphics::Size;
 
     /// Return self as any so the backend can upcast
     fn as_any(&self) -> &dyn core::any::Any;

--- a/sixtyfps_runtime/rendering_backends/gl/graphics_window.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/graphics_window.rs
@@ -50,7 +50,8 @@ pub struct GraphicsWindow {
     default_font_properties: Pin<Rc<Property<FontRequest>>>,
 
     pub(crate) graphics_cache: RefCell<BackendItemGraphicsCache>,
-    pub(crate) image_cache: RefCell<BackendImageCache>,
+    // This cache only contains textures. The cache for decoded CPU side images is in crate::IMAGE_CACHE.
+    pub(crate) texture_cache: RefCell<BackendImageCache>,
 }
 
 impl GraphicsWindow {
@@ -95,7 +96,7 @@ impl GraphicsWindow {
             active_popup: Default::default(),
             default_font_properties: default_font_properties_prop,
             graphics_cache: Default::default(),
-            image_cache: Default::default(),
+            texture_cache: Default::default(),
         })
     }
 
@@ -231,7 +232,7 @@ impl GraphicsWindow {
         // Release GL textures and other GPU bound resources.
         self.with_current_context(|| {
             self.graphics_cache.borrow_mut().clear();
-            self.image_cache.borrow_mut().remove_textures();
+            self.texture_cache.borrow_mut().remove_textures();
         });
 
         self.map_state.replace(GraphicsWindowBackendState::Unmapped);
@@ -533,14 +534,6 @@ impl PlatformWindow for GraphicsWindow {
             scale_factor,
             reference_text,
         ))
-    }
-
-    fn image_size(&self, source: &ImageInner) -> sixtyfps_corelib::graphics::Size {
-        self.image_cache
-            .borrow_mut()
-            .load_image_resource(source)
-            .and_then(|image| image.size())
-            .unwrap_or_else(|| Size::new(1., 1.))
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/sixtyfps_runtime/rendering_backends/gl/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/lib.rs
@@ -1625,7 +1625,7 @@ impl sixtyfps_corelib::backend::Backend for Backend {
                 .borrow_mut()
                 .load_image_resource(image.into())
                 .and_then(|image| image.size())
-                .unwrap_or_else(|| Size::new(1., 1.))
+                .unwrap_or_default()
         })
     }
 }

--- a/sixtyfps_runtime/rendering_backends/qt/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/qt/lib.rs
@@ -18,6 +18,9 @@ You should use the `sixtyfps` crate instead.
 #![doc(html_logo_url = "https://sixtyfps.io/resources/logo.drawio.svg")]
 #![recursion_limit = "1024"]
 
+use sixtyfps_corelib::graphics::{Image, Size};
+#[cfg(not(no_qt))]
+use sixtyfps_corelib::items::ImageFit;
 use sixtyfps_corelib::window::ComponentWindow;
 
 #[cfg(not(no_qt))]
@@ -257,5 +260,19 @@ impl sixtyfps_corelib::backend::Backend for Backend {
                 QTimer::singleShot(0, qApp, EventHolder{fnbox});
             }}
         };
+    }
+
+    fn image_size(&'static self, _image: &Image) -> Size {
+        #[cfg(not(no_qt))]
+        {
+            qt_window::load_image_from_resource(_image.into(), None, ImageFit::fill)
+                .map(|img| {
+                    let qsize = img.size();
+                    euclid::size2(qsize.width as f32, qsize.height as f32)
+                })
+                .unwrap_or_default()
+        }
+        #[cfg(no_qt)]
+        return Default::default();
     }
 }

--- a/sixtyfps_runtime/rendering_backends/qt/qt_window.rs
+++ b/sixtyfps_runtime/rendering_backends/qt/qt_window.rs
@@ -720,7 +720,7 @@ impl ItemRenderer for QtItemRenderer<'_> {
     }
 }
 
-fn load_image_from_resource(
+pub(crate) fn load_image_from_resource(
     resource: &ImageInner,
     source_size: Option<qttypes::QSize>,
     image_fit: ImageFit,
@@ -1210,15 +1210,6 @@ impl PlatformWindow for QtWindow {
         _reference_text: Pin<&Property<SharedString>>,
     ) -> Box<dyn sixtyfps_corelib::graphics::FontMetrics> {
         Box::new(get_font(unresolved_font_request_getter().merge(&self.default_font_properties())))
-    }
-
-    fn image_size(&self, source: &ImageInner) -> sixtyfps_corelib::graphics::Size {
-        load_image_from_resource(source, None, ImageFit::fill)
-            .map(|img| {
-                let qsize = img.size();
-                euclid::size2(qsize.width as f32, qsize.height as f32)
-            })
-            .unwrap_or_default()
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/xtask/src/cbindgen.rs
+++ b/xtask/src/cbindgen.rs
@@ -130,6 +130,7 @@ fn gen_corelib(root_dir: &Path, include_dir: &Path) -> anyhow::Result<()> {
         "KeyEventArg",
         "sixtyfps_color_brighter",
         "sixtyfps_color_darker",
+        "sixtyfps_image_size",
     ]
     .iter()
     .map(|x| x.to_string())
@@ -180,7 +181,11 @@ fn gen_corelib(root_dir: &Path, include_dir: &Path) -> anyhow::Result<()> {
         .write_to_file(include_dir.join("sixtyfps_properties_internal.h"));
 
     for (rust_types, extra_excluded_types, internal_header) in [
-        (vec!["ImageInner", "Image"], vec![], "sixtyfps_image_internal.h"),
+        (
+            vec!["ImageInner", "Image", "Size", "sixtyfps_image_size"],
+            vec![],
+            "sixtyfps_image_internal.h",
+        ),
         (
             vec!["Color", "sixtyfps_color_brighter", "sixtyfps_color_darker"],
             vec![],
@@ -222,6 +227,7 @@ fn gen_corelib(root_dir: &Path, include_dir: &Path) -> anyhow::Result<()> {
             "sixtyfps_new_path_events",
             "sixtyfps_color_brighter",
             "sixtyfps_color_darker",
+            "sixtyfps_image_size",
         ]
         .iter()
         .filter(|exclusion| rust_types.iter().find(|inclusion| inclusion == exclusion).is_none())


### PR DESCRIPTION
This requires the image size query to be window independent and go
through the backend instead.

This implies minor changes for the Qt backend and bigger ones for the GL
backend:

* There exists now a thread-local IMAGE_CACHE, which is used by the
  backend's image_size() function as well as by the renderer for
  loading CPU side images.
* The image remain as decoded images in there (including SVG tree)
  and the window now has a texture_cache, which holds CachedImage
  with ImageData::Texture.
* Rendering an image item therefore fetches the CPU side image,
  calls upload_to_gpu() on it, which creates a new Rc<CachedImage>
  and that's stored in the texture_cache.
* The texture cache continues to be pruned when hiding the window.