### PR TITLE
VRcMapped

### DIFF
--- a/api/sixtyfps-rs/Cargo.toml
+++ b/api/sixtyfps-rs/Cargo.toml
@@ -22,7 +22,7 @@ default = ["backend-gl", "x11", "backend-qt"]
 once_cell = "1.5"
 sixtyfps-macros = { version = "=0.1.5", path = "sixtyfps-macros" }
 const-field-offset = { version = "0.1", path = "../../helper_crates/const-field-offset" }
-vtable = { version = "0.1.2", path = "../../helper_crates/vtable" }
+vtable = { version = "0.1.4", path = "../../helper_crates/vtable" }
 sixtyfps-corelib = { version = "=0.1.5", path="../../sixtyfps_runtime/corelib" }
 sixtyfps-rendering-backend-default = { version = "=0.1.5", path="../../sixtyfps_runtime/rendering_backends/default" }
 pin-weak = "1"

--- a/helper_crates/vtable/CHANGELOG.md
+++ b/helper_crates/vtable/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this crate will be documented in this file.
 
+## [0.1.4] - Unreleased
+
+ - Added `VrcMapped` and `VWeakMapped` to allow for references to objects that are reachable via VRc
+
 ## [0.1.3] - 2021-08-16
 
  - Fixed clippy warnings

--- a/helper_crates/vtable/Cargo.toml
+++ b/helper_crates/vtable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vtable"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["SixtyFPS <info@sixtyfps.io>"]
 edition = "2018"
 license = "GPL-3.0-only"
@@ -11,6 +11,6 @@ homepage = "https://sixtyfps.io"
 [lib]
 
 [dependencies]
-vtable-macro = { version = "=0.1.3", path = "./macro" }
+vtable-macro = { version = "=0.1.4", path = "./macro" }
 const-field-offset = { version = "0.1", path = "../const-field-offset" }
 owning_ref = { version = "0.4.1" }

--- a/helper_crates/vtable/Cargo.toml
+++ b/helper_crates/vtable/Cargo.toml
@@ -13,3 +13,4 @@ homepage = "https://sixtyfps.io"
 [dependencies]
 vtable-macro = { version = "=0.1.3", path = "./macro" }
 const-field-offset = { version = "0.1", path = "../const-field-offset" }
+owning_ref = { version = "0.4.1" }

--- a/helper_crates/vtable/macro/Cargo.toml
+++ b/helper_crates/vtable/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vtable-macro"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["SixtyFPS <info@sixtyfps.io>"]
 edition = "2018"
 license = "GPL-3.0-only"

--- a/helper_crates/vtable/src/vrc.rs
+++ b/helper_crates/vtable/src/vrc.rs
@@ -379,6 +379,12 @@ impl<VTable: VTableMetaDropInPlace + 'static, MappedType: ?Sized> VRcMapped<VTab
     pub fn as_pin_ref(&self) -> Pin<&MappedType> {
         unsafe { Pin::new_unchecked(&*self) }
     }
+
+    /// Returns a strong reference to the object that the mapping originates
+    /// from.
+    pub fn origin(this: &Self) -> VRc<VTable> {
+        this.0.as_owner().clone()
+    }
 }
 
 impl<VTable: VTableMetaDropInPlace + 'static, MappedType: ?Sized> Deref

--- a/helper_crates/vtable/src/vrc.rs
+++ b/helper_crates/vtable/src/vrc.rs
@@ -385,19 +385,6 @@ impl<VTable: VTableMetaDropInPlace + 'static, MappedType: ?Sized> VRcMapped<VTab
         this.0.as_owner().clone()
     }
 
-    /// Erase the type and return a [`VRcMappedDyn`]
-    pub fn into_dyn<MappedVTable: VTableMeta>(this: &Self) -> VRcMappedDyn<VTable, MappedVTable>
-    where
-        MappedType: Sized + HasStaticVTable<MappedVTable>,
-    {
-        VRcMappedDyn {
-            mapped: VRcMapped(
-                this.0.clone().map(|r| unsafe { core::mem::transmute::<&MappedType, &Dyn>(r) }),
-            ),
-            mapped_vtable: <MappedType as HasStaticVTable<MappedVTable>>::static_vtable(),
-        }
-    }
-
     /// This function allows safely holding a reference to a field inside the `VRcMapped`. In order to accomplish
     /// that, you need to provide a mapping function `map_fn` in which you need to provide and return a
     /// pinned reference to the object you would like to map. The returned `VRcMapped` allows obtaining
@@ -464,73 +451,5 @@ impl<VTable: VTableMetaDropInPlace + 'static, MappedType: ?Sized> VWeakMapped<VT
                 unsafe { &*self.object }
             }))
         })
-    }
-}
-
-/// This is the same a [`VRcMapped`], but the `MappedType` is not a concrete type.
-/// The second type parameter is a "VTable" type, that is using the
-/// [`#[vtable]`](crate::vtable) macro.
-/// `VRcMappedDyn<FooVTable, BarVTable>` is conceptually the same as `VRcMapped<FooVTable, dyn Bar>`
-///
-/// The `OriginVTable` parametter is the VTable parameter from the [`VRc`] from which we map, and
-/// the `MappedVTable` is the VTable of the mapped type.
-#[derive(Clone)]
-pub struct VRcMappedDyn<OriginVTable: VTableMetaDropInPlace + 'static, MappedVTable: VTableMeta> {
-    mapped: VRcMapped<OriginVTable, Dyn>,
-    mapped_vtable: &'static MappedVTable::VTable,
-}
-
-impl<OriginVTable: VTableMetaDropInPlace + 'static, MappedVTable: VTableMeta>
-    VRcMappedDyn<OriginVTable, MappedVTable>
-{
-    /// Returns a new [`VWeakMappedDyn`] that points to this instance and can be upgraded back
-    /// as long as a `VRc`/`VMapped` exists.
-    pub fn downgrade(this: &Self) -> VWeakMappedDyn<OriginVTable, MappedVTable> {
-        VWeakMappedDyn {
-            mapped: VRcMapped::downgrade(&this.mapped),
-            mapped_vtable: &this.mapped_vtable,
-        }
-    }
-
-    /// Gets a [`VRef`] pointing to this instance
-    pub fn borrow(this: &Self) -> VRef<'_, MappedVTable> {
-        // Safety: we know that the ptr is a valid instance corresponding to the MAppedVTable
-        unsafe {
-            let ptr = NonNull::from(this.mapped.0.deref());
-            VRef::from_raw(NonNull::from(this.mapped_vtable), ptr.cast())
-        }
-    }
-
-    /// Gets a Pin pointing to this instance
-    pub fn borrow_pin(this: &Self) -> Pin<VRef<'_, MappedVTable>> {
-        // Safety: the map function returns a pin
-        unsafe { Pin::new_unchecked(Self::borrow(this)) }
-    }
-
-    /// Returns a strong reference to the object that the mapping originates
-    /// from.
-    pub fn origin(this: &Self) -> VRc<OriginVTable> {
-        VRcMapped::origin(&this.mapped)
-    }
-}
-
-/// VWeakMapped allows bundling a VWeak with a reference to an object that's reachable
-/// from the object a successfully upgraded VWeak points to. VWeakMapped's API consists
-/// only of the ability to create clones and to attempt upgrading back to a [`VRcMapped`].
-#[derive(Clone)]
-pub struct VWeakMappedDyn<OriginVTable: VTableMetaDropInPlace + 'static, MappedVTable: VTableMeta> {
-    mapped: VWeakMapped<OriginVTable, Dyn>,
-    mapped_vtable: &'static MappedVTable::VTable,
-}
-
-impl<OriginVTable: VTableMetaDropInPlace + 'static, MappedVTable: VTableMeta>
-    VWeakMappedDyn<OriginVTable, MappedVTable>
-{
-    /// Returns a `VRcMappedDyn` if some other instance still holds a strong reference to the owned
-    /// object. Otherwise, returns None.
-    pub fn upgrade(&self) -> Option<VRcMappedDyn<OriginVTable, MappedVTable>> {
-        self.mapped
-            .upgrade()
-            .map(|mapped| VRcMappedDyn { mapped, mapped_vtable: self.mapped_vtable })
     }
 }

--- a/helper_crates/vtable/tests/test_vrc.rs
+++ b/helper_crates/vtable/tests/test_vrc.rs
@@ -214,10 +214,16 @@ fn rc_map_test() {
         assert_eq!(*e_field, 55);
     }
 
+    let double_map =
+        VRcMapped::map(other_struct_ref, |some| SomeStruct::FIELD_OFFSETS.e.apply_pin(some));
+    let double_map_weak = VRcMapped::downgrade(&double_map);
+    drop(double_map);
+    assert_eq!(*double_map_weak.upgrade().unwrap(), 100);
+
     drop(some_struct_ref);
-    drop(other_struct_ref);
 
     assert!(weak_struct_ref.upgrade().is_none());
+    assert!(double_map_weak.upgrade().is_none());
 }
 
 #[test]

--- a/helper_crates/vtable/tests/test_vrc.rs
+++ b/helper_crates/vtable/tests/test_vrc.rs
@@ -192,9 +192,9 @@ fn rc_map_test() {
     let app_rc = AppStruct::new();
 
     let some_struct_ref =
-        VRcMapped::map(&app_rc, |app| AppStruct::FIELD_OFFSETS.some.apply_pin(app));
+        VRc::map(app_rc.clone(), |app| AppStruct::FIELD_OFFSETS.some.apply_pin(app));
     let other_struct_ref =
-        VRcMapped::map(&app_rc, |app| AppStruct::FIELD_OFFSETS.another_struct.apply_pin(app));
+        VRc::map(app_rc.clone(), |app| AppStruct::FIELD_OFFSETS.another_struct.apply_pin(app));
 
     let weak_struct_ref = VRcMapped::downgrade(&some_struct_ref);
 

--- a/helper_crates/vtable/tests/test_vrc.rs
+++ b/helper_crates/vtable/tests/test_vrc.rs
@@ -220,3 +220,25 @@ fn rc_map_test() {
 
     assert!(weak_struct_ref.upgrade().is_none());
 }
+
+#[test]
+fn rc_map_origin() {
+    let app_rc = AppStruct::new();
+
+    let some_struct_ref =
+        VRc::map(app_rc.clone(), |app| AppStruct::FIELD_OFFSETS.some.apply_pin(app));
+
+    drop(app_rc);
+
+    let strong_origin = VRcMapped::origin(&some_struct_ref);
+
+    drop(some_struct_ref);
+
+    let weak_origin = VRc::downgrade(&strong_origin);
+
+    assert_eq!(VRc::strong_count(&strong_origin), 1);
+
+    drop(strong_origin);
+
+    assert!(weak_origin.upgrade().is_none());
+}

--- a/helper_crates/vtable/tests/test_vrc.rs
+++ b/helper_crates/vtable/tests/test_vrc.rs
@@ -247,30 +247,3 @@ fn rc_map_origin() {
 
     assert!(weak_origin.upgrade().is_none());
 }
-
-#[test]
-fn rc_map_dyn_test() {
-    let app_rc = AppStruct::new();
-
-    let some_struct_ref = VRcMapped::into_dyn::<FooVTable>(&VRc::map(app_rc.clone(), |app| {
-        AppStruct::FIELD_OFFSETS.some.apply_pin(app)
-    }));
-    assert_eq!(VRcMappedDyn::borrow(&some_struct_ref).rc_string().as_str(), "some");
-
-    let weak_struct_ref = VRcMappedDyn::downgrade(&some_struct_ref);
-
-    {
-        let strong_struct_ref = weak_struct_ref.upgrade().unwrap();
-        assert_eq!(VRcMappedDyn::borrow(&strong_struct_ref).rc_string().as_str(), "some");
-    }
-
-    drop(app_rc);
-
-    {
-        let strong_struct_ref = weak_struct_ref.upgrade().unwrap();
-        assert_eq!(VRcMappedDyn::borrow(&strong_struct_ref).rc_string().as_str(), "some");
-    }
-
-    drop(some_struct_ref);
-    assert!(weak_struct_ref.upgrade().is_none());
-}

--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -809,7 +809,7 @@ fn generate_component(
                 self_rc.self_weak.set(VRc::downgrade(&self_rc)).map_err(|_|())
                         .expect("Can only be pinned once");
                 let _self = self_rc.as_pin_ref();
-                let self_mapped = sixtyfps::re_exports::VRcMapped::map(&self_rc, |s| s);
+                let self_mapped = sixtyfps::re_exports::VRc::map(self_rc.clone(), |s| s);
             },
             quote!(&sixtyfps::re_exports::VRcMapped<sixtyfps::re_exports::ComponentVTable, Self>),
             quote!(self_mapped.as_pin_ref()),


### PR DESCRIPTION
In the rust generated code: capture a mapped VRc to an Item instead of capturing simply the Component
This will allow later to de-inline each component.