### PR TITLE
GL backend: elide Text also when word-wrapping

### DIFF
--- a/sixtyfps_runtime/rendering_backends/qt/qt_window.rs
+++ b/sixtyfps_runtime/rendering_backends/qt/qt_window.rs
@@ -427,6 +427,7 @@ impl ItemRenderer for QtItemRenderer<'_> {
                 painter->drawText(rect, flags, elided);
             } else {
                 // elide and word wrap: we need to add the elipsis manually on the last line
+                string.replace(QChar('\n'), QChar::LineSeparator);
                 QString elided = string;
                 QFontMetrics fm(font);
                 QTextLayout layout(string, font);
@@ -445,10 +446,6 @@ impl ItemRenderer for QtItemRenderer<'_> {
                         break;
                     }
                     line.setLineWidth(rect.width());
-                    auto lf = QStringView(string).mid(line.textStart(), line.textLength()).indexOf('\n');
-                    if (lf >= 0) {
-                        line.setNumColumns(lf);
-                    }
                     height += leading + line.height();
                     if (height > rect.height()) {
                         break;


### PR DESCRIPTION
In this case, the last line will have elipsis on the last line
when no more line can be printed

Note that the behavior is different with the Qt backend