### PR TITLE
Use `impl Default` instead of `new()` constructors

### DIFF
--- a/api/sixtyfps-node/native/lib.rs
+++ b/api/sixtyfps-node/native/lib.rs
@@ -62,7 +62,7 @@ fn load(mut cx: FunctionContext) -> JsResult<JsValue> {
         }
         None => vec![],
     };
-    let mut compiler = sixtyfps_interpreter::ComponentCompiler::new();
+    let mut compiler = sixtyfps_interpreter::ComponentCompiler::default();
     compiler.set_include_paths(include_paths);
     let c = spin_on::spin_on(compiler.build_from_path(path));
 

--- a/api/sixtyfps-rs/sixtyfps-build/lib.rs
+++ b/api/sixtyfps-rs/sixtyfps-build/lib.rs
@@ -61,16 +61,17 @@ pub struct CompilerConfiguration {
     config: sixtyfps_compilerlib::CompilerConfiguration,
 }
 
-impl CompilerConfiguration {
-    /// Creates a new default configuration.
-    pub fn new() -> Self {
+impl Default for CompilerConfiguration {
+    fn default() -> Self {
         Self {
             config: sixtyfps_compilerlib::CompilerConfiguration::new(
                 sixtyfps_compilerlib::generator::OutputFormat::Rust,
             ),
         }
     }
+}
 
+impl CompilerConfiguration {
     /// Create a new configuration that includes sets the include paths used for looking up
     /// `.60` imports to the specified vector of paths.
     pub fn with_include_paths(self, include_paths: Vec<std::path::PathBuf>) -> Self {
@@ -168,7 +169,7 @@ impl<Sink: Write> Write for CodeFormatter<Sink> {
 /// Please check out the documentation of the `sixtyfps` crate for more information
 /// about how to use the generated code.
 pub fn compile(path: impl AsRef<std::path::Path>) -> Result<(), CompileError> {
-    compile_with_config(path, CompilerConfiguration::new())
+    compile_with_config(path, CompilerConfiguration::default())
 }
 
 /// Same as [`compile`], but allow to specify a configuration.

--- a/api/sixtyfps-wasm-interpreter/src/lib.rs
+++ b/api/sixtyfps-wasm-interpreter/src/lib.rs
@@ -53,7 +53,7 @@ pub async fn compile_from_string(
     #[cfg(feature = "console_error_panic_hook")]
     console_error_panic_hook::set_once();
 
-    let mut compiler = sixtyfps_interpreter::ComponentCompiler::new();
+    let mut compiler = sixtyfps_interpreter::ComponentCompiler::default();
 
     if let Some(load_callback) = optional_import_callback {
         let open_import_fallback = move |file_name: &Path| -> core::pin::Pin<

--- a/sixtyfps_runtime/interpreter/api.rs
+++ b/sixtyfps_runtime/interpreter/api.rs
@@ -418,9 +418,8 @@ pub struct ComponentCompiler {
     diagnostics: Vec<Diagnostic>,
 }
 
-impl ComponentCompiler {
-    /// Returns a new ComponentCompiler
-    pub fn new() -> Self {
+impl Default for ComponentCompiler {
+    fn default() -> Self {
         Self {
             config: sixtyfps_compilerlib::CompilerConfiguration::new(
                 sixtyfps_compilerlib::generator::OutputFormat::Interpreter,
@@ -428,7 +427,9 @@ impl ComponentCompiler {
             diagnostics: vec![],
         }
     }
+}
 
+impl ComponentCompiler {
     /// Sets the include paths used for looking up `.60` imports to the specified vector of paths.
     pub fn set_include_paths(&mut self, include_paths: Vec<std::path::PathBuf>) {
         self.config.include_paths = include_paths;
@@ -678,7 +679,7 @@ impl ComponentInstance {
     ///         property <int> my_property: 42;
     ///     }
     /// "#;
-    /// let mut compiler = ComponentCompiler::new();
+    /// let mut compiler = ComponentCompiler::default();
     /// let definition = spin_on::spin_on(
     ///     compiler.build_from_source(code.into(), Default::default()));
     /// assert!(compiler.diagnostics().is_empty(), "{:?}", compiler.diagnostics());
@@ -721,7 +722,7 @@ impl ComponentInstance {
     ///     }
     /// "#;
     /// let definition = spin_on::spin_on(
-    ///     ComponentCompiler::new().build_from_source(code.into(), Default::default()));
+    ///     ComponentCompiler::default().build_from_source(code.into(), Default::default()));
     /// let instance = definition.unwrap().create();
     ///
     /// let instance_weak = instance.as_weak();
@@ -903,7 +904,7 @@ pub mod testing {
 
 #[test]
 fn component_definition_properties() {
-    let mut compiler = ComponentCompiler::new();
+    let mut compiler = ComponentCompiler::default();
     let comp_def = spin_on::spin_on(
         compiler.build_from_source(
             r#"
@@ -926,7 +927,7 @@ fn component_definition_properties() {
 
 #[test]
 fn component_definition_properties2() {
-    let mut compiler = ComponentCompiler::new();
+    let mut compiler = ComponentCompiler::default();
     let comp_def = spin_on::spin_on(
         compiler.build_from_source(
             r#"

--- a/sixtyfps_runtime/interpreter/ffi.rs
+++ b/sixtyfps_runtime/interpreter/ffi.rs
@@ -568,7 +568,7 @@ impl ComponentCompilerOpaque {
 pub unsafe extern "C" fn sixtyfps_interpreter_component_compiler_new(
     compiler: *mut ComponentCompilerOpaque,
 ) {
-    std::ptr::write(compiler as *mut ComponentCompiler, ComponentCompiler::new())
+    std::ptr::write(compiler as *mut ComponentCompiler, ComponentCompiler::default())
 }
 
 #[no_mangle]

--- a/sixtyfps_runtime/interpreter/lib.rs
+++ b/sixtyfps_runtime/interpreter/lib.rs
@@ -32,7 +32,7 @@ This example loads a `.60` dynamically from a path and show errors if any:
 ```rust
 use sixtyfps_interpreter::{ComponentDefinition, ComponentCompiler};
 
-let mut compiler = ComponentCompiler::new();
+let mut compiler = ComponentCompiler::default();
 let definition =
     spin_on::spin_on(compiler.build_from_path("hello.60"));
 # #[cfg(feature="print_diagnostics")]
@@ -57,7 +57,7 @@ let code = r#"
     }
 "#;
 
-let mut compiler = ComponentCompiler::new();
+let mut compiler = ComponentCompiler::default();
 let definition =
     spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
 assert!(compiler.diagnostics().is_empty());

--- a/sixtyfps_runtime/interpreter/tests.rs
+++ b/sixtyfps_runtime/interpreter/tests.rs
@@ -21,7 +21,7 @@ fn reuse_window() {
         }
     "#;
     let handle = {
-        let mut compiler = ComponentCompiler::new();
+        let mut compiler = ComponentCompiler::default();
         let definition =
             spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
         assert!(compiler.diagnostics().is_empty(), "{:?}", compiler.diagnostics());
@@ -34,7 +34,7 @@ fn reuse_window() {
     };
 
     let _handle2 = {
-        let mut compiler = ComponentCompiler::new();
+        let mut compiler = ComponentCompiler::default();
         let definition =
             spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
         assert!(compiler.diagnostics().is_empty(), "{:?}", compiler.diagnostics());

--- a/tests/doctests/main.rs
+++ b/tests/doctests/main.rs
@@ -10,7 +10,7 @@ LICENSE END */
 
 #[cfg(test)]
 fn do_test(snippet: &str) -> Result<(), Box<dyn std::error::Error>> {
-    let mut compiler = sixtyfps_interpreter::ComponentCompiler::new();
+    let mut compiler = sixtyfps_interpreter::ComponentCompiler::default();
     let component =
         spin_on::spin_on(compiler.build_from_source(snippet.into(), Default::default()));
 

--- a/tests/driver/interpreter/interpreter.rs
+++ b/tests/driver/interpreter/interpreter.rs
@@ -18,7 +18,7 @@ pub fn test(testcase: &test_driver_lib::TestCase) -> Result<(), Box<dyn Error>> 
     let include_paths = test_driver_lib::extract_include_paths(&source)
         .map(std::path::PathBuf::from)
         .collect::<Vec<_>>();
-    let mut compiler = sixtyfps_interpreter::ComponentCompiler::new();
+    let mut compiler = sixtyfps_interpreter::ComponentCompiler::default();
     compiler.set_include_paths(include_paths);
 
     let component =

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -206,7 +206,7 @@ async fn reload_preview(
         cache.current = preview_component.clone();
     }
 
-    let mut builder = sixtyfps_interpreter::ComponentCompiler::new();
+    let mut builder = sixtyfps_interpreter::ComponentCompiler::default();
     let cli_args = super::Cli::from_args();
     if !cli_args.style.is_empty() {
         builder.set_style(cli_args.style)

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -74,7 +74,7 @@ fn init_compiler(
     args: &Cli,
     fswatcher: Option<Arc<Mutex<notify::RecommendedWatcher>>>,
 ) -> sixtyfps_interpreter::ComponentCompiler {
-    let mut compiler = sixtyfps_interpreter::ComponentCompiler::new();
+    let mut compiler = sixtyfps_interpreter::ComponentCompiler::default();
     compiler.set_include_paths(args.include_paths.clone());
     if !args.style.is_empty() {
         compiler.set_style(args.style.clone());


### PR DESCRIPTION
The detault trait impl instead of `new()` patch separated out of the latest janitor patch set.