### PR TITLE
Start a new sixtyfps::Window API for Rust, C++, the interpreters and JS

### DIFF
--- a/api/sixtyfps-cpp/docs/generated_code.md
+++ b/api/sixtyfps-cpp/docs/generated_code.md
@@ -13,6 +13,8 @@ This class will have the following public member functions:
   and react to user input, it's still necessary to spin the event loop, by calling {cpp:func}`sixtyfps::run_event_loop()`
   or using the convenience `fun` function in this class.
 * A `hide` function, which de-registers the component from the windowing system.
+* A `window` function that provides access to the {cpp:class}`sixtyfps::Window`, allow for further customization
+  towards the windowing system.
 * A `run` convenience function, which will show the component and starts the event loop.
 * for each properties:
   * A getter `get_<property_name>` returning the property type.

--- a/api/sixtyfps-cpp/include/sixtyfps.h
+++ b/api/sixtyfps-cpp/include/sixtyfps.h
@@ -286,9 +286,9 @@ public:
     ~Window() = default;
 
     /// Registers the window with the windowing system in order to make it visible on the screen.
-    void show() const { inner.show(); }
+    void show() { inner.show(); }
     /// De-registers the window from the windowing system, therefore hiding it.
-    void hide() const { inner.hide(); }
+    void hide() { inner.hide(); }
 
     /// \private
     private_api::WindowRc &window_handle() { return inner; }

--- a/api/sixtyfps-cpp/include/sixtyfps.h
+++ b/api/sixtyfps-cpp/include/sixtyfps.h
@@ -276,14 +276,8 @@ public:
     /// Internal function used by the generated code to construct a new instance of this
     /// public API wrapper.
     explicit Window(const private_api::WindowRc &windowrc) : inner(windowrc) { }
-    /// Copy-constructs a new window from \a other. Window instances are explicitly
-    /// shared and reference counted. Creating a copy will not create a second window
-    /// on the screen.
-    Window(const Window &other) = default;
-    /// Copy-constructs the window \a other to this and returns a reference to this.
-    /// Window instances are explicitly shared and reference counted. Creating a copy
-    /// will not create a second window on the screen.
-    Window &operator=(const Window &other) = default;
+    Window(const Window &other) = delete;
+    Window &operator=(const Window &other) = delete;
     Window(Window &&other) = delete;
     Window &operator=(Window &&other) = delete;
     /// Destroys this window. Window instances are explicitly shared and reference counted.
@@ -295,6 +289,11 @@ public:
     void show() const { inner.show(); }
     /// De-registers the window from the windowing system, therefore hiding it.
     void hide() const { inner.hide(); }
+
+    /// \private
+    private_api::WindowRc &window_handle() { return inner; }
+    /// \private
+    const private_api::WindowRc &window_handle() const { return inner; }
 
 private:
     private_api::WindowRc inner;

--- a/api/sixtyfps-cpp/include/sixtyfps.h
+++ b/api/sixtyfps-cpp/include/sixtyfps.h
@@ -237,6 +237,10 @@ public:
     const T *operator->() const { return inner.operator->(); }
     /// Dereference operator that implements pointer semantics.
     const T &operator*() const { return inner.operator*(); }
+    /// Arrow operator that implements pointer semantics.
+    T *operator->() { return inner.operator->(); }
+    /// Dereference operator that implements pointer semantics.
+    T &operator*() { return inner.operator*(); }
 
     /// internal function that returns the internal handle
     vtable::VRc<private_api::ComponentVTable> into_dyn() const { return inner.into_dyn(); }

--- a/api/sixtyfps-cpp/include/sixtyfps_interpreter.h
+++ b/api/sixtyfps-cpp/include/sixtyfps_interpreter.h
@@ -585,6 +585,15 @@ public:
     {
         cbindgen_private::sixtyfps_interpreter_component_instance_show(inner(), false);
     }
+    /// Returns the Window associated with this component. The window API can be used
+    /// to control different aspects of the integration into the windowing system,
+    /// such as the position on the screen.
+    sixtyfps::Window window() const
+    {
+        cbindgen_private::WindowRcOpaque win;
+        cbindgen_private::sixtyfps_interpreter_component_instance_window(inner(), &win);
+        return sixtyfps::Window(sixtyfps::private_api::WindowRc(win));
+    }
     /// This is a convenience function that first calls show(), followed by
     /// sixtyfps::run_event_loop() and hide().
     void run() const

--- a/api/sixtyfps-cpp/include/sixtyfps_interpreter.h
+++ b/api/sixtyfps-cpp/include/sixtyfps_interpreter.h
@@ -588,11 +588,11 @@ public:
     /// Returns the Window associated with this component. The window API can be used
     /// to control different aspects of the integration into the windowing system,
     /// such as the position on the screen.
-    sixtyfps::Window window() const
+    const sixtyfps::Window &window()
     {
-        cbindgen_private::WindowRcOpaque win;
-        cbindgen_private::sixtyfps_interpreter_component_instance_window(inner(), &win);
-        return sixtyfps::Window(sixtyfps::private_api::WindowRc(win));
+        const cbindgen_private::WindowRcOpaque *win_ptr = nullptr;
+        cbindgen_private::sixtyfps_interpreter_component_instance_window(inner(), &win_ptr);
+        return *reinterpret_cast<const sixtyfps::Window *>(win_ptr);
     }
     /// This is a convenience function that first calls show(), followed by
     /// sixtyfps::run_event_loop() and hide().
@@ -608,11 +608,10 @@ public:
     /// it may return nullptr if the Qt backend is not used at runtime.
     QWidget *qwidget() const
     {
-        cbindgen_private::WindowRcOpaque win;
-        cbindgen_private::sixtyfps_interpreter_component_instance_window(inner(), &win);
+        const cbindgen_private::WindowRcOpaque *win_ptr = nullptr;
+        cbindgen_private::sixtyfps_interpreter_component_instance_window(inner(), &win_ptr);
         auto wid = reinterpret_cast<QWidget *>(cbindgen_private::sixtyfps_qt_get_widget(
-                reinterpret_cast<cbindgen_private::WindowRc *>(&win)));
-        cbindgen_private::sixtyfps_windowrc_drop(&win);
+                reinterpret_cast<const cbindgen_private::WindowRc *>(win_ptr)));
         return wid;
     }
 #endif
@@ -951,11 +950,10 @@ inline void send_keyboard_string_sequence(const sixtyfps::interpreter::Component
                                           const sixtyfps::SharedString &str,
                                           KeyboardModifiers modifiers = {})
 {
-    cbindgen_private::WindowRcOpaque win;
+    const cbindgen_private::WindowRcOpaque *win_ptr = nullptr;
     cbindgen_private::sixtyfps_interpreter_component_instance_window(
-            reinterpret_cast<const cbindgen_private::ErasedComponentBox *>(component), &win);
+            reinterpret_cast<const cbindgen_private::ErasedComponentBox *>(component), &win_ptr);
     cbindgen_private::send_keyboard_string_sequence(
-            &str, modifiers, reinterpret_cast<cbindgen_private::WindowRc *>(&win));
-    cbindgen_private::sixtyfps_windowrc_drop(&win);
+            &str, modifiers, reinterpret_cast<const cbindgen_private::WindowRc *>(win_ptr));
 }
 }

--- a/api/sixtyfps-cpp/include/sixtyfps_testing.h
+++ b/api/sixtyfps-cpp/include/sixtyfps_testing.h
@@ -26,7 +26,7 @@ template<typename Component>
 inline void send_mouse_click(const Component *component, float x, float y)
 {
     auto crc = *component->self_weak.into_dyn().lock();
-    cbindgen_private::sixtyfps_send_mouse_click(&crc, x, y, &component->window_rc);
+    cbindgen_private::sixtyfps_send_mouse_click(&crc, x, y, &component->m_window.window_handle());
 }
 
 template<typename Component>
@@ -34,7 +34,8 @@ inline void send_keyboard_string_sequence(const Component *component,
                                           const sixtyfps::SharedString &str,
                                           cbindgen_private::KeyboardModifiers modifiers = {})
 {
-    cbindgen_private::send_keyboard_string_sequence(&str, modifiers, &component->window_rc);
+    cbindgen_private::send_keyboard_string_sequence(&str, modifiers,
+                                                    &component->m_window.window_handle());
 }
 
 #define assert_eq(A, B)                                                                            \

--- a/api/sixtyfps-cpp/include/sixtyfps_testing.h
+++ b/api/sixtyfps-cpp/include/sixtyfps_testing.h
@@ -26,7 +26,7 @@ template<typename Component>
 inline void send_mouse_click(const Component *component, float x, float y)
 {
     auto crc = *component->self_weak.into_dyn().lock();
-    cbindgen_private::sixtyfps_send_mouse_click(&crc, x, y, &component->window_);
+    cbindgen_private::sixtyfps_send_mouse_click(&crc, x, y, &component->window_rc);
 }
 
 template<typename Component>
@@ -34,7 +34,7 @@ inline void send_keyboard_string_sequence(const Component *component,
                                           const sixtyfps::SharedString &str,
                                           cbindgen_private::KeyboardModifiers modifiers = {})
 {
-    cbindgen_private::send_keyboard_string_sequence(&str, modifiers, &component->window_);
+    cbindgen_private::send_keyboard_string_sequence(&str, modifiers, &component->window_rc);
 }
 
 #define assert_eq(A, B)                                                                            \

--- a/api/sixtyfps-cpp/include/sixtyfps_testing.h
+++ b/api/sixtyfps-cpp/include/sixtyfps_testing.h
@@ -13,7 +13,8 @@ LICENSE END */
 
 namespace sixtyfps::testing {
 
-inline void init() {
+inline void init()
+{
     cbindgen_private::sixtyfps_testing_init_backend();
 }
 
@@ -25,7 +26,7 @@ template<typename Component>
 inline void send_mouse_click(const Component *component, float x, float y)
 {
     auto crc = *component->self_weak.into_dyn().lock();
-    cbindgen_private::sixtyfps_send_mouse_click(&crc, x, y, &component->window);
+    cbindgen_private::sixtyfps_send_mouse_click(&crc, x, y, &component->window_);
 }
 
 template<typename Component>
@@ -33,7 +34,7 @@ inline void send_keyboard_string_sequence(const Component *component,
                                           const sixtyfps::SharedString &str,
                                           cbindgen_private::KeyboardModifiers modifiers = {})
 {
-    cbindgen_private::send_keyboard_string_sequence(&str, modifiers, &component->window);
+    cbindgen_private::send_keyboard_string_sequence(&str, modifiers, &component->window_);
 }
 
 #define assert_eq(A, B)                                                                            \

--- a/api/sixtyfps-cpp/include/vtable.h
+++ b/api/sixtyfps-cpp/include/vtable.h
@@ -124,6 +124,12 @@ public:
     const X& operator*() const {
         return inner->data;
     }
+    X* operator->() {
+        return &inner->data;
+    }
+    X& operator*() {
+        return inner->data;
+    }
 
     VRc<VTable, Dyn> into_dyn() const { return *reinterpret_cast<const VRc<VTable, Dyn> *>(this); }
 

--- a/api/sixtyfps-node/lib/index.ts
+++ b/api/sixtyfps-node/lib/index.ts
@@ -41,11 +41,15 @@ class Component {
     }
 
     show() {
-        this.comp.show();
+        this.window.show();
     }
 
     hide() {
-        this.comp.hide();
+        this.window.hide()
+    }
+
+    get window(): Window {
+        return this.comp.window();
     }
 
     send_mouse_click(x: number, y: number) {
@@ -55,6 +59,11 @@ class Component {
     send_keyboard_string_sequence(s: String) {
         this.comp.send_keyboard_string_sequence(s)
     }
+}
+
+interface Window {
+    show(): void;
+    hide(): void;
 }
 
 /**

--- a/api/sixtyfps-node/native/lib.rs
+++ b/api/sixtyfps-node/native/lib.rs
@@ -11,6 +11,7 @@ use core::cell::RefCell;
 use neon::prelude::*;
 use rand::RngCore;
 use sixtyfps_compilerlib::langtype::Type;
+use sixtyfps_corelib::window::WindowHandleAccess;
 use sixtyfps_corelib::{ImageInner, SharedVector};
 
 mod js_model;
@@ -18,7 +19,7 @@ mod persistent_context;
 
 struct WrappedComponentType(Option<sixtyfps_interpreter::ComponentDefinition>);
 struct WrappedComponentRc(Option<sixtyfps_interpreter::ComponentInstance>);
-struct WrappedWindow(Option<sixtyfps_interpreter::Window>);
+struct WrappedWindow(Option<sixtyfps_corelib::window::WindowRc>);
 
 /// We need to do some gymnastic with closures to pass the ExecuteContext with the right lifetime
 type GlobalContextCallback<'c> =
@@ -349,7 +350,7 @@ declare_types! {
             let this = cx.this();
             let component = cx.borrow(&this, |x| x.0.as_ref().map(|c| c.clone_strong()));
             let component = component.ok_or(()).or_else(|()| cx.throw_error("Invalid type"))?;
-            let window = component.window();
+            let window = component.window().window_handle().clone();
             let mut obj = SixtyFpsWindow::new::<_, JsValue, _>(&mut cx, std::iter::empty())?;
             cx.borrow_mut(&mut obj, |mut obj| obj.0 = Some(window));
             Ok(obj.as_value(&mut cx))

--- a/api/sixtyfps-rs/docs.rs
+++ b/api/sixtyfps-rs/docs.rs
@@ -56,6 +56,7 @@ pub mod generated_code {
     use crate::re_exports;
     use crate::ComponentHandle;
     use crate::Weak;
+    use crate::Window;
 
     /// This an example of the API that is generated for a component in `.60` design markup. This may help you understand
     /// what functions you can call and how you can pass data in and out.
@@ -144,6 +145,13 @@ pub mod generated_code {
         /// the window from the windowing system and it will not receive any further events.
         fn hide(&self) {
             unimplemented!();
+        }
+
+        /// Returns the Window associated with this component. The window API can be used
+        /// to control different aspects of the integration into the windowing system,
+        /// such as the position on the screen.
+        fn window(&self) -> Window {
+            unimplemented!()
         }
 
         /// This is a convenience function that first calls [`Self::show`], followed by [`crate::run_event_loop()`]

--- a/api/sixtyfps-rs/docs.rs
+++ b/api/sixtyfps-rs/docs.rs
@@ -150,7 +150,7 @@ pub mod generated_code {
         /// Returns the Window associated with this component. The window API can be used
         /// to control different aspects of the integration into the windowing system,
         /// such as the position on the screen.
-        fn window(&self) -> Window {
+        fn window(&self) -> &Window {
             unimplemented!()
         }
 

--- a/api/sixtyfps-rs/lib.rs
+++ b/api/sixtyfps-rs/lib.rs
@@ -339,7 +339,7 @@ pub trait ComponentHandle {
     /// Returns the Window associated with this component. The window API can be used
     /// to control different aspects of the integration into the windowing system,
     /// such as the position on the screen.
-    fn window(&self) -> Window;
+    fn window(&self) -> &Window;
 
     /// This is a convenience function that first calls [`Self::show`], followed by [`crate::run_event_loop()`]
     /// and [`Self::hide`].

--- a/api/sixtyfps-rs/lib.rs
+++ b/api/sixtyfps-rs/lib.rs
@@ -336,6 +336,11 @@ pub trait ComponentHandle {
     /// the window from the windowing system and it will not receive any further events.
     fn hide(&self);
 
+    /// Returns the Window associated with this component. The window API can be used
+    /// to control different aspects of the integration into the windowing system,
+    /// such as the position on the screen.
+    fn window(&self) -> Window;
+
     /// This is a convenience function that first calls [`Self::show`], followed by [`crate::run_event_loop()`]
     /// and [`Self::hide`].
     fn run(&self);
@@ -439,6 +444,8 @@ mod weak_handle {
 }
 
 pub use weak_handle::*;
+
+pub use sixtyfps_corelib::window::api::Window;
 
 /// This module contains functions useful for unit tests
 pub mod testing {

--- a/cspell.json
+++ b/cspell.json
@@ -90,6 +90,7 @@
         "untracked",
         "vtable",
         "wasm",
+        "windowrc", // used in sixtyfps_windowrc_foo FFI functions
         "xtask"
     ],
     "ignorePaths": [

--- a/sixtyfps_compiler/generator/cpp.rs
+++ b/sixtyfps_compiler/generator/cpp.rs
@@ -953,8 +953,11 @@ fn generate_component(
             Access::Public,
             Declaration::Function(Function {
                 name: "window".into(),
-                signature: "() -> sixtyfps::Window&".into(),
-                statements: Some(vec!["return m_window;".into()]),
+                signature: "() const -> sixtyfps::Window&".into(),
+                statements: Some(vec![format!(
+                    "return const_cast<{} *>(this)->m_window;",
+                    component_struct.name
+                )]),
                 ..Default::default()
             }),
         ));

--- a/sixtyfps_compiler/generator/cpp.rs
+++ b/sixtyfps_compiler/generator/cpp.rs
@@ -933,7 +933,7 @@ fn generate_component(
             Access::Public,
             Declaration::Function(Function {
                 name: "show".into(),
-                signature: "() const".into(),
+                signature: "()".into(),
                 statements: Some(vec!["m_window.show();".into()]),
                 ..Default::default()
             }),
@@ -943,7 +943,7 @@ fn generate_component(
             Access::Public,
             Declaration::Function(Function {
                 name: "hide".into(),
-                signature: "() const".into(),
+                signature: "()".into(),
                 statements: Some(vec!["m_window.hide();".into()]),
                 ..Default::default()
             }),
@@ -953,7 +953,7 @@ fn generate_component(
             Access::Public,
             Declaration::Function(Function {
                 name: "window".into(),
-                signature: "() const -> const sixtyfps::Window&".into(),
+                signature: "() -> sixtyfps::Window&".into(),
                 statements: Some(vec!["return m_window;".into()]),
                 ..Default::default()
             }),
@@ -963,7 +963,7 @@ fn generate_component(
             Access::Public,
             Declaration::Function(Function {
                 name: "run".into(),
-                signature: "() const".into(),
+                signature: "()".into(),
                 statements: Some(vec![
                     "show();".into(),
                     "sixtyfps::run_event_loop();".into(),

--- a/sixtyfps_compiler/generator/cpp.rs
+++ b/sixtyfps_compiler/generator/cpp.rs
@@ -901,7 +901,7 @@ fn generate_component(
             Access::Private,
             Declaration::Var(Var {
                 ty: "sixtyfps::private_api::WindowRc".into(),
-                name: "window_".into(),
+                name: "window_rc".into(),
                 ..Var::default()
             }),
         ));
@@ -910,7 +910,7 @@ fn generate_component(
             Access::Public, // FIXME: many of the different component bindings need to access this
             Declaration::Var(Var {
                 ty: "sixtyfps::private_api::WindowRc".into(),
-                name: "window_".into(),
+                name: "window_rc".into(),
                 ..Var::default()
             }),
         ));
@@ -932,7 +932,7 @@ fn generate_component(
             Declaration::Function(Function {
                 name: "show".into(),
                 signature: "() const".into(),
-                statements: Some(vec!["window_.show();".into()]),
+                statements: Some(vec!["window_rc.show();".into()]),
                 ..Default::default()
             }),
         ));
@@ -942,7 +942,7 @@ fn generate_component(
             Declaration::Function(Function {
                 name: "hide".into(),
                 signature: "() const".into(),
-                statements: Some(vec!["window_.hide();".into()]),
+                statements: Some(vec!["window_rc.hide();".into()]),
                 ..Default::default()
             }),
         ));
@@ -952,7 +952,7 @@ fn generate_component(
             Declaration::Function(Function {
                 name: "window".into(),
                 signature: "() const -> sixtyfps::Window".into(),
-                statements: Some(vec!["return sixtyfps::Window(window_);".into()]),
+                statements: Some(vec!["return sixtyfps::Window(window_rc);".into()]),
                 ..Default::default()
             }),
         ));
@@ -971,7 +971,7 @@ fn generate_component(
             }),
         ));
 
-        init.push("self->window_.init_items(this, item_tree());".into());
+        init.push("self->window_rc.init_items(this, item_tree());".into());
 
         component_struct.friends.push("sixtyfps::private_api::WindowRc".into());
     }
@@ -986,7 +986,7 @@ fn generate_component(
         ];
 
         if component.parent_element.upgrade().is_none() {
-            create_code.push("self->window_.set_component(**self->self_weak.lock());".into());
+            create_code.push("self->window_rc.set_component(**self->self_weak.lock());".into());
         }
 
         create_code.extend(
@@ -1098,7 +1098,7 @@ fn generate_component(
             is_constructor_or_destructor: true,
             statements: Some(init),
             constructor_member_initializers: if !component.is_global() && !is_root {
-                vec!["window_(parent->window_)".into()]
+                vec!["window_rc(parent->window_rc)".into()]
             } else {
                 vec![]
             },
@@ -1127,7 +1127,7 @@ fn generate_component(
                     .join(","),
             );
             destructor.push("};".into());
-            destructor.push("window_.free_graphics_resources(sixtyfps::Slice<sixtyfps::private_api::ItemRef>{items, std::size(items)});".into());
+            destructor.push("window_rc.free_graphics_resources(sixtyfps::Slice<sixtyfps::private_api::ItemRef>{items, std::size(items)});".into());
         }
 
         component_struct.members.push((
@@ -1414,7 +1414,7 @@ fn compile_expression(
         ),
         Expression::BuiltinFunctionReference(funcref, _) => match funcref {
             BuiltinFunction::GetWindowScaleFactor => {
-                "self->window_.scale_factor".into()
+                "self->window_rc.scale_factor".into()
             }
             BuiltinFunction::Debug => {
                 "[](auto... args){ (std::cout << ... << args) << std::endl; return nullptr; }"
@@ -1433,10 +1433,10 @@ fn compile_expression(
             BuiltinFunction::ACos => format!("[](float a){{ return std::acos(a) / {}; }}", std::f32::consts::PI / 180.),
             BuiltinFunction::ATan => format!("[](float a){{ return std::atan(a) / {}; }}", std::f32::consts::PI / 180.),
             BuiltinFunction::SetFocusItem => {
-                "self->window_.set_focus_item".into()
+                "self->window_rc.set_focus_item".into()
             }
             BuiltinFunction::ShowPopupWindow => {
-                "self->window_.show_popup".into()
+                "self->window_rc.show_popup".into()
             }
 
            /*  std::from_chars is unfortunately not yet implemented in gcc
@@ -1572,7 +1572,7 @@ fn compile_expression(
                 if let Expression::ElementReference(focus_item) = &arguments[0] {
                     let focus_item = focus_item.upgrade().unwrap();
                     let focus_item = focus_item.borrow();
-                    format!("self->window_.set_focus_item(self->self_weak.lock()->into_dyn(), {});", focus_item.item_index.get().unwrap())
+                    format!("self->window_rc.set_focus_item(self->self_weak.lock()->into_dyn(), {});", focus_item.item_index.get().unwrap())
                 } else {
                     panic!("internal error: argument to SetFocusItem must be an element")
                 }
@@ -1584,13 +1584,13 @@ fn compile_expression(
                 if let Expression::ElementReference(popup_window) = &arguments[0] {
                     let popup_window = popup_window.upgrade().unwrap();
                     let pop_comp = popup_window.borrow().enclosing_component.upgrade().unwrap();
-                    let popup_window_id = component_id(&pop_comp);
+                    let popup_window_rcid = component_id(&pop_comp);
                     let parent_component = pop_comp.parent_element.upgrade().unwrap().borrow().enclosing_component.upgrade().unwrap();
                     let popup_list = parent_component.popup_windows.borrow();
                     let popup = popup_list.iter().find(|p| Rc::ptr_eq(&p.component, &pop_comp)).unwrap();
                     let x = access_named_reference(&popup.x, component, "self");
                     let y = access_named_reference(&popup.y, component, "self");
-                    format!("self->window_.show_popup<{}>(self, {{ {}.get(), {}.get() }} );", popup_window_id, x, y)
+                    format!("self->window_rc.show_popup<{}>(self, {{ {}.get(), {}.get() }} );", popup_window_rcid, x, y)
                 } else {
                     panic!("internal error: argument to SetFocusItem must be an element")
                 }
@@ -1603,7 +1603,7 @@ fn compile_expression(
                     let item = item.upgrade().unwrap();
                     let item = item.borrow();
                     let native_item = item.base_type.as_native();
-                    format!("{vt}->layouting_info({{{vt}, const_cast<sixtyfps::cbindgen_private::{ty}*>(&self->{id})}}, {o}, &window_)",
+                    format!("{vt}->layouting_info({{{vt}, const_cast<sixtyfps::cbindgen_private::{ty}*>(&self->{id})}}, {o}, &window_rc)",
                         vt = native_item.cpp_vtable_getter,
                         ty = native_item.class_name,
                         id = item.id,
@@ -2048,7 +2048,7 @@ fn get_layout_info(
         format!("{}.get()", access_named_reference(layout_info_prop, component, "self"))
     } else {
         format!(
-            "{vt}->layouting_info({{{vt}, const_cast<sixtyfps::cbindgen_private::{ty}*>(&self->{id})}}, {o}, &self->window_)",
+            "{vt}->layouting_info({{{vt}, const_cast<sixtyfps::cbindgen_private::{ty}*>(&self->{id})}}, {o}, &self->window_rc)",
             vt = elem.borrow().base_type.as_native().cpp_vtable_getter,
             ty = elem.borrow().base_type.as_native().class_name,
             id = elem.borrow().id,

--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -833,11 +833,15 @@ fn generate_component(
                     }
 
                     fn show(&self) {
-                        vtable::VRc::as_pin_ref(&self.0).window.window_handle().show();
+                        self.window().show();
                     }
 
                     fn hide(&self) {
-                        vtable::VRc::as_pin_ref(&self.0).window.window_handle().hide();
+                        self.window().hide()
+                    }
+
+                    fn window(&self) -> sixtyfps::Window {
+                        vtable::VRc::as_pin_ref(&self.0).window.clone().into()
                     }
                 }
             ))

--- a/sixtyfps_runtime/corelib/items.rs
+++ b/sixtyfps_runtime/corelib/items.rs
@@ -507,7 +507,7 @@ impl Item for FocusScope {
             return InputEventResult::EventIgnored;
         }*/
         if matches!(event, MouseEvent::MousePressed { .. }) && !self.has_focus() {
-            window.0.clone().set_focus_item(self_rc);
+            window.clone().set_focus_item(self_rc);
         }
         InputEventResult::EventIgnored
     }

--- a/sixtyfps_runtime/corelib/items/text.rs
+++ b/sixtyfps_runtime/corelib/items/text.rs
@@ -119,7 +119,7 @@ impl Item for Text {
     }
 
     fn layouting_info(self: Pin<&Self>, orientation: Orientation, window: &WindowRc) -> LayoutInfo {
-        let font_metrics = window.0.font_metrics(
+        let font_metrics = window.font_metrics(
             &self.cached_rendering_data,
             &|| self.unresolved_font_request(),
             Self::FIELD_OFFSETS.text.apply_pin(self),
@@ -264,7 +264,7 @@ impl Item for TextInput {
     }
 
     fn layouting_info(self: Pin<&Self>, orientation: Orientation, window: &WindowRc) -> LayoutInfo {
-        let font_metrics = window.0.font_metrics(
+        let font_metrics = window.font_metrics(
             &self.cached_rendering_data,
             &|| self.unresolved_font_request(),
             Self::FIELD_OFFSETS.text.apply_pin(self),
@@ -304,7 +304,7 @@ impl Item for TextInput {
         }
 
         let text = self.text();
-        let font_metrics = window.0.font_metrics(
+        let font_metrics = window.font_metrics(
             &self.cached_rendering_data,
             &|| self.unresolved_font_request(),
             Self::FIELD_OFFSETS.text.apply_pin(self),
@@ -316,7 +316,7 @@ impl Item for TextInput {
                 self.as_ref().anchor_position.set(clicked_offset);
                 self.as_ref().cursor_position.set(clicked_offset);
                 if !self.has_focus() {
-                    window.0.clone().set_focus_item(self_rc);
+                    window.clone().set_focus_item(self_rc);
                 }
             }
             MouseEvent::MouseReleased { .. } | MouseEvent::MouseExit => {
@@ -467,7 +467,7 @@ impl From<KeyboardModifiers> for AnchorMode {
 
 impl TextInput {
     fn show_cursor(&self, window: &WindowRc) {
-        window.0.set_cursor_blink_binding(&self.cursor_visible);
+        window.set_cursor_blink_binding(&self.cursor_visible);
     }
 
     fn hide_cursor(&self) {

--- a/sixtyfps_runtime/corelib/tests.rs
+++ b/sixtyfps_runtime/corelib/tests.rs
@@ -74,12 +74,12 @@ pub extern "C" fn send_keyboard_string_sequence(
         }
         let text: SharedString = ch.to_string().into();
 
-        window.0.clone().process_key_input(&KeyEvent {
+        window.clone().process_key_input(&KeyEvent {
             event_type: KeyEventType::KeyPressed,
             text: text.clone(),
             modifiers,
         });
-        window.0.clone().process_key_input(&KeyEvent {
+        window.clone().process_key_input(&KeyEvent {
             event_type: KeyEventType::KeyReleased,
             text,
             modifiers,

--- a/sixtyfps_runtime/corelib/window.rs
+++ b/sixtyfps_runtime/corelib/window.rs
@@ -332,6 +332,7 @@ pub mod api {
     /// This type represents a window towards the windowing system, that's used to render the
     /// scene of a component. It provides API to control windowing system specific aspects such
     /// as the position on the screen.
+    #[repr(transparent)]
     pub struct Window(pub(super) std::rc::Rc<super::Window>);
 
     #[doc(hidden)]

--- a/sixtyfps_runtime/corelib/window.rs
+++ b/sixtyfps_runtime/corelib/window.rs
@@ -346,7 +346,7 @@ pub mod api {
     /// scene of a component. It provides API to control windowing system specific aspects such
     /// as the position on the screen.
     #[derive(Clone)]
-    pub struct Window(super::WindowRc);
+    pub struct Window(pub(super) super::WindowRc);
 
     #[doc(hidden)]
     impl From<super::WindowRc> for Window {
@@ -368,12 +368,11 @@ pub mod api {
             self.0.window_handle().hide();
         }
     }
+}
 
-    #[doc(hidden)]
-    impl super::WindowHandleAccess for Window {
-        fn window_handle(&self) -> &std::rc::Rc<super::Window> {
-            self.0.window_handle()
-        }
+impl WindowHandleAccess for api::Window {
+    fn window_handle(&self) -> &std::rc::Rc<Window> {
+        self.0.window_handle()
     }
 }
 

--- a/sixtyfps_runtime/corelib/window.rs
+++ b/sixtyfps_runtime/corelib/window.rs
@@ -339,6 +339,44 @@ impl WindowHandleAccess for WindowRc {
     }
 }
 
+/// Internal module to define the public Window API, for re-export in the regular Rust crate
+/// and the interpreter crate.
+pub mod api {
+    /// This type represents a window towards the windowing system, that's used to render the
+    /// scene of a component. It provides API to control windowing system specific aspects such
+    /// as the position on the screen.
+    #[derive(Clone)]
+    pub struct Window(super::WindowRc);
+
+    #[doc(hidden)]
+    impl From<super::WindowRc> for Window {
+        fn from(window: super::WindowRc) -> Self {
+            Self(window)
+        }
+    }
+
+    impl Window {
+        /// Registers the window with the windowing system in order to make it visible on the screen.
+        pub fn show(&self) {
+            use super::WindowHandleAccess;
+            self.0.window_handle().show();
+        }
+
+        /// De-registers the window from the windowing system, therefore hiding it.
+        pub fn hide(&self) {
+            use super::WindowHandleAccess;
+            self.0.window_handle().hide();
+        }
+    }
+
+    #[doc(hidden)]
+    impl super::WindowHandleAccess for Window {
+        fn window_handle(&self) -> &std::rc::Rc<super::Window> {
+            self.0.window_handle()
+        }
+    }
+}
+
 /// This module contains the functions needed to interface with the event loop and window traits
 /// from outside the Rust language.
 #[cfg(feature = "ffi")]

--- a/sixtyfps_runtime/interpreter/eval_layout.rs
+++ b/sixtyfps_runtime/interpreter/eval_layout.rs
@@ -181,7 +181,7 @@ fn grid_layout_data(
             let mut layout_info = get_layout_info(
                 &cell.item.element,
                 component,
-                &eval::window_ref(component).unwrap().into(),
+                eval::window_ref(component).unwrap(),
                 orientation,
             );
             fill_layout_info_constraints(
@@ -218,7 +218,7 @@ fn box_layout_data(
                 let instance = crate::dynamic_component::instantiate(
                     rep.1.clone(),
                     Some(component.borrow()),
-                    Some(window.clone()),
+                    Some(&window),
                 );
                 instance.run_setup_code();
                 instance
@@ -276,7 +276,7 @@ fn repeater_indices(children: &[ElementRc], component: InstanceRef) -> Vec<u32> 
                 let instance = crate::dynamic_component::instantiate(
                     rep.1.clone(),
                     Some(component.borrow()),
-                    Some(window.clone()),
+                    Some(&window),
                 );
                 instance.run_setup_code();
                 instance

--- a/sixtyfps_runtime/interpreter/ffi.rs
+++ b/sixtyfps_runtime/interpreter/ffi.rs
@@ -13,6 +13,7 @@ use crate::dynamic_component::ErasedComponentBox;
 use super::*;
 use sixtyfps_corelib::model::{Model, ModelNotify, ModelPeer};
 use sixtyfps_corelib::slice::Slice;
+use sixtyfps_corelib::window::{WindowHandleAccess, WindowRc};
 use std::ffi::c_void;
 use vtable::VRef;
 
@@ -414,9 +415,9 @@ pub extern "C" fn sixtyfps_interpreter_component_instance_show(
     generativity::make_guard!(guard);
     let comp = inst.unerase(guard);
     if is_visible {
-        comp.window().show();
+        comp.borrow_instance().window().show();
     } else {
-        comp.window().hide();
+        comp.borrow_instance().window().hide();
     }
 }
 
@@ -429,12 +430,11 @@ pub unsafe extern "C" fn sixtyfps_interpreter_component_instance_window(
     inst: &ErasedComponentBox,
     out: *mut sixtyfps_corelib::window::ffi::WindowRcOpaque,
 ) {
-    use sixtyfps_corelib::window::WindowRc;
     assert_eq!(
         core::mem::size_of::<WindowRc>(),
         core::mem::size_of::<sixtyfps_corelib::window::ffi::WindowRcOpaque>()
     );
-    core::ptr::write(out as *mut WindowRc, inst.window().into())
+    core::ptr::write(out as *mut WindowRc, inst.window().window_handle().clone())
 }
 
 /// Instantiate an instance from a definition.

--- a/sixtyfps_runtime/interpreter/ffi.rs
+++ b/sixtyfps_runtime/interpreter/ffi.rs
@@ -428,13 +428,13 @@ pub extern "C" fn sixtyfps_interpreter_component_instance_show(
 #[no_mangle]
 pub unsafe extern "C" fn sixtyfps_interpreter_component_instance_window(
     inst: &ErasedComponentBox,
-    out: *mut sixtyfps_corelib::window::ffi::WindowRcOpaque,
+    out: *mut *const sixtyfps_corelib::window::ffi::WindowRcOpaque,
 ) {
     assert_eq!(
         core::mem::size_of::<WindowRc>(),
         core::mem::size_of::<sixtyfps_corelib::window::ffi::WindowRcOpaque>()
     );
-    core::ptr::write(out as *mut WindowRc, inst.window().window_handle().clone())
+    core::ptr::write(out as *mut *const WindowRc, inst.window().window_handle() as *const _)
 }
 
 /// Instantiate an instance from a definition.

--- a/sixtyfps_runtime/rendering_backends/qt/qt_window.rs
+++ b/sixtyfps_runtime/rendering_backends/qt/qt_window.rs
@@ -1497,8 +1497,7 @@ pub(crate) mod ffi {
     pub extern "C" fn sixtyfps_qt_get_widget(
         window: &sixtyfps_corelib::window::WindowRc,
     ) -> *mut c_void {
-        use sixtyfps_corelib::window::WindowHandleAccess;
-        <dyn std::any::Any>::downcast_ref(window.window_handle().as_any())
+        <dyn std::any::Any>::downcast_ref(window.as_any())
             .map_or(std::ptr::null_mut(), |win: &QtWindow| {
                 win.widget_ptr().cast::<c_void>().as_ptr()
             })

--- a/tests/cases/types/length.60
+++ b/tests/cases/types/length.60
@@ -53,7 +53,7 @@ assert(instance.get_test_zero());
 assert(instance.get_test());
 
 ratio = 2.;
-instance.window_rc.set_scale_factor(ratio);
+instance.m_window.window_handle().set_scale_factor(ratio);
 assert_eq(instance.get_l1(), 12.);
 assert_eq(instance.get_l2(), 12. * ratio);
 assert_eq(instance.get_l3(), 100. + 12. * ratio);

--- a/tests/cases/types/length.60
+++ b/tests/cases/types/length.60
@@ -53,7 +53,7 @@ assert(instance.get_test_zero());
 assert(instance.get_test());
 
 ratio = 2.;
-instance.window.set_scale_factor(ratio);
+instance.window_.set_scale_factor(ratio);
 assert_eq(instance.get_l1(), 12.);
 assert_eq(instance.get_l2(), 12. * ratio);
 assert_eq(instance.get_l3(), 100. + 12. * ratio);

--- a/tests/cases/types/length.60
+++ b/tests/cases/types/length.60
@@ -53,7 +53,7 @@ assert(instance.get_test_zero());
 assert(instance.get_test());
 
 ratio = 2.;
-instance.window_.set_scale_factor(ratio);
+instance.window_rc.set_scale_factor(ratio);
 assert_eq(instance.get_l1(), 12.);
 assert_eq(instance.get_l2(), 12. * ratio);
 assert_eq(instance.get_l3(), 100. + 12. * ratio);

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -240,7 +240,7 @@ async fn reload_preview(
             let mut preview_state = preview_state.borrow_mut();
             if let Some(handle) = preview_state.handle.take() {
                 let window = handle.window();
-                let handle = compiled.create_with_existing_window(window);
+                let handle = compiled.create_with_existing_window(&window);
                 match post_load_behavior {
                     PostLoadBehavior::ShowAfterLoad => handle.show(),
                     PostLoadBehavior::DoNothing => {}

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -133,7 +133,7 @@ async fn reload(args: Cli, fswatcher: Arc<Mutex<notify::RecommendedWatcher>>) {
             let mut current = current.borrow_mut();
             if let Some(handle) = current.take() {
                 let window = handle.window();
-                current.replace(c.create_with_existing_window(window));
+                current.replace(c.create_with_existing_window(&window));
             } else {
                 let handle = c.create();
                 handle.show();


### PR DESCRIPTION
The generated component now provides access to a Window type
via the window() accessor function.

This is part of #333