### PR TITLE
Janitor: CSpell fixes

### DIFF
--- a/api/sixtyfps-rs/sixtyfps-macros/lib.rs
+++ b/api/sixtyfps-rs/sixtyfps-macros/lib.rs
@@ -15,6 +15,9 @@ This crate should not be used directly by application using SixtyFPS.
 You should use the `sixtyfps` crate instead.
 
 */
+
+// cSpell:ignore punct
+
 #![doc(html_logo_url = "https://sixtyfps.io/resources/logo.drawio.svg")]
 
 extern crate proc_macro;

--- a/helper_crates/const-field-offset/src/lib.rs
+++ b/helper_crates/const-field-offset/src/lib.rs
@@ -37,7 +37,7 @@ mod tests {
     use crate as const_field_offset;
     // ### Structures were change to repr(c) and to inherit FieldOffsets
 
-    // Example structs
+    // Example structures
     #[derive(Debug, FieldOffsets)]
     #[repr(C)]
     struct Foo {

--- a/sixtyfps_compiler/generator/cpp.rs
+++ b/sixtyfps_compiler/generator/cpp.rs
@@ -10,6 +10,8 @@ LICENSE END */
 /*! module for the C++ code generator
 */
 
+// cSpell:ignore cstdlib cmath constexpr nullptr decltype intptr uintptr
+
 /// This module contains some data structure that helps represent a C++ code.
 /// It is then rendered into an actual C++ text using the Display trait
 mod cpp_ast {


### PR DESCRIPTION
Mark up some special words in documents (like C++ lingo in rust files).