### PR TITLE
GL backend: Use the cache for the Window icon

### DIFF
--- a/sixtyfps_runtime/rendering_backends/gl/graphics_window.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/graphics_window.rs
@@ -23,7 +23,6 @@ use corelib::slice::Slice;
 use corelib::window::{ComponentWindow, PlatformWindow};
 use corelib::Property;
 use corelib::SharedString;
-use image::GenericImageView;
 use sixtyfps_corelib as corelib;
 use winit::dpi::LogicalSize;
 
@@ -472,11 +471,11 @@ impl PlatformWindow for GraphicsWindow {
                     let backend = window.backend.borrow();
                     let winit_window = backend.window();
                     winit_window.set_title(&title);
-                    if let Some(img) = crate::images::CachedImage::new_from_resource((&icon).into())
-                        .and_then(|i| i.into_image())
+                    if let Some(rgba) = crate::IMAGE_CACHE
+                        .with(|c| c.borrow_mut().load_image_resource((&icon).into()))
+                        .and_then(|i| i.to_rgba())
                     {
-                        let (width, height) = img.dimensions();
-                        let rgba = img.into_rgba8();
+                        let (width, height) = rgba.dimensions();
                         winit_window.set_window_icon(
                             winit::window::Icon::from_rgba(rgba.into_raw(), width, height).ok(),
                         );

--- a/sixtyfps_runtime/rendering_backends/gl/images.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/images.rs
@@ -375,9 +375,9 @@ impl CachedImage {
         }
     }
 
-    pub(crate) fn into_image(self) -> Option<image::DynamicImage> {
-        if let ImageData::DecodedImage(img) = self.0.into_inner() {
-            Some(img)
+    pub(crate) fn to_rgba(&self) -> Option<image::RgbaImage> {
+        if let ImageData::DecodedImage(img) = &*self.0.borrow() {
+            Some(img.to_rgba8())
         } else {
             None
         }


### PR DESCRIPTION
I had to change a bit  the internal image API to avoid copying too much.