### PR TITLE
updated erroneous link

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -62,7 +62,7 @@ We use a rather complex mechanism to expose internal data structures implemented
 
 As a starting point, we recommend reading the blog entry we published about this:
 
-[https://sixtyfps.io/blog/expose-rust-library-to-other-languages.html]()
+[https://sixtyfps.io/blog/expose-rust-library-to-other-languages.html](https://sixtyfps.io/blog/expose-rust-library-to-other-languages.html)
 
 What this article omits are how we invoke cbindgen and what kind of tweaks we apply on various levels:
 


### PR DESCRIPTION
The link to the blog post previously pointed to the root of the repo's docs folder.