### PR TITLE
Fix stack overflow with Rust generated code in debug builds on Windows

### DIFF
--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -1965,7 +1965,7 @@ fn compile_path(path: &Path, component: &Rc<Component>) -> TokenStream {
 // In Rust debug builds, accessing the member of the FIELD_OFFSETS ends up copying the
 // entire FIELD_OFFSETS into a new stack allocation, which with large property
 // binding initialization functions isn't re-used and with large generated inner
-// components ends up large amounts of stack space.
+// components ends up large amounts of stack space (see issue #133)
 fn access_component_field_offset(component_id: &Ident, field: &Ident) -> TokenStream {
     quote!({
         let field = &#component_id::FIELD_OFFSETS.#field;

--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -1967,8 +1967,5 @@ fn compile_path(path: &Path, component: &Rc<Component>) -> TokenStream {
 // binding initialization functions isn't re-used and with large generated inner
 // components ends up large amounts of stack space (see issue #133)
 fn access_component_field_offset(component_id: &Ident, field: &Ident) -> TokenStream {
-    quote!({
-        let field = &#component_id::FIELD_OFFSETS.#field;
-        *field
-    })
+    quote!({ *&#component_id::FIELD_OFFSETS.#field })
 }

--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -673,7 +673,9 @@ fn generate_component(
     let (drop_impl, pin) = if component.is_global() {
         (None, quote!(#[pin]))
     } else {
-        let item_fields = item_names.iter().map(|field_name| access_self_field_offset(&field_name));
+        let item_fields = item_names
+            .iter()
+            .map(|field_name| access_component_field_offset(&format_ident!("Self"), &field_name));
         (
             Some(quote!(impl sixtyfps::re_exports::PinnedDrop for #inner_component_id {
                 fn drop(self: core::pin::Pin<&mut #inner_component_id>) {
@@ -1253,7 +1255,7 @@ fn compile_expression(expr: &Expression, component: &Rc<Component>) -> TokenStre
                         let item = item.upgrade().unwrap();
                         let item = item.borrow();
                         let item_id = format_ident!("r#{}", item.id);
-                        let item_field = access_self_field_offset(&item_id);
+                        let item_field = access_component_field_offset(&format_ident!("Self"), &item_id);
                         quote!(
                             #item_field.apply_pin(_self).layouting_info(#orient, &_self.window)
                         )
@@ -1967,13 +1969,6 @@ fn compile_path(path: &Path, component: &Rc<Component>) -> TokenStream {
 fn access_component_field_offset(component_id: &Ident, field: &Ident) -> TokenStream {
     quote!({
         let field = &#component_id::FIELD_OFFSETS.#field;
-        *field
-    })
-}
-
-fn access_self_field_offset(field: &Ident) -> TokenStream {
-    quote!({
-        let field = &Self::FIELD_OFFSETS.#field;
         *field
     })
 }


### PR DESCRIPTION
On Windows the default stack size is less than on Linux/macOS and
therefore an issues surfaces that is however operating system agnostic:

Due to inlining we generate quite big inner components with many fields.
Their field offsets are accumulated in the separate FIELD_OFFSETS
struct. The access pattern typically looks like this:

    Self::FIELD_OFFSETS.some_field.apply_pin(...)

This is destructed into at least two smaller operations, fetching
some_field and then calling apply_pin with that field as self parameter.

In Rust debug builds the first operation, unfortunately, ends up making
a full copy of Self::FIELD_OFFSETS into a temporary variable on the
stack. Unfortunately also that stack space isn't reused, so every access
results in a new stack allocation to hold all of the FIELD_OFFSETS
structure (~5kb in the printer demo).

With so many accesses to that in the generated code, we run out of stack
space already in the new() function, in item_tree() as well as in the
Drop impl that also accesses all field offsets.

This patch applies the following workaround that does the trick. The
above expression is replaced with

    {
        let field = &Self::FIELD_OFFSETS.some_field;
        *field
    }.apply_pin(...)

Fixes #133