### PR TITLE
Pr/janitor

### DIFF
--- a/helper_crates/const-field-offset/macro/macro.rs
+++ b/helper_crates/const-field-offset/macro/macro.rs
@@ -259,6 +259,7 @@ pub fn const_field_offset(input: TokenStream) -> TokenStream {
             #(#vis #fields : #crate_::FieldOffset<#struct_name, #types, #pin_flag>,)*
         }
 
+        #[allow(clippy::eval_order_dependence)] // The point of this code is to depend on the order!
         impl #struct_name {
             /// Return a struct containing the offset of for the fields of this struct
             pub const FIELD_OFFSETS : #field_struct_name = {

--- a/sixtyfps_runtime/corelib/model.rs
+++ b/sixtyfps_runtime/corelib/model.rs
@@ -32,7 +32,7 @@ pub struct ModelPeer {
 }
 
 /// Dispatch notifications from a [`Model`] to one or several [`ModelPeer`].
-/// Typically, you would want to put this in the implementaiton of the Model
+/// Typically, you would want to put this in the implementation of the Model
 #[derive(Default)]
 pub struct ModelNotify {
     inner: RefCell<weak_table::PtrWeakHashSet<Weak<RefCell<ModelPeerInner>>>>,


### PR DESCRIPTION
Tiny janitor fixes.

The FieldOffsets warning disablement removed 23 warnings all over the code base and is the right thing to do IMHO, as this warning can be helpful in general, so I would not want to just turn it off overall.