### PR TITLE
Janitor: Remove unnecessary `&`

### DIFF
--- a/sixtyfps_compiler/expression_tree.rs
+++ b/sixtyfps_compiler/expression_tree.rs
@@ -654,7 +654,7 @@ impl Expression {
             Expression::ReadLocalVariable { .. } => {}
             Expression::EasingCurve(_) => {}
             Expression::LinearGradient { angle, stops } => {
-                visitor(&angle);
+                visitor(angle);
                 for (c, s) in stops {
                     visitor(c);
                     visitor(s);
@@ -1265,12 +1265,12 @@ pub fn pretty_print(f: &mut dyn std::fmt::Write, expression: &Expression) -> std
         Expression::EasingCurve(e) => write!(f, "{:?}", e),
         Expression::LinearGradient { angle, stops } => {
             write!(f, "@linear-gradient(")?;
-            pretty_print(f, &angle)?;
+            pretty_print(f, angle)?;
             for (c, s) in stops {
                 write!(f, ", ")?;
-                pretty_print(f, &c)?;
+                pretty_print(f, c)?;
                 write!(f, "  ")?;
-                pretty_print(f, &s)?;
+                pretty_print(f, s)?;
             }
             write!(f, ")")
         }

--- a/sixtyfps_compiler/langtype.rs
+++ b/sixtyfps_compiler/langtype.rs
@@ -349,7 +349,7 @@ impl Type {
     /// Assume this is a builtin type, panic if it isn't
     pub fn as_builtin(&self) -> &BuiltinElement {
         match self {
-            Type::Builtin(b) => &b,
+            Type::Builtin(b) => b,
             Type::Component(_) => panic!("This should not happen because of inlining"),
             _ => panic!("invalid type"),
         }
@@ -358,7 +358,7 @@ impl Type {
     /// Assume this is a builtin type, panic if it isn't
     pub fn as_native(&self) -> &NativeClass {
         match self {
-            Type::Native(b) => &b,
+            Type::Native(b) => b,
             Type::Component(_) => {
                 panic!("This should not happen because of native class resolution")
             }

--- a/sixtyfps_compiler/layout.rs
+++ b/sixtyfps_compiler/layout.rs
@@ -143,14 +143,14 @@ pub struct LayoutConstraints {
 impl LayoutConstraints {
     pub fn new(element: &ElementRc, diag: &mut BuildDiagnostics) -> Self {
         let mut constraints = Self {
-            min_width: binding_reference(&element, "min_width"),
-            max_width: binding_reference(&element, "max_width"),
-            min_height: binding_reference(&element, "min_height"),
-            max_height: binding_reference(&element, "max_height"),
-            preferred_width: binding_reference(&element, "preferred_width"),
-            preferred_height: binding_reference(&element, "preferred_height"),
-            horizontal_stretch: binding_reference(&element, "horizontal_stretch"),
-            vertical_stretch: binding_reference(&element, "vertical_stretch"),
+            min_width: binding_reference(element, "min_width"),
+            max_width: binding_reference(element, "max_width"),
+            min_height: binding_reference(element, "min_height"),
+            max_height: binding_reference(element, "max_height"),
+            preferred_width: binding_reference(element, "preferred_width"),
+            preferred_height: binding_reference(element, "preferred_height"),
+            horizontal_stretch: binding_reference(element, "horizontal_stretch"),
+            vertical_stretch: binding_reference(element, "vertical_stretch"),
             fixed_width: false,
             fixed_height: false,
         };

--- a/sixtyfps_compiler/lib.rs
+++ b/sixtyfps_compiler/lib.rs
@@ -171,7 +171,7 @@ pub async fn run_passes(
 ) {
     let global_type_registry = type_loader.global_type_registry.clone();
     passes::infer_aliases_types::resolve_aliases(doc, diag);
-    passes::resolving::resolve_expressions(doc, &type_loader, diag);
+    passes::resolving::resolve_expressions(doc, type_loader, diag);
     passes::check_expressions::check_expressions(doc, diag);
     passes::check_public_api::check_public_api(&doc.root_component, diag);
     passes::inlining::inline(doc);

--- a/sixtyfps_compiler/lookup.rs
+++ b/sixtyfps_compiler/lookup.rs
@@ -193,7 +193,7 @@ impl LookupObject for IdLookup {
             }
             None
         }
-        visit(&ctx.component_scope, f)
+        visit(ctx.component_scope, f)
     }
     // TODO: hash based lookup
 }
@@ -265,9 +265,8 @@ impl LookupObject for ElementRc {
         f: &mut impl FnMut(&str, Expression) -> Option<R>,
     ) -> Option<R> {
         for (name, prop) in &self.borrow().property_declarations {
-            let e =
-                expression_from_reference(NamedReference::new(self, &name), &prop.property_type);
-            if let Some(r) = f(&name, e) {
+            let e = expression_from_reference(NamedReference::new(self, name), &prop.property_type);
+            if let Some(r) = f(name, e) {
                 return Some(r);
             }
         }
@@ -279,8 +278,8 @@ impl LookupObject for ElementRc {
             }
         }
         for (name, ty) in crate::typeregister::reserved_properties() {
-            let e = expression_from_reference(NamedReference::new(self, &name), &ty);
-            if let Some(r) = f(&name, e) {
+            let e = expression_from_reference(NamedReference::new(self, name), &ty);
+            if let Some(r) = f(name, e) {
                 return Some(r);
             }
         }
@@ -289,7 +288,7 @@ impl LookupObject for ElementRc {
 
     fn lookup(&self, _ctx: &LookupCtx, name: &str) -> Option<LookupResult> {
         let crate::langtype::PropertyLookupResult { resolved_name, property_type } =
-            self.borrow().lookup_property(&name);
+            self.borrow().lookup_property(name);
         (property_type != Type::Invalid).then(|| LookupResult {
             expression: expression_from_reference(
                 NamedReference::new(self, &resolved_name),
@@ -507,7 +506,7 @@ impl LookupObject for Expression {
                 Type::Struct { fields, .. } => {
                     for name in fields.keys() {
                         if let Some(r) = f(
-                            &name,
+                            name,
                             Expression::StructFieldAccess {
                                 base: Box::new(self.clone()),
                                 name: name.clone(),

--- a/sixtyfps_compiler/object_tree.rs
+++ b/sixtyfps_compiler/object_tree.rs
@@ -688,7 +688,7 @@ impl Element {
                 match QualifiedTypeName::from_node(prop_name_token.clone()).members.as_slice() {
                     [unresolved_prop_name] => {
                         let PropertyLookupResult { resolved_name, property_type } =
-                            r.lookup_property(&unresolved_prop_name);
+                            r.lookup_property(unresolved_prop_name);
                         if let Some(anim_element) = animation_element_from_node(
                             &anim,
                             &prop_name_token,
@@ -698,7 +698,7 @@ impl Element {
                         ) {
                             if unresolved_prop_name != resolved_name.as_ref() {
                                 diag.push_property_deprecation_warning(
-                                    &unresolved_prop_name,
+                                    unresolved_prop_name,
                                     &resolved_name,
                                     &prop_name_token,
                                 );
@@ -1120,10 +1120,10 @@ fn lookup_property_from_qualified_name(
             if !property_type.is_property_type() {
                 diag.push_error(format!("'{}' is not a valid property", qualname), &node);
             }
-            Some((NamedReference::new(&r, &resolved_name), property_type))
+            Some((NamedReference::new(r, &resolved_name), property_type))
         }
         [elem_id, unresolved_prop_name] => {
-            if let Some(element) = find_element_by_id(&r, elem_id.as_ref()) {
+            if let Some(element) = find_element_by_id(r, elem_id.as_ref()) {
                 let PropertyLookupResult { resolved_name, property_type } =
                     element.borrow().lookup_property(unresolved_prop_name.as_ref());
                 if !property_type.is_property_type() {
@@ -1568,7 +1568,7 @@ pub fn inject_element_as_repeated_element(repeated_element: &ElementRc, new_root
 
     // Any elements with a weak reference to the repeater's component will need fixing later.
     let mut elements_with_enclosing_component_reference = Vec::new();
-    recurse_elem(&old_root, &(), &mut |element: &ElementRc, _| {
+    recurse_elem(old_root, &(), &mut |element: &ElementRc, _| {
         if let Some(enclosing_component) = element.borrow().enclosing_component.upgrade() {
             if Rc::ptr_eq(&enclosing_component, &component) {
                 elements_with_enclosing_component_reference.push(element.clone());

--- a/sixtyfps_compiler/parser.rs
+++ b/sixtyfps_compiler/parser.rs
@@ -569,7 +569,7 @@ impl<'a> DefaultParser<'a> {
 
     /// Constructor that create a parser from the source code
     pub fn new(source: &str, diags: &'a mut BuildDiagnostics) -> Self {
-        Self::from_tokens(crate::lexer::lex(&source), diags)
+        Self::from_tokens(crate::lexer::lex(source), diags)
     }
 
     fn current_token(&self) -> Token {
@@ -749,7 +749,7 @@ impl NodeOrToken {
 
     pub fn as_node(&self) -> Option<&SyntaxNode> {
         match self {
-            NodeOrToken::Node(n) => Some(&n),
+            NodeOrToken::Node(n) => Some(n),
             NodeOrToken::Token(_) => None,
         }
     }
@@ -757,7 +757,7 @@ impl NodeOrToken {
     pub fn as_token(&self) -> Option<&SyntaxToken> {
         match self {
             NodeOrToken::Node(_) => None,
-            NodeOrToken::Token(t) => Some(&t),
+            NodeOrToken::Token(t) => Some(t),
         }
     }
 

--- a/sixtyfps_compiler/passes/apply_default_properties_from_style.rs
+++ b/sixtyfps_compiler/passes/apply_default_properties_from_style.rs
@@ -31,7 +31,7 @@ pub async fn apply_default_properties_from_style<'a>(
     let style_metrics = if let Some(Type::Component(c)) = style_metrics { c } else { return };
 
     crate::object_tree::recurse_elem_including_sub_components(
-        &root_component,
+        root_component,
         &(),
         &mut |elem, _| {
             let mut elem = elem.borrow_mut();

--- a/sixtyfps_compiler/passes/binding_analysis.rs
+++ b/sixtyfps_compiler/passes/binding_analysis.rs
@@ -42,7 +42,7 @@ pub fn binding_analysis(component: &Rc<Component>, diag: &mut BuildDiagnostics) 
                     continue;
                 }
                 let mut set = PropertySet::default();
-                analyse_binding(e, &name, &mut set, diag);
+                analyse_binding(e, name, &mut set, diag);
             }
         },
     );
@@ -203,21 +203,21 @@ fn visit_implicit_layout_info_dependencies(
     let base_type = item.borrow().base_type.to_string();
     match base_type.as_str() {
         "Image" => {
-            vis(&NamedReference::new(&item, "source"));
+            vis(&NamedReference::new(item, "source"));
             if orientation == Orientation::Vertical {
-                vis(&NamedReference::new(&item, "width"));
+                vis(&NamedReference::new(item, "width"));
             }
         }
         "Text" => {
-            vis(&NamedReference::new(&item, "text"));
-            vis(&NamedReference::new(&item, "font_family"));
-            vis(&NamedReference::new(&item, "font_size"));
-            vis(&NamedReference::new(&item, "font_weight"));
-            vis(&NamedReference::new(&item, "letter_spacing"));
-            vis(&NamedReference::new(&item, "wrap"));
-            vis(&NamedReference::new(&item, "overflow"));
+            vis(&NamedReference::new(item, "text"));
+            vis(&NamedReference::new(item, "font_family"));
+            vis(&NamedReference::new(item, "font_size"));
+            vis(&NamedReference::new(item, "font_weight"));
+            vis(&NamedReference::new(item, "letter_spacing"));
+            vis(&NamedReference::new(item, "wrap"));
+            vis(&NamedReference::new(item, "overflow"));
             if orientation == Orientation::Vertical {
-                vis(&NamedReference::new(&item, "width"));
+                vis(&NamedReference::new(item, "width"));
             }
         }
         _ => (),

--- a/sixtyfps_compiler/passes/clip.rs
+++ b/sixtyfps_compiler/passes/clip.rs
@@ -26,7 +26,7 @@ pub fn handle_clip(
     let native_clip = type_register.lookup("Clip").as_builtin().native_class.clone();
 
     crate::object_tree::recurse_elem_including_sub_components(
-        &component,
+        component,
         &(),
         &mut |elem_rc: &ElementRc, _| {
             let mut elem = elem_rc.borrow_mut();

--- a/sixtyfps_compiler/passes/collect_globals.rs
+++ b/sixtyfps_compiler/passes/collect_globals.rs
@@ -27,6 +27,6 @@ pub fn collect_globals(root_component: &Rc<Component>, _diag: &mut BuildDiagnost
             hash.insert(global_component.id.clone(), global_component.clone());
         }
     };
-    visit_all_named_references(&root_component, &mut maybe_collect_global);
+    visit_all_named_references(root_component, &mut maybe_collect_global);
     *root_component.used_global.borrow_mut() = hash.into_iter().map(|(_, v)| v).collect();
 }

--- a/sixtyfps_compiler/passes/collect_structs.rs
+++ b/sixtyfps_compiler/passes/collect_structs.rs
@@ -26,7 +26,7 @@ pub fn collect_structs(root_component: &Rc<Component>, _diag: &mut BuildDiagnost
         });
     };
 
-    recurse_elem_including_sub_components_no_borrow(&root_component, &(), &mut |elem, _| {
+    recurse_elem_including_sub_components_no_borrow(root_component, &(), &mut |elem, _| {
         for x in elem.borrow().property_declarations.values() {
             maybe_collect_object(&x.property_type);
         }
@@ -61,7 +61,7 @@ fn sort_struct(hash: &mut BTreeMap<String, Type>, vec: &mut Vec<Type>, key: &str
         }
 
         for sub_ty in fields.values() {
-            visit_named_object(&sub_ty, &mut |name, _| sort_struct(hash, vec, name));
+            visit_named_object(sub_ty, &mut |name, _| sort_struct(hash, vec, name));
         }
     }
     vec.push(ty)
@@ -72,10 +72,10 @@ fn visit_named_object(ty: &Type, visitor: &mut impl FnMut(&String, &Type)) {
         Type::Struct { fields, name, .. } => {
             name.as_ref().map(|struct_name| visitor(struct_name, ty));
             for sub_ty in fields.values() {
-                visit_named_object(&sub_ty, visitor);
+                visit_named_object(sub_ty, visitor);
             }
         }
-        Type::Array(x) => visit_named_object(&x, visitor),
+        Type::Array(x) => visit_named_object(x, visitor),
         _ => {}
     }
 }

--- a/sixtyfps_compiler/passes/deduplicate_property_read.rs
+++ b/sixtyfps_compiler/passes/deduplicate_property_read.rs
@@ -88,7 +88,7 @@ impl<'a> DedupPropState<'a> {
 }
 
 fn process_expression(expr: &mut Expression, old_state: &DedupPropState) {
-    let new_state = DedupPropState { parent_state: Some(&old_state), ..DedupPropState::default() };
+    let new_state = DedupPropState { parent_state: Some(old_state), ..DedupPropState::default() };
     collect_unconditional_read_count(expr, &new_state);
     process_conditional_expressions(expr, &new_state);
     do_replacements(expr, &new_state);

--- a/sixtyfps_compiler/passes/flickable.rs
+++ b/sixtyfps_compiler/passes/flickable.rs
@@ -34,7 +34,7 @@ pub fn handle_flickable(root_component: &Rc<Component>, tr: &TypeRegister) {
     }
 
     crate::object_tree::recurse_elem_including_sub_components(
-        &root_component,
+        root_component,
         &(),
         &mut |elem: &ElementRc, _| {
             if !matches!(elem.borrow().builtin_type(), Some(n) if n.name == "Flickable") {

--- a/sixtyfps_compiler/passes/generate_item_indices.rs
+++ b/sixtyfps_compiler/passes/generate_item_indices.rs
@@ -10,7 +10,7 @@ LICENSE END */
 //! Assign the Element::item_index on each elements
 pub fn generate_item_indices(component: &std::rc::Rc<crate::object_tree::Component>) {
     let mut current_item_index: usize = 0;
-    crate::generator::build_array_helper(&component, move |item_rc, _, _| {
+    crate::generator::build_array_helper(component, move |item_rc, _, _| {
         let item = item_rc.borrow();
         if item.base_type == crate::langtype::Type::Void {
         } else {

--- a/sixtyfps_compiler/passes/inlining.rs
+++ b/sixtyfps_compiler/passes/inlining.rs
@@ -233,7 +233,7 @@ fn duplicate_property_animation(
 
 fn fixup_reference(nr: &mut NamedReference, mapping: &HashMap<ByAddress<ElementRc>, ElementRc>) {
     if let Some(e) = mapping.get(&element_key(nr.element())) {
-        *nr = NamedReference::new(&e, nr.name());
+        *nr = NamedReference::new(e, nr.name());
     }
 }
 

--- a/sixtyfps_compiler/passes/lower_layout.rs
+++ b/sixtyfps_compiler/passes/lower_layout.rs
@@ -26,7 +26,7 @@ pub fn lower_layouts<'a>(
     *component.root_constraints.borrow_mut() =
         LayoutConstraints::new(&component.root_element, diag);
 
-    recurse_elem_including_sub_components(&component, &(), &mut |elem, _| {
+    recurse_elem_including_sub_components(component, &(), &mut |elem, _| {
         let component = elem.borrow().enclosing_component.upgrade().unwrap();
         lower_element_layout(&component, elem, type_register, diag);
         check_no_layout_properties(elem, diag);
@@ -78,7 +78,7 @@ fn lower_grid_layout(
 ) {
     let mut grid = GridLayout {
         elems: Default::default(),
-        geometry: LayoutGeometry::new(&grid_layout_element),
+        geometry: LayoutGeometry::new(grid_layout_element),
     };
 
     let layout_cache_prop_h =
@@ -199,15 +199,15 @@ impl GridLayout {
         }
 
         let index = self.elems.len();
-        if let Some(layout_item) = create_layout_item(&item_element, diag) {
+        if let Some(layout_item) = create_layout_item(item_element, diag) {
             let e = &layout_item.elem;
-            set_prop_from_cache(e, "x", &layout_cache_prop_h, index * 2, &None, diag);
+            set_prop_from_cache(e, "x", layout_cache_prop_h, index * 2, &None, diag);
             if !layout_item.item.constraints.fixed_width {
-                set_prop_from_cache(e, "width", &layout_cache_prop_h, index * 2 + 1, &None, diag);
+                set_prop_from_cache(e, "width", layout_cache_prop_h, index * 2 + 1, &None, diag);
             }
-            set_prop_from_cache(e, "y", &layout_cache_prop_v, index * 2, &None, diag);
+            set_prop_from_cache(e, "y", layout_cache_prop_v, index * 2, &None, diag);
             if !layout_item.item.constraints.fixed_height {
-                set_prop_from_cache(e, "height", &layout_cache_prop_v, index * 2 + 1, &None, diag);
+                set_prop_from_cache(e, "height", layout_cache_prop_v, index * 2 + 1, &None, diag);
             }
 
             self.elems.push(GridLayoutElement {
@@ -230,7 +230,7 @@ fn lower_box_layout(
     let mut layout = BoxLayout {
         orientation,
         elems: Default::default(),
-        geometry: LayoutGeometry::new(&layout_element),
+        geometry: LayoutGeometry::new(layout_element),
     };
 
     let layout_cache_prop = create_new_prop(layout_element, "layout_cache", Type::LayoutCache);
@@ -501,7 +501,7 @@ fn eval_const_expr(
                 Some(r)
             }
         }
-        Expression::Cast { from, .. } => eval_const_expr(&from, name, span, diag),
+        Expression::Cast { from, .. } => eval_const_expr(from, name, span, diag),
         _ => {
             diag.push_error(format!("'{}' must be an integer literal", name), span);
             None

--- a/sixtyfps_compiler/passes/lower_shadows.rs
+++ b/sixtyfps_compiler/passes/lower_shadows.rs
@@ -142,7 +142,7 @@ pub fn lower_shadow_properties(
         );
     }
 
-    recurse_elem_including_sub_components_no_borrow(&component, &(), &mut |elem, _| {
+    recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
         // When encountering a repeater where the repeated element has a `drop-shadow` property, we create a new
         // dedicated shadow element and make the previously repeated element a child of that. This ensures rendering
         // underneath while maintaining the hierarchy for the repeater.

--- a/sixtyfps_compiler/passes/remove_aliases.rs
+++ b/sixtyfps_compiler/passes/remove_aliases.rs
@@ -77,7 +77,7 @@ pub fn remove_aliases(component: &Rc<Component>, diag: &mut BuildDiagnostics) {
                     diag.push_error("Property cannot alias to itself".into(), binding);
                     continue 'bindings;
                 }
-                property_sets.add_link(NamedReference::new(e, &name), nr.clone());
+                property_sets.add_link(NamedReference::new(e, name), nr.clone());
 
                 exp = match next {
                     Some(x) => &*x,
@@ -139,7 +139,7 @@ pub fn remove_aliases(component: &Rc<Component>, diag: &mut BuildDiagnostics) {
                             crate::passes::inlining::maybe_merge_two_ways(
                                 &mut binding.expression,
                                 &mut 0,
-                                &e.get(),
+                                e.get(),
                             );
                             *e.get_mut() = binding;
                         }

--- a/sixtyfps_compiler/passes/repeater_component.rs
+++ b/sixtyfps_compiler/passes/repeater_component.rs
@@ -66,7 +66,7 @@ fn create_repeater_components(component: &Rc<Component>) {
 /// Make sure that references to property within the repeated element actually point to the reference
 /// to the root of the newly created component
 fn adjust_references(comp: &Rc<Component>) {
-    visit_all_named_references(&comp, &mut |nr| {
+    visit_all_named_references(comp, &mut |nr| {
         if nr.name() == "$model" {
             return;
         }

--- a/sixtyfps_compiler/passes/resolve_native_classes.rs
+++ b/sixtyfps_compiler/passes/resolve_native_classes.rs
@@ -17,7 +17,7 @@ use crate::langtype::{NativeClass, Type};
 use crate::object_tree::{recurse_elem_including_sub_components, Component};
 
 pub fn resolve_native_classes(component: &Component) {
-    recurse_elem_including_sub_components(&component, &(), &mut |elem, _| {
+    recurse_elem_including_sub_components(component, &(), &mut |elem, _| {
         let new_native_class = {
             let elem = elem.borrow();
 
@@ -77,7 +77,7 @@ fn select_minimal_class_based_on_property_usage<'a>(
     let (_min_distance, minimal_class) = properties_used.fold(
         (std::usize::MAX, minimal_class),
         |(current_distance, current_class), prop_name| {
-            let (prop_distance, prop_class) = lookup_property_distance(class.clone(), &prop_name);
+            let (prop_distance, prop_class) = lookup_property_distance(class.clone(), prop_name);
 
             if prop_distance < current_distance {
                 (prop_distance, prop_class)

--- a/sixtyfps_compiler/passes/transform_and_opacity.rs
+++ b/sixtyfps_compiler/passes/transform_and_opacity.rs
@@ -28,44 +28,40 @@ pub(crate) fn handle_transform_and_opacity(
         diag.push_error("The opacity property cannot be used on the root element".to_string(), b);
     }
 
-    object_tree::recurse_elem_including_sub_components_no_borrow(
-        &component,
-        &(),
-        &mut |elem, _| {
-            if elem.borrow().base_type.to_string() == "Opacity" {
-                return;
-            }
+    object_tree::recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
+        if elem.borrow().base_type.to_string() == "Opacity" {
+            return;
+        }
 
-            let old_children = {
-                let mut elem = elem.borrow_mut();
-                let new_children = Vec::with_capacity(elem.children.len());
-                std::mem::replace(&mut elem.children, new_children)
-            };
+        let old_children = {
+            let mut elem = elem.borrow_mut();
+            let new_children = Vec::with_capacity(elem.children.len());
+            std::mem::replace(&mut elem.children, new_children)
+        };
 
-            let has_opacity_binding = |e: &ElementRc| {
-                e.borrow().base_type.lookup_property("opacity").property_type != Type::Invalid
-                    && e.borrow().bindings.contains_key("opacity")
-            };
+        let has_opacity_binding = |e: &ElementRc| {
+            e.borrow().base_type.lookup_property("opacity").property_type != Type::Invalid
+                && e.borrow().bindings.contains_key("opacity")
+        };
 
-            for mut child in old_children {
-                if child.borrow().repeated.is_some() {
-                    let root_elem = child.borrow().base_type.as_component().root_element.clone();
-                    if has_opacity_binding(&root_elem) {
-                        object_tree::inject_element_as_repeated_element(
-                            &child,
-                            create_opacity_element(&root_elem, type_register),
-                        )
-                    }
-                } else if has_opacity_binding(&child) {
-                    let new_child = create_opacity_element(&child, type_register);
-                    new_child.borrow_mut().children.push(child);
-                    child = new_child;
+        for mut child in old_children {
+            if child.borrow().repeated.is_some() {
+                let root_elem = child.borrow().base_type.as_component().root_element.clone();
+                if has_opacity_binding(&root_elem) {
+                    object_tree::inject_element_as_repeated_element(
+                        &child,
+                        create_opacity_element(&root_elem, type_register),
+                    )
                 }
-
-                elem.borrow_mut().children.push(child);
+            } else if has_opacity_binding(&child) {
+                let new_child = create_opacity_element(&child, type_register);
+                new_child.borrow_mut().children.push(child);
+                child = new_child;
             }
-        },
-    );
+
+            elem.borrow_mut().children.push(child);
+        }
+    });
 }
 
 fn create_opacity_element(child: &ElementRc, type_register: &TypeRegister) -> ElementRc {
@@ -75,7 +71,7 @@ fn create_opacity_element(child: &ElementRc, type_register: &TypeRegister) -> El
         enclosing_component: child.borrow().enclosing_component.clone(),
         bindings: std::iter::once((
             "opacity".to_owned(),
-            Expression::TwoWayBinding(NamedReference::new(&child, "opacity"), None).into(),
+            Expression::TwoWayBinding(NamedReference::new(child, "opacity"), None).into(),
         ))
         .collect(),
         ..Default::default()

--- a/sixtyfps_compiler/passes/z_order.rs
+++ b/sixtyfps_compiler/passes/z_order.rs
@@ -20,7 +20,7 @@ use crate::object_tree::{Component, ElementRc};
 
 pub fn reorder_by_z_order(root_component: &Rc<Component>, diag: &mut BuildDiagnostics) {
     crate::object_tree::recurse_elem_including_sub_components(
-        &root_component,
+        root_component,
         &(),
         &mut |elem: &ElementRc, _| {
             reorder_children_by_zorder(elem, diag);
@@ -84,9 +84,9 @@ fn eval_const_expr(
 ) -> Option<f64> {
     match expression {
         Expression::NumberLiteral(v, Unit::None) => Some(*v),
-        Expression::Cast { from, .. } => eval_const_expr(&from, name, span, diag),
-        Expression::UnaryOp { sub, op: '-' } => eval_const_expr(&sub, name, span, diag).map(|v| -v),
-        Expression::UnaryOp { sub, op: '+' } => eval_const_expr(&sub, name, span, diag),
+        Expression::Cast { from, .. } => eval_const_expr(from, name, span, diag),
+        Expression::UnaryOp { sub, op: '-' } => eval_const_expr(sub, name, span, diag).map(|v| -v),
+        Expression::UnaryOp { sub, op: '+' } => eval_const_expr(sub, name, span, diag),
         _ => {
             diag.push_error(format!("'{}' must be an number literal", name), span);
             None

--- a/sixtyfps_compiler/typeloader.rs
+++ b/sixtyfps_compiler/typeloader.rs
@@ -117,7 +117,7 @@ impl<'a> TypeLoader<'a> {
         diagnostics: &mut BuildDiagnostics,
         registry_to_populate: &Rc<RefCell<TypeRegister>>,
     ) -> Vec<ImportedTypes> {
-        let dependencies = self.collect_dependencies(&doc, diagnostics).await;
+        let dependencies = self.collect_dependencies(doc, diagnostics).await;
         let mut foreign_imports = vec![];
         for mut import in dependencies.into_iter() {
             if import.file.ends_with(".60") {
@@ -287,7 +287,7 @@ impl<'a> TypeLoader<'a> {
         diagnostics: &mut BuildDiagnostics,
     ) {
         let dependency_doc: syntax_nodes::Document =
-            crate::parser::parse(source_code, Some(&source_path), diagnostics).into();
+            crate::parser::parse(source_code, Some(source_path), diagnostics).into();
 
         let dependency_registry =
             Rc::new(RefCell::new(TypeRegister::new(&self.global_type_registry)));
@@ -320,7 +320,7 @@ impl<'a> TypeLoader<'a> {
             &dependency_registry,
         );
         crate::passes::infer_aliases_types::resolve_aliases(&doc, diagnostics);
-        crate::passes::resolving::resolve_expressions(&doc, &self, diagnostics);
+        crate::passes::resolving::resolve_expressions(&doc, self, diagnostics);
         crate::passes::check_expressions::check_expressions(&doc, diagnostics);
         self.all_documents.docs.insert(path.to_owned(), doc);
     }

--- a/sixtyfps_runtime/corelib/graphics/image.rs
+++ b/sixtyfps_runtime/corelib/graphics/image.rs
@@ -75,7 +75,7 @@ impl Image {
     /// Returns the size of the Image in pixels.
     pub fn size(&self) -> crate::graphics::Size {
         match crate::backend::instance() {
-            Some(backend) => backend.image_size(&self),
+            Some(backend) => backend.image_size(self),
             None => panic!("sixtyfps::Image::size() called too early (before a graphics backend was chosen). You need to create a component first."),
         }
     }

--- a/sixtyfps_runtime/corelib/window.rs
+++ b/sixtyfps_runtime/corelib/window.rs
@@ -211,7 +211,7 @@ impl Window {
         let mut item = self.focus_item.borrow().clone();
         while let Some(focus_item) = item.upgrade() {
             let window = &ComponentWindow::new(self.clone());
-            if focus_item.borrow().as_ref().key_event(event, &window)
+            if focus_item.borrow().as_ref().key_event(event, window)
                 == crate::input::KeyEventResult::EventAccepted
             {
                 return;


### PR DESCRIPTION
This is a big one touching a lot of files, removing some stray `&` all over the place.