### PR TITLE
Remove the freetype dependency on Windows and macOS

### DIFF
--- a/sixtyfps_runtime/rendering_backends/gl/Cargo.toml
+++ b/sixtyfps_runtime/rendering_backends/gl/Cargo.toml
@@ -50,13 +50,15 @@ ttf-parser = "0.12.0"
 winit = { version = "0.25", default-features = false }
 glutin = { version = "0.27", default-features = false }
 glow = { version = "0.10.0", default-features = false }
-font-kit = { version = "0.10", features = ["loader-freetype"] }
+font-kit = { version = "0.10", features = [] }
 fontdb = { version = "0.5.1", features = ["fs"] }
 
-# Require font-config from the system. Issue #88 indicates that the copy provided by servo-fontconfig may be incompatible
-# with distros at times.
 [target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios", target_arch = "wasm32")))'.dependencies]
+# Require font-config from the system on Linux. Issue #88 indicates that the copy provided by servo-fontconfig may be incompatible
+# with distros at times.
 servo-fontconfig = { version = "0.5", features = [ "force_system_lib" ] }
+# On Windows and macOS we don't need freetype (font-kit has coretext/directwrite backends)
+font-kit = { version = "0.10", features = ["loader-freetype"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = { version = "0.24.0" }


### PR DESCRIPTION
It's not needed and this would fix #315