### PR TITLE
Fix panic when editing text after programmatically replacing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
  - GridLayout cells with colspan and rowspan respect properly their constraints
-
+ - Panic when replacing programmatically text in a `TextInput` and then editing it.
 
 ## [0.1.0] - 2021-06-30
 

--- a/tests/cases/text/text_change.60
+++ b/tests/cases/text/text_change.60
@@ -1,0 +1,47 @@
+/* LICENSE BEGIN
+    This file is part of the SixtyFPS Project -- https://sixtyfps.io
+    Copyright (c) 2021 Olivier Goffart <olivier.goffart@sixtyfps.io>
+    Copyright (c) 2021 Simon Hausmann <simon.hausmann@sixtyfps.io>
+
+    SPDX-License-Identifier: GPL-3.0-only
+    This file is also available under commercial licensing terms.
+    Please contact info@sixtyfps.io for more information.
+LICENSE END */
+
+TestCase := Window {
+    width: 100phx;
+    height: 100phx;
+    VerticalLayout {
+        padding: 0;
+        spacing: 0;
+        ti := TextInput { }
+        Rectangle { }
+    }
+
+    property <string> text <=> ti.text;
+    property <bool> input_focused: ti.has_focus;
+    property<int> test_cursor_pos: ti.cursor_position;
+}
+
+/*
+```rust
+
+// from input.rs
+const LEFT_CODE: char = '\u{000E}'; // shift out
+
+let instance = TestCase::new();
+sixtyfps::testing::send_mouse_click(&instance, 5., 5.);
+assert!(instance.get_input_focused());
+assert_eq!(instance.get_text(), "");
+sixtyfps::testing::send_keyboard_string_sequence(&instance, "Hallo");
+assert_eq!(instance.get_text(), "Hallo");
+instance.set_text("Yo".into());
+assert_eq!(instance.get_text(), "Yo");
+sixtyfps::testing::send_keyboard_string_sequence(&instance, "Hello Again");
+assert_eq!(instance.get_text(), "YoHello Again");
+instance.set_text("Yo".into());
+// Issue #331: assert_eq!(instance.get_test_cursor_pos(), 2);
+sixtyfps::testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+assert_eq!(instance.get_test_cursor_pos(), 1);
+```
+*/


### PR DESCRIPTION
When replacing the text, it may happen that the cursor position becomes outdated.
As per #331 we should make sure that this is handled also on an API level,
but this patch at least avoids the panic triggered by using editing.