### PR TITLE
Rename the implementation of the `Window` item to `WindowItem`

### DIFF
--- a/sixtyfps_compiler/builtins.60
+++ b/sixtyfps_compiler/builtins.60
@@ -151,7 +151,7 @@ export Flickable := _ {
     //-default_size_binding:expands_to_parent_geometry
 }
 
-export Window := _ {
+export WindowItem := _ {
     property <length> width: native_output;
     property <length> height: native_output;
     property <color> background; // StyleMetrics.window_background  set in apply_default_properties_from_style
@@ -161,6 +161,8 @@ export Window := _ {
     property <length> default_font_size;
     property <int> default_font_weight;
 }
+
+export { WindowItem as Window }
 
 export BoxShadow := _ {
     property <length> x;

--- a/sixtyfps_runtime/corelib/items.rs
+++ b/sixtyfps_runtime/corelib/items.rs
@@ -1043,7 +1043,7 @@ pub struct PropertyAnimation {
 #[repr(C)]
 #[derive(FieldOffsets, Default, SixtyFPSElement)]
 #[pin]
-pub struct Window {
+pub struct WindowItem {
     pub width: Property<f32>,
     pub height: Property<f32>,
     pub background: Property<Color>,
@@ -1054,7 +1054,7 @@ pub struct Window {
     pub cached_rendering_data: CachedRenderingData,
 }
 
-impl Item for Window {
+impl Item for WindowItem {
     fn init(self: Pin<&Self>, _window: &ComponentWindow) {}
 
     fn geometry(self: Pin<&Self>) -> Rect {
@@ -1096,7 +1096,7 @@ impl Item for Window {
     fn render(self: Pin<&Self>, _backend: &mut ItemRendererRef) {}
 }
 
-impl Window {
+impl WindowItem {
     /// Returns the font properties that can be used as defaults for child items
     pub fn default_font_properties(self: Pin<&Self>) -> crate::graphics::FontRequest {
         crate::graphics::FontRequest {
@@ -1129,13 +1129,13 @@ impl Window {
     }
 }
 
-impl ItemConsts for Window {
+impl ItemConsts for WindowItem {
     const cached_rendering_data_offset: const_field_offset::FieldOffset<Self, CachedRenderingData> =
         Self::FIELD_OFFSETS.cached_rendering_data.as_unpinned_projection();
 }
 
 declare_item_vtable! {
-    fn sixtyfps_get_WindowVTable() -> WindowVTable for Window
+    fn sixtyfps_get_WindowItemVTable() -> WindowItemVTable for WindowItem
 }
 
 /// The implementation of the `BoxShadow` element

--- a/sixtyfps_runtime/corelib/window.rs
+++ b/sixtyfps_runtime/corelib/window.rs
@@ -52,7 +52,7 @@ pub trait PlatformWindow {
     /// Request for the event loop to wake up and call [`Window::update_window_properties()`].
     fn request_window_properties_update(&self);
     /// Request for the given title string to be set to the windowing system for use as window title.
-    fn apply_window_properties(&self, window_item: Pin<&crate::items::Window>);
+    fn apply_window_properties(&self, window_item: Pin<&crate::items::WindowItem>);
 
     /// Return a font metrics trait object for the given font request. This is typically provided by the backend and
     /// requested by text related items in order to measure text metrics with the item's chosen font.
@@ -277,7 +277,8 @@ impl Window {
                 let component = ComponentRc::borrow_pin(&component);
                 let root_item = component.as_ref().get_item_ref(0);
 
-                if let Some(window_item) = ItemRef::downcast_pin::<crate::items::Window>(root_item)
+                if let Some(window_item) =
+                    ItemRef::downcast_pin::<crate::items::WindowItem>(root_item)
                 {
                     self.platform_window.get().unwrap().apply_window_properties(window_item);
                 }

--- a/sixtyfps_runtime/interpreter/dynamic_component.rs
+++ b/sixtyfps_runtime/interpreter/dynamic_component.rs
@@ -678,7 +678,7 @@ pub(crate) fn generate_component<'id>(
                 rtti_for::<FocusScope>(),
                 rtti_for::<Path>(),
                 rtti_for::<Flickable>(),
-                rtti_for::<Window>(),
+                rtti_for::<WindowItem>(),
                 rtti_for::<TextInput>(),
                 rtti_for::<Clip>(),
                 rtti_for::<BoxShadow>(),

--- a/sixtyfps_runtime/rendering_backends/gl/graphics_window.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/graphics_window.rs
@@ -77,7 +77,7 @@ impl GraphicsWindow {
                         let component = ComponentRc::borrow_pin(&component_rc);
                         let root_item = component.as_ref().get_item_ref(0);
                         ItemRef::downcast_pin(root_item).map(
-                            |window_item: Pin<&corelib::items::Window>| {
+                            |window_item: Pin<&corelib::items::WindowItem>| {
                                 window_item.default_font_properties()
                             },
                         )
@@ -170,7 +170,7 @@ impl GraphicsWindow {
     /// Requests for the window to be mapped to the screen.
     ///
     /// Arguments:
-    /// * `component`: The component that holds the root item of the scene. If the item is a [`corelib::items::Window`], then
+    /// * `component`: The component that holds the root item of the scene. If the item is a [`corelib::items::WindowItem`], then
     ///   the `width` and `height` properties are read and the values are passed to the windowing system as request
     ///   for the initial size of the window. Then bindings are installed on these properties to keep them up-to-date
     ///   with the size as it may be changed by the user or the windowing system in general.
@@ -183,12 +183,13 @@ impl GraphicsWindow {
         let component = ComponentRc::borrow_pin(&component);
         let root_item = component.as_ref().get_item_ref(0);
 
-        let window_title =
-            if let Some(window_item) = ItemRef::downcast_pin::<corelib::items::Window>(root_item) {
-                window_item.title().to_string()
-            } else {
-                "SixtyFPS Window".to_string()
-            };
+        let window_title = if let Some(window_item) =
+            ItemRef::downcast_pin::<corelib::items::WindowItem>(root_item)
+        {
+            window_item.title().to_string()
+        } else {
+            "SixtyFPS Window".to_string()
+        };
         let window_builder = winit::window::WindowBuilder::new().with_title(window_title);
 
         let window_builder = if std::env::var("SIXTYFPS_FULLSCREEN").is_ok() {
@@ -273,10 +274,10 @@ impl GraphicsWindow {
                         let layout_info_v = popup.as_ref().layout_info(Orientation::Vertical);
 
                         let width =
-                            corelib::items::Window::FIELD_OFFSETS.width.apply_pin(window_item);
+                            corelib::items::WindowItem::FIELD_OFFSETS.width.apply_pin(window_item);
                         let mut w = width.get();
                         let height =
-                            corelib::items::Window::FIELD_OFFSETS.height.apply_pin(window_item);
+                            corelib::items::WindowItem::FIELD_OFFSETS.height.apply_pin(window_item);
                         let mut h = height.get();
                         if w <= 0. {
                             w = layout_info_h.preferred;
@@ -296,7 +297,7 @@ impl GraphicsWindow {
             let window = map_state.as_mapped();
             let root_item = component.as_ref().get_item_ref(0);
             let background_color = if let Some(window_item) =
-                ItemRef::downcast_pin::<corelib::items::Window>(root_item)
+                ItemRef::downcast_pin::<corelib::items::WindowItem>(root_item)
             {
                 window_item.background()
             } else {
@@ -386,7 +387,9 @@ impl GraphicsWindow {
         self.self_weak.upgrade().unwrap().try_component().map(|component_rc| {
             let component = ComponentRc::borrow_pin(&component_rc);
             let root_item = component.as_ref().get_item_ref(0);
-            if let Some(window_item) = ItemRef::downcast_pin::<corelib::items::Window>(root_item) {
+            if let Some(window_item) =
+                ItemRef::downcast_pin::<corelib::items::WindowItem>(root_item)
+            {
                 window_item.width.set(width);
                 window_item.height.set(height);
             }
@@ -461,7 +464,7 @@ impl PlatformWindow for GraphicsWindow {
         }
     }
 
-    fn apply_window_properties(&self, window_item: Pin<&sixtyfps_corelib::items::Window>) {
+    fn apply_window_properties(&self, window_item: Pin<&sixtyfps_corelib::items::WindowItem>) {
         match &*self.map_state.borrow() {
             GraphicsWindowBackendState::Unmapped => {}
             GraphicsWindowBackendState::Mapped(window) => {

--- a/sixtyfps_runtime/rendering_backends/qt/qt_window.rs
+++ b/sixtyfps_runtime/rendering_backends/qt/qt_window.rs
@@ -1048,7 +1048,7 @@ impl QtWindow {
         let component_rc = self.self_weak.upgrade().unwrap().component();
         let component = ComponentRc::borrow_pin(&component_rc);
         let root_item = component.as_ref().get_item_ref(0);
-        if let Some(window_item) = ItemRef::downcast_pin::<items::Window>(root_item) {
+        if let Some(window_item) = ItemRef::downcast_pin::<items::WindowItem>(root_item) {
             window_item.width.set(size.width as _);
             window_item.height.set(size.height as _);
         }
@@ -1110,8 +1110,9 @@ impl QtWindow {
             .and_then(|component_rc| {
                 let component = ComponentRc::borrow_pin(&component_rc);
                 let root_item = component.as_ref().get_item_ref(0);
-                ItemRef::downcast_pin(root_item)
-                    .map(|window_item: Pin<&items::Window>| window_item.default_font_properties())
+                ItemRef::downcast_pin(root_item).map(|window_item: Pin<&items::WindowItem>| {
+                    window_item.default_font_properties()
+                })
             })
             .unwrap_or_default()
     }
@@ -1155,7 +1156,7 @@ impl PlatformWindow for QtWindow {
     }
 
     /// Apply windows property such as title to the QWidget*
-    fn apply_window_properties(&self, window_item: Pin<&items::Window>) {
+    fn apply_window_properties(&self, window_item: Pin<&items::WindowItem>) {
         let widget_ptr = self.widget_ptr();
         let title: qttypes::QString = window_item.title().as_str().into();
         let mut size = qttypes::QSize {
@@ -1212,7 +1213,7 @@ impl PlatformWindow for QtWindow {
         let component = ComponentRc::borrow_pin(popup);
         let root_item = component.as_ref().get_item_ref(0);
         let (mut w, mut h) =
-            if let Some(window_item) = ItemRef::downcast_pin::<items::Window>(root_item) {
+            if let Some(window_item) = ItemRef::downcast_pin::<items::WindowItem>(root_item) {
                 (window_item.width(), window_item.height())
             } else {
                 (0., 0.)

--- a/sixtyfps_runtime/rendering_backends/testing/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/testing/lib.rs
@@ -132,7 +132,7 @@ impl PlatformWindow for TestingWindow {
 
     fn request_window_properties_update(&self) {}
 
-    fn apply_window_properties(&self, _window_item: Pin<&sixtyfps_corelib::items::Window>) {
+    fn apply_window_properties(&self, _window_item: Pin<&sixtyfps_corelib::items::WindowItem>) {
         todo!()
     }
 

--- a/xtask/src/cbindgen.rs
+++ b/xtask/src/cbindgen.rs
@@ -82,7 +82,7 @@ fn gen_corelib(root_dir: &Path, include_dir: &Path) -> anyhow::Result<()> {
         "Flickable",
         "Text",
         "Path",
-        "Window",
+        "WindowItem",
         "TextInput",
         "Clip",
         "BoxShadow",


### PR DESCRIPTION
If we were to add `sixtyfps::window::Window` to the re_exports, then
this clashes. We might rename the former, but this is a cleaner naming
in any case.

Relates to #333