### PR TITLE
Dropping a reference does nothing

### DIFF
--- a/sixtyfps_compiler/passes/remove_aliases.rs
+++ b/sixtyfps_compiler/passes/remove_aliases.rs
@@ -173,7 +173,6 @@ pub fn remove_aliases(component: &Rc<Component>, diag: &mut BuildDiagnostics) {
             if let Some(d) = elem.property_declarations.get_mut(remove.name()) {
                 if d.expose_in_public_api {
                     d.is_alias = Some(to.clone());
-                    drop(d);
                     drop(elem);
                     // one must mark the aliased property as setable from outside
                     to.element()
@@ -184,7 +183,6 @@ pub fn remove_aliases(component: &Rc<Component>, diag: &mut BuildDiagnostics) {
                         .or_default()
                         .is_set = true;
                 } else {
-                    drop(d);
                     elem.property_declarations.remove(remove.name());
                 }
             } else {


### PR DESCRIPTION
Clippy says this code is fishy: This is dropping a reference, which does nothing.

So this code should be strictly identical to what has been there before. I am not sure this is what you intended to have though!