### PR TITLE
Model: Unify PartialEq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+ - Changed the base class of `ModelHandle` to be a `SharedModel` which wraps the
+   `Rc<dyn Model>` that was used before.
+
 ### Added
 
  - Compilation error when there are duplicated element id

--- a/api/sixtyfps-node/native/lib.rs
+++ b/api/sixtyfps-node/native/lib.rs
@@ -191,7 +191,7 @@ fn to_eval_value<'cx>(
                 obj.get(cx, "rowCount")?.downcast_or_throw::<JsFunction, _>(cx)?;
                 obj.get(cx, "rowData")?.downcast_or_throw::<JsFunction, _>(cx)?;
                 let m = js_model::JsModel::new(obj, *a, cx, persistent_context)?;
-                Ok(Value::Model(m))
+                Ok(Value::Model(sixtyfps_corelib::model::SharedModel(m)))
             }
         },
         Type::Image => {

--- a/sixtyfps_runtime/corelib/model.rs
+++ b/sixtyfps_runtime/corelib/model.rs
@@ -128,7 +128,7 @@ impl<T: 'static> VecModel<T> {
     where
         T: Clone,
     {
-        ModelHandle(Some(Rc::<Self>::new(slice.to_vec().into())))
+        ModelHandle::new(Rc::<Self>::new(slice.to_vec().into()))
     }
 
     /// Add a row at the end of the model
@@ -205,14 +205,49 @@ impl Model for bool {
     }
 }
 
+/// A shared model
+#[repr(transparent)]
+#[derive(derive_more::Deref, derive_more::DerefMut)]
+pub struct SharedModel<T>(pub Rc<dyn Model<Data = T>>);
+
+impl<T> std::fmt::Debug for SharedModel<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SharedModel(dyn Model)")
+    }
+}
+
+impl<T> Clone for SharedModel<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T> core::cmp::PartialEq for SharedModel<T> {
+    #[allow(clippy::vtable_address_comparisons)]
+    // We think vtable_address_comparisons are safe here!
+    // Rc::ptr_eq will compare a fat pointer consisting of a `vtable` and a `self` pointer.
+    //
+    // We can get:
+    // * false positives: Two different `Model`s get considered the same, even though they are not.
+    //   For this the `self` pointer need to point to the same place. That can not happen here
+    //   since `Rc` will allocate for the refcounts, even if `T` is `()`.
+    // * false negatives: The same `Model` gets considered to be two different `Model`s.
+    //   In this case the `vtable` pointer must differ, e.g. because two crates created separate
+    //   instances of the vtable for the `Model` trait.
+    //   This will trigger some unnecessary rendering, but is benign otherwise.
+    fn eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.0, &other.0)
+    }
+}
+
 /// Properties of type array in the .60 language are represented as
 /// an [`Option`] of an [`Rc`] of something implemented the [`Model`] trait
 #[derive(derive_more::Deref, derive_more::DerefMut, derive_more::From, derive_more::Into)]
-pub struct ModelHandle<T>(pub Option<Rc<dyn Model<Data = T>>>);
+pub struct ModelHandle<T>(pub Option<SharedModel<T>>);
 
 impl<T> std::fmt::Debug for ModelHandle<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ModelHandle({:?})", self.0.as_ref().map(|_| "dyn Model"))
+        write!(f, "ModelHandle({:?})", self.0.as_ref())
     }
 }
 
@@ -221,6 +256,7 @@ impl<T> Clone for ModelHandle<T> {
         Self(self.0.clone())
     }
 }
+
 impl<T> Default for ModelHandle<T> {
     fn default() -> Self {
         Self(None)
@@ -231,9 +267,8 @@ impl<T> core::cmp::PartialEq for ModelHandle<T> {
     fn eq(&self, other: &Self) -> bool {
         match (&self.0, &other.0) {
             (None, None) => true,
-            (None, Some(_)) => false,
-            (Some(_), None) => false,
-            (Some(a), Some(b)) => Rc::ptr_eq(a, b),
+            (Some(a), Some(b)) => a == b,
+            _ => false,
         }
     }
 }
@@ -247,7 +282,7 @@ impl<T> From<Rc<dyn Model<Data = T>>> for ModelHandle<T> {
 impl<T> ModelHandle<T> {
     /// Create a new handle wrapping the given model
     pub fn new(model: Rc<dyn Model<Data = T>>) -> Self {
-        Self(Some(model))
+        Self(Some(SharedModel(model)))
     }
 }
 

--- a/sixtyfps_runtime/corelib/model.rs
+++ b/sixtyfps_runtime/corelib/model.rs
@@ -242,7 +242,9 @@ impl<T> core::cmp::PartialEq for SharedModel<T> {
 
 /// Properties of type array in the .60 language are represented as
 /// an [`Option`] of an [`Rc`] of something implemented the [`Model`] trait
-#[derive(derive_more::Deref, derive_more::DerefMut, derive_more::From, derive_more::Into)]
+#[derive(
+    PartialEq, derive_more::Deref, derive_more::DerefMut, derive_more::From, derive_more::Into,
+)]
 pub struct ModelHandle<T>(pub Option<SharedModel<T>>);
 
 impl<T> std::fmt::Debug for ModelHandle<T> {
@@ -260,16 +262,6 @@ impl<T> Clone for ModelHandle<T> {
 impl<T> Default for ModelHandle<T> {
     fn default() -> Self {
         Self(None)
-    }
-}
-
-impl<T> core::cmp::PartialEq for ModelHandle<T> {
-    fn eq(&self, other: &Self) -> bool {
-        match (&self.0, &other.0) {
-            (None, None) => true,
-            (Some(a), Some(b)) => a == b,
-            _ => false,
-        }
     }
 }
 

--- a/sixtyfps_runtime/interpreter/api.rs
+++ b/sixtyfps_runtime/interpreter/api.rs
@@ -101,7 +101,7 @@ pub enum Value {
     /// An Array in the .60 language.
     Array(SharedVector<Value>),
     /// A more complex model which is not created by the interpreter itself (Value::Array can also be used for models)
-    Model(Rc<dyn sixtyfps_corelib::model::Model<Data = Value>>),
+    Model(sixtyfps_corelib::model::SharedModel<Value>),
     /// An object
     Struct(Struct),
     /// Correspond to `brush` or `color` type in .60.  For color, this is then a [`Brush::SolidColor`]
@@ -152,7 +152,7 @@ impl PartialEq for Value {
             Value::Bool(lhs) => matches!(other, Value::Bool(rhs) if lhs == rhs),
             Value::Image(lhs) => matches!(other, Value::Image(rhs) if lhs == rhs),
             Value::Array(lhs) => matches!(other, Value::Array(rhs) if lhs == rhs),
-            Value::Model(lhs) => matches!(other, Value::Model(rhs) if Rc::ptr_eq(lhs, rhs)),
+            Value::Model(lhs) => matches!(other, Value::Model(rhs) if lhs == rhs),
             Value::Struct(lhs) => matches!(other, Value::Struct(rhs) if lhs == rhs),
             Value::Brush(lhs) => matches!(other, Value::Brush(rhs) if lhs == rhs),
             Value::PathElements(lhs) => matches!(other, Value::PathElements(rhs) if lhs == rhs),

--- a/sixtyfps_runtime/interpreter/dynamic_component.rs
+++ b/sixtyfps_runtime/interpreter/dynamic_component.rs
@@ -1216,8 +1216,8 @@ pub fn instantiate<'id>(
                     InstanceRef::from_pin_ref(c, guard)
                 }),
             );
-            sixtyfps_corelib::model::ModelHandle(Some(Rc::new(
-                crate::value_model::ValueModel::new(m),
+            sixtyfps_corelib::model::ModelHandle::new(Rc::new(crate::value_model::ValueModel::new(
+                m,
             )))
         });
     }

--- a/sixtyfps_runtime/interpreter/ffi.rs
+++ b/sixtyfps_runtime/interpreter/ffi.rs
@@ -123,7 +123,10 @@ pub unsafe extern "C" fn sixtyfps_interpreter_value_new_model(
     model: vtable::VBox<ModelAdaptorVTable>,
     val: *mut ValueOpaque,
 ) {
-    std::ptr::write(val as *mut Value, Value::Model(Rc::new(ModelAdaptorWrapper(model))))
+    std::ptr::write(
+        val as *mut Value,
+        Value::Model(sixtyfps_corelib::model::SharedModel(Rc::new(ModelAdaptorWrapper(model)))),
+    )
 }
 
 #[no_mangle]


### PR DESCRIPTION
Implement PartialEq for Rc<Model> and use that for ModelHandle as well
as Value<Model>

Wrap a Rc<Model> into a SharedModel and implement PartialEq for that.

Wrap Option<SharedModel> into the ModuleHandle as well as Value::Model.