### PR TITLE
window api cleanup

### DIFF
--- a/api/sixtyfps-cpp/lib.rs
+++ b/api/sixtyfps-cpp/lib.rs
@@ -29,7 +29,7 @@ pub unsafe extern "C" fn sixtyfps_component_window_init(out: *mut ComponentWindo
         core::mem::size_of::<ComponentWindow>(),
         core::mem::size_of::<ComponentWindowOpaque>()
     );
-    core::ptr::write(out as *mut ComponentWindow, crate::backend().create_window());
+    core::ptr::write(out as *mut ComponentWindow, crate::backend().create_window().into());
 }
 
 #[no_mangle]

--- a/api/sixtyfps-rs/lib.rs
+++ b/api/sixtyfps-rs/lib.rs
@@ -254,7 +254,7 @@ pub mod re_exports {
 /// Creates a new window to render components in.
 #[doc(hidden)]
 pub fn create_window() -> re_exports::ComponentWindow {
-    sixtyfps_rendering_backend_default::backend().create_window()
+    sixtyfps_rendering_backend_default::backend().create_window().into()
 }
 
 /// Enters the main event loop. This is necessary in order to receive

--- a/api/sixtyfps-rs/lib.rs
+++ b/api/sixtyfps-rs/lib.rs
@@ -242,7 +242,7 @@ pub mod re_exports {
         set_state_binding, Property, PropertyTracker, StateInfo,
     };
     pub use sixtyfps_corelib::slice::Slice;
-    pub use sixtyfps_corelib::window::ComponentWindow;
+    pub use sixtyfps_corelib::window::{ComponentWindow, WindowHandleAccess};
     pub use sixtyfps_corelib::Color;
     pub use sixtyfps_corelib::ComponentVTable_static;
     pub use sixtyfps_corelib::SharedString;

--- a/api/sixtyfps-rs/lib.rs
+++ b/api/sixtyfps-rs/lib.rs
@@ -505,8 +505,9 @@ pub mod testing {
         component: &Component,
         factor: f32,
     ) {
+        use sixtyfps_corelib::window::WindowHandleAccess;
         let component = component.clone_strong().into();
-        component.component_window().set_scale_factor(factor)
+        component.component_window().window_handle().set_scale_factor(factor)
     }
 }
 

--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -1236,7 +1236,7 @@ fn compile_expression(expr: &Expression, component: &Rc<Component>) -> TokenStre
                         let x = access_named_reference(&popup.x, component, quote!(_self));
                         let y = access_named_reference(&popup.y, component, quote!(_self));
                         quote!(
-                            _self.window.show_popup(
+                            _self.window.window_handle().show_popup(
                                 &VRc::into_dyn(#popup_window_id::new(_self.self_weak.get().unwrap().clone(), &_self.window).into()),
                                 Point::new(#x.get(), #y.get())
                             );

--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -648,7 +648,7 @@ fn generate_component(
 
         visibility = Some(quote!(pub));
 
-        init.push(quote!(_self.window.set_component(&VRc::into_dyn(_self.as_ref().self_weak.get().unwrap().upgrade().unwrap()));));
+        init.push(quote!(_self.window.window_handle().set_component(&VRc::into_dyn(_self.as_ref().self_weak.get().unwrap().upgrade().unwrap()));));
 
         has_window_impl = Some(quote!(
             impl sixtyfps::testing::HasWindow for #inner_component_id {
@@ -1216,7 +1216,7 @@ fn compile_expression(expr: &Expression, component: &Rc<Component>) -> TokenStre
                         let focus_item = focus_item.borrow();
                         let item_index = focus_item.item_index.get().unwrap();
                         quote!(
-                            _self.window.set_focus_item(&ItemRc::new(VRc::into_dyn(_self.self_weak.get().unwrap().upgrade().unwrap()), #item_index));
+                            _self.window.window_handle().clone().set_focus_item(&ItemRc::new(VRc::into_dyn(_self.self_weak.get().unwrap().upgrade().unwrap()), #item_index));
                         )
                     } else {
                         panic!("internal error: argument to SetFocusItem must be an element")

--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -821,11 +821,11 @@ fn generate_component(
                     }
 
                     fn show(&self) {
-                        vtable::VRc::as_pin_ref(&self.0).window.show();
+                        vtable::VRc::as_pin_ref(&self.0).window.window_handle().show();
                     }
 
                     fn hide(&self) {
-                        vtable::VRc::as_pin_ref(&self.0).window.hide();
+                        vtable::VRc::as_pin_ref(&self.0).window.window_handle().hide();
                     }
                 }
             ))
@@ -1102,7 +1102,7 @@ fn compile_expression(expr: &Expression, component: &Rc<Component>) -> TokenStre
         }
         Expression::BuiltinFunctionReference(funcref, _) => match funcref {
             BuiltinFunction::GetWindowScaleFactor => {
-                quote!(_self.window.scale_factor)
+                quote!(_self.window.window_handle().scale_factor)
             }
             BuiltinFunction::Debug => quote!((|x| println!("{:?}", x))),
             BuiltinFunction::Mod => quote!((|a1, a2| (a1 as i32) % (a2 as i32))),

--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -681,7 +681,7 @@ fn generate_component(
                     let items = [
                         #(VRef::new_pin(#item_fields.apply_pin(self.as_ref())),)*
                     ];
-                    self.window.free_graphics_resources(&Slice::from_slice(&items));
+                    self.window.window_handle().free_graphics_resources(&Slice::from_slice(&items));
                 }
             })),
             quote!(#[pin_drop]),

--- a/sixtyfps_runtime/corelib/backend.rs
+++ b/sixtyfps_runtime/corelib/backend.rs
@@ -12,9 +12,10 @@ The backend is the abstraction for crates that need to do the actual drawing and
 */
 
 use std::path::Path;
+use std::rc::Rc;
 
 use crate::graphics::{Image, Size};
-use crate::window::ComponentWindow;
+use crate::window::Window;
 
 /// Behavior describing how the event loop should terminate.
 pub enum EventLoopQuitBehavior {
@@ -24,11 +25,11 @@ pub enum EventLoopQuitBehavior {
     QuitOnlyExplicitly,
 }
 
-/// Interface implemented by backends
+/// Interface implemented by back-ends
 pub trait Backend: Send + Sync {
     /// Instantiate a window for a component.
     /// FIXME: should return a Box<dyn PlatformWindow>
-    fn create_window(&'static self) -> ComponentWindow;
+    fn create_window(&'static self) -> Rc<Window>;
 
     /// Spins an event loop and renders the visible windows.
     fn run_event_loop(&'static self, behavior: EventLoopQuitBehavior);

--- a/sixtyfps_runtime/corelib/items.rs
+++ b/sixtyfps_runtime/corelib/items.rs
@@ -507,7 +507,7 @@ impl Item for FocusScope {
             return InputEventResult::EventIgnored;
         }*/
         if matches!(event, MouseEvent::MousePressed { .. }) && !self.has_focus() {
-            window.set_focus_item(self_rc);
+            window.0.clone().set_focus_item(self_rc);
         }
         InputEventResult::EventIgnored
     }

--- a/sixtyfps_runtime/corelib/items/text.rs
+++ b/sixtyfps_runtime/corelib/items/text.rs
@@ -475,7 +475,7 @@ impl From<KeyboardModifiers> for AnchorMode {
 
 impl TextInput {
     fn show_cursor(&self, window: &ComponentWindow) {
-        window.set_cursor_blink_binding(&self.cursor_visible);
+        window.0.set_cursor_blink_binding(&self.cursor_visible);
     }
 
     fn hide_cursor(&self) {

--- a/sixtyfps_runtime/corelib/items/text.rs
+++ b/sixtyfps_runtime/corelib/items/text.rs
@@ -324,7 +324,7 @@ impl Item for TextInput {
                 self.as_ref().anchor_position.set(clicked_offset);
                 self.as_ref().cursor_position.set(clicked_offset);
                 if !self.has_focus() {
-                    window.set_focus_item(self_rc);
+                    window.0.clone().set_focus_item(self_rc);
                 }
             }
             MouseEvent::MouseReleased { .. } | MouseEvent::MouseExit => {

--- a/sixtyfps_runtime/corelib/tests.rs
+++ b/sixtyfps_runtime/corelib/tests.rs
@@ -74,12 +74,12 @@ pub extern "C" fn send_keyboard_string_sequence(
         }
         let text: SharedString = ch.to_string().into();
 
-        window.process_key_input(&KeyEvent {
+        window.0.clone().process_key_input(&KeyEvent {
             event_type: KeyEventType::KeyPressed,
             text: text.clone(),
             modifiers,
         });
-        window.process_key_input(&KeyEvent {
+        window.0.clone().process_key_input(&KeyEvent {
             event_type: KeyEventType::KeyReleased,
             text,
             modifiers,

--- a/sixtyfps_runtime/corelib/window.rs
+++ b/sixtyfps_runtime/corelib/window.rs
@@ -304,6 +304,12 @@ impl core::ops::Deref for Window {
     }
 }
 
+/// Internal trait used by generated code to access window internals.
+pub trait WindowHandleAccess {
+    /// Returns a reference to the window implementation.
+    fn window_handle(&self) -> &std::rc::Rc<Window>;
+}
+
 /// The ComponentWindow is the (rust) facing public type that can render the items
 /// of components to the screen.
 #[repr(C)]
@@ -364,10 +370,11 @@ impl ComponentWindow {
     pub fn close_popup(&self) {
         self.0.platform_window.get().unwrap().clone().close_popup()
     }
+}
 
-    /// Return self as any so the backend can upcast
-    pub fn as_any(&self) -> &dyn core::any::Any {
-        self.0.as_any()
+impl WindowHandleAccess for ComponentWindow {
+    fn window_handle(&self) -> &std::rc::Rc<Window> {
+        &self.0
     }
 }
 

--- a/sixtyfps_runtime/corelib/window.rs
+++ b/sixtyfps_runtime/corelib/window.rs
@@ -355,15 +355,6 @@ impl ComponentWindow {
     pub fn set_component(&self, component: &ComponentRc) {
         self.0.set_component(component)
     }
-
-    /// Show a popup at the given position
-    pub fn show_popup(&self, popup: &ComponentRc, position: Point) {
-        self.0.platform_window.get().unwrap().clone().show_popup(popup, position)
-    }
-    /// Close the active popup if any
-    pub fn close_popup(&self) {
-        self.0.platform_window.get().unwrap().clone().close_popup()
-    }
 }
 
 impl WindowHandleAccess for ComponentWindow {
@@ -486,13 +477,13 @@ pub mod ffi {
         position: crate::graphics::Point,
     ) {
         let window = &*(handle as *const ComponentWindow);
-        window.show_popup(popup, position);
+        window.window_handle().show_popup(popup, position);
     }
     /// Close the current popup
     pub unsafe extern "C" fn sixtyfps_component_window_close_popup(
         handle: *const ComponentWindowOpaque,
     ) {
         let window = &*(handle as *const ComponentWindow);
-        window.close_popup();
+        window.window_handle().close_popup();
     }
 }

--- a/sixtyfps_runtime/corelib/window.rs
+++ b/sixtyfps_runtime/corelib/window.rs
@@ -345,12 +345,6 @@ impl ComponentWindow {
         self.0.set_scale_factor(factor)
     }
 
-    /// This function is called by the generated code when a component and therefore its tree of items are destroyed. The
-    /// implementation typically uses this to free the underlying graphics resources cached via [RenderingCache][`crate::graphics::RenderingCache`].
-    pub fn free_graphics_resources<'a>(&self, items: &Slice<'a, Pin<ItemRef<'a>>>) {
-        self.0.free_graphics_resources(items);
-    }
-
     /// Clears the focus on any previously focused item and makes the provided
     /// item the focus item, in order to receive future key events.
     pub fn set_focus_item(&self, focus_item: &ItemRc) {
@@ -461,7 +455,7 @@ pub mod ffi {
         items: &Slice<'a, Pin<ItemRef<'a>>>,
     ) {
         let window = &*(handle as *const ComponentWindow);
-        window.free_graphics_resources(items)
+        window.window_handle().free_graphics_resources(items)
     }
 
     /// Sets the focus item.

--- a/sixtyfps_runtime/corelib/window.rs
+++ b/sixtyfps_runtime/corelib/window.rs
@@ -344,17 +344,6 @@ impl ComponentWindow {
     pub fn set_scale_factor(&self, factor: f32) {
         self.0.set_scale_factor(factor)
     }
-
-    /// Clears the focus on any previously focused item and makes the provided
-    /// item the focus item, in order to receive future key events.
-    pub fn set_focus_item(&self, focus_item: &ItemRc) {
-        self.0.clone().set_focus_item(focus_item)
-    }
-
-    /// Associates this window with the specified component, for future event handling, etc.
-    pub fn set_component(&self, component: &ComponentRc) {
-        self.0.set_component(component)
-    }
 }
 
 impl WindowHandleAccess for ComponentWindow {
@@ -456,7 +445,7 @@ pub mod ffi {
         focus_item: &ItemRc,
     ) {
         let window = &*(handle as *const ComponentWindow);
-        window.set_focus_item(focus_item)
+        window.window_handle().clone().set_focus_item(focus_item)
     }
 
     /// Associates the window with the given component.
@@ -466,7 +455,7 @@ pub mod ffi {
         component: &ComponentRc,
     ) {
         let window = &*(handle as *const ComponentWindow);
-        window.set_component(component)
+        window.window_handle().set_component(component)
     }
 
     /// Show a popup.

--- a/sixtyfps_runtime/corelib/window.rs
+++ b/sixtyfps_runtime/corelib/window.rs
@@ -345,15 +345,6 @@ impl ComponentWindow {
         self.0.free_graphics_resources(items);
     }
 
-    /// Installs a binding on the specified property that's toggled whenever the text cursor is supposed to be visible or not.
-    pub(crate) fn set_cursor_blink_binding(&self, prop: &crate::properties::Property<bool>) {
-        self.0.clone().set_cursor_blink_binding(prop)
-    }
-
-    pub(crate) fn process_key_input(&self, event: &KeyEvent) {
-        self.0.clone().process_key_input(event)
-    }
-
     /// Clears the focus on any previously focused item and makes the provided
     /// item the focus item, in order to receive future key events.
     pub fn set_focus_item(&self, focus_item: &ItemRc) {

--- a/sixtyfps_runtime/interpreter/api.rs
+++ b/sixtyfps_runtime/interpreter/api.rs
@@ -11,7 +11,6 @@ LICENSE END */
 use core::convert::TryInto;
 use sixtyfps_compilerlib::langtype::Type as LangType;
 use sixtyfps_corelib::graphics::Image;
-use sixtyfps_corelib::window::WindowHandleAccess;
 use sixtyfps_corelib::{Brush, PathData, SharedString, SharedVector};
 use std::collections::HashMap;
 use std::iter::FromIterator;
@@ -580,7 +579,7 @@ impl ComponentDefinition {
     #[doc(hidden)]
     pub fn create_with_existing_window(
         &self,
-        window: sixtyfps_corelib::window::ComponentWindow,
+        window: Rc<sixtyfps_corelib::window::Window>,
     ) -> ComponentInstance {
         generativity::make_guard!(guard);
         ComponentInstance {
@@ -771,7 +770,7 @@ impl ComponentInstance {
     pub fn show(&self) {
         generativity::make_guard!(guard);
         let comp = self.inner.unerase(guard);
-        comp.window().window_handle().show();
+        comp.window().show();
     }
 
     /// Marks the window of this component to be hidden on the screen. This de-registers
@@ -779,7 +778,7 @@ impl ComponentInstance {
     pub fn hide(&self) {
         generativity::make_guard!(guard);
         let comp = self.inner.unerase(guard);
-        comp.window().window_handle().hide();
+        comp.window().hide();
     }
     /// This is a convenience function that first calls [`Self::show`], followed by [`crate::run_event_loop()`]
     /// and [`Self::hide`].
@@ -810,10 +809,10 @@ impl ComponentInstance {
     /// Return the window.
     /// This method is internal because the Window is not a public type
     #[doc(hidden)]
-    pub fn window(&self) -> sixtyfps_corelib::window::ComponentWindow {
+    pub fn window(&self) -> Rc<sixtyfps_corelib::window::Window> {
         generativity::make_guard!(guard);
         let comp = self.inner.unerase(guard);
-        comp.window()
+        comp.window().clone()
     }
 }
 
@@ -892,7 +891,7 @@ pub mod testing {
             &vtable::VRc::into_dyn(comp.inner.clone()),
             x,
             y,
-            &comp.inner.window(),
+            &comp.inner.window().into(),
         );
     }
     /// Wrapper around [`sixtyfps_corelib::tests::send_keyboard_string_sequence`]
@@ -903,7 +902,7 @@ pub mod testing {
         sixtyfps_corelib::tests::send_keyboard_string_sequence(
             &string,
             Default::default(),
-            &comp.inner.window(),
+            &comp.inner.window().into(),
         );
     }
 }

--- a/sixtyfps_runtime/interpreter/api.rs
+++ b/sixtyfps_runtime/interpreter/api.rs
@@ -11,6 +11,7 @@ LICENSE END */
 use core::convert::TryInto;
 use sixtyfps_compilerlib::langtype::Type as LangType;
 use sixtyfps_corelib::graphics::Image;
+use sixtyfps_corelib::window::WindowHandleAccess;
 use sixtyfps_corelib::{Brush, PathData, SharedString, SharedVector};
 use std::collections::HashMap;
 use std::iter::FromIterator;
@@ -770,7 +771,7 @@ impl ComponentInstance {
     pub fn show(&self) {
         generativity::make_guard!(guard);
         let comp = self.inner.unerase(guard);
-        comp.window().show();
+        comp.window().window_handle().show();
     }
 
     /// Marks the window of this component to be hidden on the screen. This de-registers
@@ -778,7 +779,7 @@ impl ComponentInstance {
     pub fn hide(&self) {
         generativity::make_guard!(guard);
         let comp = self.inner.unerase(guard);
-        comp.window().hide();
+        comp.window().window_handle().hide();
     }
     /// This is a convenience function that first calls [`Self::show`], followed by [`crate::run_event_loop()`]
     /// and [`Self::hide`].

--- a/sixtyfps_runtime/interpreter/dynamic_component.rs
+++ b/sixtyfps_runtime/interpreter/dynamic_component.rs
@@ -69,6 +69,7 @@ impl<'id> ComponentBox<'id> {
 
 impl<'id> Drop for ComponentBox<'id> {
     fn drop(&mut self) {
+        use sixtyfps_corelib::window::WindowHandleAccess;
         let instance_ref = self.borrow_instance();
         match eval::window_ref(instance_ref) {
             Some(window) => {
@@ -81,7 +82,9 @@ impl<'id> Drop for ComponentBox<'id> {
                     })
                     .collect::<Vec<_>>();
 
-                window.free_graphics_resources(&Slice::from_slice(items.as_slice()));
+                window
+                    .window_handle()
+                    .free_graphics_resources(&Slice::from_slice(items.as_slice()));
             }
             None => {}
         }

--- a/sixtyfps_runtime/interpreter/dynamic_component.rs
+++ b/sixtyfps_runtime/interpreter/dynamic_component.rs
@@ -30,7 +30,7 @@ use sixtyfps_corelib::model::Repeater;
 use sixtyfps_corelib::properties::InterpolatedPropertyValue;
 use sixtyfps_corelib::rtti::{self, AnimatedBindingKind, FieldOffset, PropertyInfo};
 use sixtyfps_corelib::slice::Slice;
-use sixtyfps_corelib::window::ComponentWindow;
+use sixtyfps_corelib::window::{ComponentWindow, WindowHandleAccess};
 use sixtyfps_corelib::{Brush, Color, Property, SharedString, SharedVector};
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -69,7 +69,6 @@ impl<'id> ComponentBox<'id> {
 
 impl<'id> Drop for ComponentBox<'id> {
     fn drop(&mut self) {
-        use sixtyfps_corelib::window::WindowHandleAccess;
         let instance_ref = self.borrow_instance();
         match eval::window_ref(instance_ref) {
             Some(window) => {
@@ -1473,5 +1472,6 @@ pub fn show_popup(
     let inst = instantiate(compiled, Some(parent_comp), Some(parent_window.clone()));
     inst.run_setup_code();
     parent_window
+        .window_handle()
         .show_popup(&vtable::VRc::into_dyn(inst), sixtyfps_corelib::graphics::Point::new(x, y));
 }

--- a/sixtyfps_runtime/interpreter/dynamic_component.rs
+++ b/sixtyfps_runtime/interpreter/dynamic_component.rs
@@ -350,6 +350,7 @@ impl<'id> ComponentDescription<'id> {
         component_ref
             .as_pin_ref()
             .window()
+            .window_handle()
             .set_component(&vtable::VRc::into_dyn(component_ref.clone()));
         component_ref.run_setup_code();
         component_ref

--- a/sixtyfps_runtime/interpreter/eval.rs
+++ b/sixtyfps_runtime/interpreter/eval.rs
@@ -198,7 +198,7 @@ pub fn eval_expression(e: &Expression, local_context: &mut EvalLocalContext) -> 
             }
             Expression::BuiltinFunctionReference(BuiltinFunction::GetWindowScaleFactor, _) => {
                 match local_context.component_instance {
-                    ComponentInstance::InstanceRef(component) => Value::Number(window_ref(component).unwrap().scale_factor() as _),
+                    ComponentInstance::InstanceRef(component) => Value::Number(window_ref(component).unwrap().window_handle().scale_factor() as _),
                     ComponentInstance::GlobalComponent(_) => panic!("Cannot get the window from a global component"),
                 }
             }

--- a/sixtyfps_runtime/interpreter/eval.rs
+++ b/sixtyfps_runtime/interpreter/eval.rs
@@ -15,7 +15,7 @@ use core::pin::Pin;
 use corelib::graphics::{GradientStop, LinearGradientBrush, PathElement};
 use corelib::items::{ItemRef, PropertyAnimation};
 use corelib::rtti::AnimatedBindingKind;
-use corelib::window::ComponentWindow;
+use corelib::window::{ComponentWindow, WindowHandleAccess};
 use corelib::{Brush, Color, PathData, SharedString, SharedVector};
 use sixtyfps_compilerlib::expression_tree::{
     BindingExpression, BuiltinFunction, EasingCurve, Expression, Path as ExprPath,
@@ -275,7 +275,7 @@ pub fn eval_expression(e: &Expression, local_context: &mut EvalLocalContext) -> 
 
                     let focus_item_comp = enclosing_component.self_weak().get().unwrap().upgrade().unwrap();
 
-                    window_ref(component).unwrap().set_focus_item(&corelib::items::ItemRc::new(vtable::VRc::into_dyn(focus_item_comp), item_info.item_index()));
+                    window_ref(component).unwrap().window_handle().clone().set_focus_item(&corelib::items::ItemRc::new(vtable::VRc::into_dyn(focus_item_comp), item_info.item_index()));
                     Value::Void
                 } else {
                     panic!("internal error: argument to SetFocusItem must be an element")

--- a/sixtyfps_runtime/interpreter/eval_layout.rs
+++ b/sixtyfps_runtime/interpreter/eval_layout.rs
@@ -181,7 +181,7 @@ fn grid_layout_data(
             let mut layout_info = get_layout_info(
                 &cell.item.element,
                 component,
-                &eval::window_ref(component).unwrap(),
+                &eval::window_ref(component).unwrap().into(),
                 orientation,
             );
             fill_layout_info_constraints(
@@ -234,7 +234,8 @@ fn box_layout_data(
                     .map(|x| x.as_pin_ref().box_layout_data(to_runtime(orientation))),
             );
         } else {
-            let mut layout_info = get_layout_info(&cell.element, component, &window, orientation);
+            let mut layout_info =
+                get_layout_info(&cell.element, component, &window.clone().into(), orientation);
             fill_layout_info_constraints(
                 &mut layout_info,
                 &cell.constraints,

--- a/sixtyfps_runtime/interpreter/ffi.rs
+++ b/sixtyfps_runtime/interpreter/ffi.rs
@@ -400,9 +400,9 @@ pub extern "C" fn sixtyfps_interpreter_component_instance_show(
     generativity::make_guard!(guard);
     let comp = inst.unerase(guard);
     if is_visible {
-        comp.window().show();
+        comp.window().window_handle().show();
     } else {
-        comp.window().hide();
+        comp.window().window_handle().hide();
     }
 }
 

--- a/sixtyfps_runtime/interpreter/ffi.rs
+++ b/sixtyfps_runtime/interpreter/ffi.rs
@@ -400,9 +400,9 @@ pub extern "C" fn sixtyfps_interpreter_component_instance_show(
     generativity::make_guard!(guard);
     let comp = inst.unerase(guard);
     if is_visible {
-        comp.window().window_handle().show();
+        comp.window().show();
     } else {
-        comp.window().window_handle().hide();
+        comp.window().hide();
     }
 }
 
@@ -420,7 +420,7 @@ pub unsafe extern "C" fn sixtyfps_interpreter_component_instance_window(
         core::mem::size_of::<ComponentWindow>(),
         core::mem::size_of::<sixtyfps_corelib::window::ffi::ComponentWindowOpaque>()
     );
-    core::ptr::write(out as *mut ComponentWindow, inst.window())
+    core::ptr::write(out as *mut ComponentWindow, inst.window().into())
 }
 
 /// Instantiate an instance from a definition.

--- a/sixtyfps_runtime/rendering_backends/gl/graphics_window.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/graphics_window.rs
@@ -20,7 +20,7 @@ use corelib::input::{KeyboardModifiers, MouseEvent};
 use corelib::items::ItemRef;
 use corelib::layout::Orientation;
 use corelib::slice::Slice;
-use corelib::window::{ComponentWindow, PlatformWindow};
+use corelib::window::PlatformWindow;
 use corelib::Property;
 use corelib::SharedString;
 use sixtyfps_corelib as corelib;
@@ -346,7 +346,7 @@ impl GraphicsWindow {
         self.mouse_input_state.set(corelib::input::process_mouse_input(
             component,
             event,
-            &ComponentWindow::new(self.self_weak.upgrade().unwrap()),
+            &self.self_weak.upgrade().unwrap().into(),
             self.mouse_input_state.take(),
         ));
 

--- a/sixtyfps_runtime/rendering_backends/gl/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/lib.rs
@@ -1547,12 +1547,12 @@ fn to_femtovg_color(col: &Color) -> femtovg::Color {
 
 #[cfg(target_arch = "wasm32")]
 pub fn create_gl_window_with_canvas_id(canvas_id: String) -> ComponentWindow {
-    let window = sixtyfps_corelib::window::Window::new(|window| {
+    sixtyfps_corelib::window::Window::new(|window| {
         GraphicsWindow::new(window, move |window_builder| {
             GLRenderer::new(window_builder, &canvas_id)
         })
-    });
-    ComponentWindow(window)
+    })
+    .into()
 }
 
 #[doc(hidden)]
@@ -1573,7 +1573,7 @@ thread_local!(pub(crate) static IMAGE_CACHE: RefCell<images::ImageCache> = Defau
 pub struct Backend;
 impl sixtyfps_corelib::backend::Backend for Backend {
     fn create_window(&'static self) -> ComponentWindow {
-        let window = sixtyfps_corelib::window::Window::new(|window| {
+        sixtyfps_corelib::window::Window::new(|window| {
             GraphicsWindow::new(window, |window_builder| {
                 GLRenderer::new(
                     window_builder,
@@ -1581,8 +1581,8 @@ impl sixtyfps_corelib::backend::Backend for Backend {
                     "canvas",
                 )
             })
-        });
-        ComponentWindow(window)
+        })
+        .into()
     }
 
     fn run_event_loop(&'static self, behavior: sixtyfps_corelib::backend::EventLoopQuitBehavior) {

--- a/sixtyfps_runtime/rendering_backends/gl/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/lib.rs
@@ -28,7 +28,7 @@ use sixtyfps_corelib::items::{
     FillRule, ImageFit, TextHorizontalAlignment, TextOverflow, TextVerticalAlignment, TextWrap,
 };
 use sixtyfps_corelib::properties::Property;
-use sixtyfps_corelib::window::ComponentWindow;
+use sixtyfps_corelib::window::Window;
 
 use sixtyfps_corelib::SharedString;
 
@@ -1546,13 +1546,12 @@ fn to_femtovg_color(col: &Color) -> femtovg::Color {
 }
 
 #[cfg(target_arch = "wasm32")]
-pub fn create_gl_window_with_canvas_id(canvas_id: String) -> ComponentWindow {
+pub fn create_gl_window_with_canvas_id(canvas_id: String) -> Rc<Window> {
     sixtyfps_corelib::window::Window::new(|window| {
         GraphicsWindow::new(window, move |window_builder| {
             GLRenderer::new(window_builder, &canvas_id)
         })
     })
-    .into()
 }
 
 #[doc(hidden)]
@@ -1572,7 +1571,7 @@ thread_local!(pub(crate) static IMAGE_CACHE: RefCell<images::ImageCache> = Defau
 
 pub struct Backend;
 impl sixtyfps_corelib::backend::Backend for Backend {
-    fn create_window(&'static self) -> ComponentWindow {
+    fn create_window(&'static self) -> Rc<Window> {
         sixtyfps_corelib::window::Window::new(|window| {
             GraphicsWindow::new(window, |window_builder| {
                 GLRenderer::new(
@@ -1582,7 +1581,6 @@ impl sixtyfps_corelib::backend::Backend for Backend {
                 )
             })
         })
-        .into()
     }
 
     fn run_event_loop(&'static self, behavior: sixtyfps_corelib::backend::EventLoopQuitBehavior) {

--- a/sixtyfps_runtime/rendering_backends/qt/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/qt/lib.rs
@@ -21,7 +21,7 @@ You should use the `sixtyfps` crate instead.
 use sixtyfps_corelib::graphics::{Image, Size};
 #[cfg(not(no_qt))]
 use sixtyfps_corelib::items::ImageFit;
-use sixtyfps_corelib::window::ComponentWindow;
+use sixtyfps_corelib::window::Window;
 
 #[cfg(not(no_qt))]
 mod qt_window;
@@ -111,12 +111,12 @@ pub const IS_AVAILABLE: bool = cfg!(not(no_qt));
 
 pub struct Backend;
 impl sixtyfps_corelib::backend::Backend for Backend {
-    fn create_window(&'static self) -> ComponentWindow {
+    fn create_window(&'static self) -> std::rc::Rc<Window> {
         #[cfg(no_qt)]
         panic!("The Qt backend needs Qt");
         #[cfg(not(no_qt))]
         {
-            sixtyfps_corelib::window::Window::new(|window| qt_window::QtWindow::new(window)).into()
+            sixtyfps_corelib::window::Window::new(|window| qt_window::QtWindow::new(window))
         }
     }
 

--- a/sixtyfps_runtime/rendering_backends/qt/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/qt/lib.rs
@@ -116,9 +116,7 @@ impl sixtyfps_corelib::backend::Backend for Backend {
         panic!("The Qt backend needs Qt");
         #[cfg(not(no_qt))]
         {
-            let window =
-                sixtyfps_corelib::window::Window::new(|window| qt_window::QtWindow::new(window));
-            ComponentWindow::new(window)
+            sixtyfps_corelib::window::Window::new(|window| qt_window::QtWindow::new(window)).into()
         }
     }
 

--- a/sixtyfps_runtime/rendering_backends/qt/qt_window.rs
+++ b/sixtyfps_runtime/rendering_backends/qt/qt_window.rs
@@ -1496,7 +1496,8 @@ pub(crate) mod ffi {
     pub extern "C" fn sixtyfps_qt_get_widget(
         window: &sixtyfps_corelib::window::ComponentWindow,
     ) -> *mut c_void {
-        <dyn std::any::Any>::downcast_ref(window.as_any())
+        use sixtyfps_corelib::window::WindowHandleAccess;
+        <dyn std::any::Any>::downcast_ref(window.window_handle().as_any())
             .map_or(std::ptr::null_mut(), |win: &QtWindow| {
                 win.widget_ptr().cast::<c_void>().as_ptr()
             })

--- a/sixtyfps_runtime/rendering_backends/qt/qt_window.rs
+++ b/sixtyfps_runtime/rendering_backends/qt/qt_window.rs
@@ -1496,7 +1496,7 @@ pub(crate) mod ffi {
     pub extern "C" fn sixtyfps_qt_get_widget(
         window: &sixtyfps_corelib::window::ComponentWindow,
     ) -> *mut c_void {
-        <dyn std::any::Any>::downcast_ref(window.0.as_any())
+        <dyn std::any::Any>::downcast_ref(window.as_any())
             .map_or(std::ptr::null_mut(), |win: &QtWindow| {
                 win.widget_ptr().cast::<c_void>().as_ptr()
             })

--- a/sixtyfps_runtime/rendering_backends/testing/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/testing/lib.rs
@@ -20,7 +20,7 @@ use image::GenericImageView;
 use sixtyfps_corelib::component::ComponentRc;
 use sixtyfps_corelib::graphics::{FontMetrics, Image, Size};
 use sixtyfps_corelib::slice::Slice;
-use sixtyfps_corelib::window::{ComponentWindow, PlatformWindow, Window};
+use sixtyfps_corelib::window::{PlatformWindow, Window};
 use sixtyfps_corelib::{ImageInner, Property};
 use std::path::Path;
 use std::pin::Pin;
@@ -33,8 +33,8 @@ pub struct TestingBackend {
 }
 
 impl sixtyfps_corelib::backend::Backend for TestingBackend {
-    fn create_window(&'static self) -> ComponentWindow {
-        Window::new(|_| Rc::new(TestingWindow::default())).into()
+    fn create_window(&'static self) -> Rc<Window> {
+        Window::new(|_| Rc::new(TestingWindow::default()))
     }
 
     fn run_event_loop(&'static self, _behavior: sixtyfps_corelib::backend::EventLoopQuitBehavior) {

--- a/sixtyfps_runtime/rendering_backends/testing/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/testing/lib.rs
@@ -34,7 +34,7 @@ pub struct TestingBackend {
 
 impl sixtyfps_corelib::backend::Backend for TestingBackend {
     fn create_window(&'static self) -> ComponentWindow {
-        ComponentWindow::new(Window::new(|_| Rc::new(TestingWindow::default())))
+        Window::new(|_| Rc::new(TestingWindow::default())).into()
     }
 
     fn run_event_loop(&'static self, _behavior: sixtyfps_corelib::backend::EventLoopQuitBehavior) {


### PR DESCRIPTION
This reduces the API surface of ComponentWindow, so that we can rename it to `sixtyfps::Window` for example.