### PR TITLE
Janitor: Fix clippy error about f32 comparison

### DIFF
--- a/sixtyfps_runtime/corelib/graphics/color.rs
+++ b/sixtyfps_runtime/corelib/graphics/color.rs
@@ -232,6 +232,7 @@ impl From<RgbaColor<f32>> for HsvaColor {
         let max = red.max(green).max(blue);
         let chroma = max - min;
 
+        #[allow(clippy::float_cmp)] // `max` is either `red`, `green` or `blue`
         let hue = 60.
             * if chroma == 0. {
                 0.0


### PR DESCRIPTION
This is a code change, but it should not change behavior.