### PR TITLE
Add a as_any to the Model trait to allow getting a reference to the original model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable changes to this project will be documented in this file.
 
  - Compilation error when there are duplicated element id
  - `ComboBox` now has a `selected` callback
- - Added `sixtyfps::Weak::upgrade_in_event_loop' in the Rust API
+ - Added `sixtyfps::Weak::upgrade_in_event_loop` in the Rust API
+ - Added `sixtyfps::Model::as_any()` in the Rust API
 
 ### Fixed
 

--- a/api/sixtyfps-node/native/js_model.rs
+++ b/api/sixtyfps-node/native/js_model.rs
@@ -105,6 +105,10 @@ impl Model for JsModel {
                 .and_then(|func| func.call(cx, obj, [row, data].iter().cloned()).ok());
         });
     }
+
+    fn as_any(&self) -> &dyn core::any::Any {
+        self
+    }
 }
 
 struct WrappedJsModel(Weak<JsModel>);

--- a/sixtyfps_runtime/interpreter/value_model.rs
+++ b/sixtyfps_runtime/interpreter/value_model.rs
@@ -70,4 +70,8 @@ impl Model for ValueModel {
             _ => println!("Value of model cannot be change"),
         }
     }
+
+    fn as_any(&self) -> &dyn core::any::Any {
+        self
+    }
 }


### PR DESCRIPTION
This should help to get back the original model from the component.

For example, it will remove the need in this hack to use a thread local 

https://github.com/sixtyfpsui/cargo-ui/blob/cefb0b2bca658290c0b27d9cff48e365c3dfbebc/src/main.rs#L101

because we can just get the model back from the component and downcast it to the right value.

