### PR TITLE
Fix float comparison in qt_window.rs

### DIFF
--- a/sixtyfps_runtime/rendering_backends/qt/qt_window.rs
+++ b/sixtyfps_runtime/rendering_backends/qt/qt_window.rs
@@ -890,8 +890,8 @@ impl QtItemRenderer<'_> {
                 rect.is_valid()
                     && (rect.x != 0.
                         || rect.y != 0.
-                        || rect.width.approx_eq(&target_width)
-                        || rect.height.approx_eq(&target_height))
+                        || !rect.width.approx_eq(&target_width)
+                        || !rect.height.approx_eq(&target_height))
             });
             let source_size = if !has_source_clipping {
                 Some(qttypes::QSize { width: target_width as u32, height: target_height as u32 })


### PR DESCRIPTION
Sorry, I broke the float comparison fix earlier. I only noticed when going over the patch again once you had spotted the same issue in a different place already (and fixed it there before merging).

Amends 02bdcbf6fffa38a822ecebcc84e16ad1be92c46e