### PR TITLE
Fix panic in preview.html when loading images

### DIFF
--- a/sixtyfps_runtime/interpreter/dynamic_component.rs
+++ b/sixtyfps_runtime/interpreter/dynamic_component.rs
@@ -331,7 +331,11 @@ impl<'id> ComponentDescription<'id> {
         #[cfg(not(target_arch = "wasm32"))]
         let window = sixtyfps_rendering_backend_default::backend().create_window();
         #[cfg(target_arch = "wasm32")]
-        let window = sixtyfps_rendering_backend_gl::create_gl_window_with_canvas_id(canvas_id);
+        let window = {
+            // Ensure that the backend is initialized
+            sixtyfps_rendering_backend_default::backend();
+            sixtyfps_rendering_backend_gl::create_gl_window_with_canvas_id(canvas_id)
+        };
         self.create_with_existing_window(window)
     }
 


### PR DESCRIPTION
Binding expressions may end up calling sixtyfps::Image:size(), which
requires a graphics backend to be set.

The wasm interpreter code path circumvented the sixtyfps_corelib::backend::instance_or_init
call and went straight to the GL backend.

This patch re-introduces the usual routing through the default backend.