### PR TITLE
Fix angles conversion and allow angle and duration in the public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
  - Default height of element in a ListView no longer defaults to 100%
  - Support of `*=` and `/=` on types with unit such as length.
  - Proper compilation error when using a self assignment operator on an invalid type instead of a panic
+ - Angle conversion for value not in degree
 
 ## [0.1.0] - 2021-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
  - Added `sixtyfps::Weak::upgrade_in_event_loop` in the Rust API
  - Added `sixtyfps::Model::as_any()` in the Rust API
  - Added conversion between `sixtyfps::Image` and `sixtyfps::interpreter::Value` in the C++ API
+ - `angle` and `duration` are allowed in the public API
 
 ### Fixed
 
@@ -23,7 +24,7 @@ All notable changes to this project will be documented in this file.
  - Default height of element in a ListView no longer defaults to 100%
  - Support of `*=` and `/=` on types with unit such as length.
  - Proper compilation error when using a self assignment operator on an invalid type instead of a panic
- - Angle conversion for value not in degree
+ - Angle conversion for values specified in radians, gradians and turns
 
 ## [0.1.0] - 2021-06-30
 

--- a/api/sixtyfps-cpp/docs/types.md
+++ b/api/sixtyfps-cpp/docs/types.md
@@ -14,6 +14,7 @@ The follow table summarizes the entire mapping:
 | `physical_length` | `float` | The unit are physical pixels. |
 | `length` | `float` | At run-time, logical lengths are automatically translated to physical pixels using the device pixel ratio. |
 | `duration` | `std::int64_t` | At run-time, durations are always represented as signed 64-bit integers with millisecond precision. |
+| `angle` | `float` | The value in degrees. |
 | structure | A `class` of the same name | The order of the data member are in the lexicographic order of their name |
 
 ## Structures

--- a/api/sixtyfps-cpp/tests/interpreter.cpp
+++ b/api/sixtyfps-cpp/tests/interpreter.cpp
@@ -426,6 +426,37 @@ SCENARIO("Array between .60 and C++")
     }
 }
 
+SCENARIO("Angle between .60 and C++")
+{
+    using namespace sixtyfps::interpreter;
+    using namespace sixtyfps;
+
+    ComponentCompiler compiler;
+
+    auto result = compiler.build_from_source(
+            "export Dummy := Rectangle { property <angle> angle: 0.25turn;  property <bool> test: angle == 0.5turn; }", "");
+    REQUIRE(result.has_value());
+    auto instance = result->create();
+
+    SECTION("Read property")
+    {
+        auto angle_value = instance->get_property("angle");
+        REQUIRE(angle_value.has_value());
+        REQUIRE(angle_value->type() == Value::Type::Number);
+        auto angle = angle_value->to_number();
+        REQUIRE(angle.has_value());
+        REQUIRE(*angle == 90);
+    }
+    SECTION("Write property")
+    {
+        REQUIRE(!*instance->get_property("test")->to_bool());
+        bool ok = instance->set_property("angle", 180.);
+        REQUIRE(ok);
+        REQUIRE(*instance->get_property("angle")->to_number() == 180);
+        REQUIRE(*instance->get_property("test")->to_bool());
+    }
+}
+
 SCENARIO("Component Definition Name")
 {
     using namespace sixtyfps::interpreter;

--- a/api/sixtyfps-node/README.md
+++ b/api/sixtyfps-node/README.md
@@ -91,7 +91,8 @@ component.clicked();
 | `color` | `String` | Colors are represented as strings in the form `"#rrggbbaa"`. When setting a color property, any CSS compliant color is accepted as a string. |
 | `length` | `Number` | |
 | `physical_length` | `Number` | |
-| `duration` | `Number` | |
+| `duration` | `Number` | The number of milliseconds |
+| `angle` | `Number` | The value in degrees |
 | structure | `Object` | Structures are mapped to JavaScrip objects with structure fields mapped to properties. |
 | array | `Array` or Model Object | |
 

--- a/api/sixtyfps-rs/lib.rs
+++ b/api/sixtyfps-rs/lib.rs
@@ -154,6 +154,7 @@ The follow table summarizes the entire mapping:
 | `physical_length` | `f32` | The unit are physical pixels. |
 | `length` | `f32` | At run-time, logical lengths are automatically translated to physical pixels using the device pixel ratio. |
 | `duration` | `i64` | At run-time, durations are always represented as signed 64-bit integers with millisecond precision. |
+| `angle` | `f32` | The value in degrees |
 | structure | `struct` of the same name | |
 | array | [`ModelHandle`] |  |
 

--- a/sixtyfps_compiler/expression_tree.rs
+++ b/sixtyfps_compiler/expression_tree.rs
@@ -269,11 +269,11 @@ declare_units! {
     /// Degree
     Deg = "deg" -> Angle,
     /// Gradians
-    Grad = "grad" -> Angle * 400./360.,
+    Grad = "grad" -> Angle * 360./180.,
     /// Turns
-    Turn = "turn" -> Angle * 1./360.,
+    Turn = "turn" -> Angle * 360.,
     /// Radians
-    Rad = "rad" -> Angle * std::f32::consts::TAU/360.,
+    Rad = "rad" -> Angle * 360./std::f32::consts::TAU,
 }
 
 impl Default for Unit {

--- a/sixtyfps_compiler/langtype.rs
+++ b/sixtyfps_compiler/langtype.rs
@@ -234,8 +234,7 @@ impl Type {
     }
 
     pub fn ok_for_public_api(&self) -> bool {
-        // Duration and Easing don't have good types for public API exposure yet.
-        !matches!(self, Self::Duration | Self::Easing | Self::Angle)
+        !matches!(self, Self::Easing)
     }
 
     pub fn lookup_property<'a>(&self, name: &'a str) -> PropertyLookupResult<'a> {

--- a/sixtyfps_compiler/object_tree.rs
+++ b/sixtyfps_compiler/object_tree.rs
@@ -447,6 +447,9 @@ pub fn pretty_print(
         indent!();
         write!(f, "{}: ", name)?;
         expression_tree::pretty_print(f, &expr.expression)?;
+        if expr.analysis.borrow().as_ref().map_or(false, |a| a.is_const) {
+            writeln!(f, "/*const*/")?;
+        }
         writeln!(f, ";")?;
         //writeln!(f, "; /*{}*/", expr.priority)?;
         if let Some(anim) = &expr.animation {

--- a/sixtyfps_compiler/tests/syntax/basic/arithmetic_op.60
+++ b/sixtyfps_compiler/tests/syntax/basic/arithmetic_op.60
@@ -9,7 +9,6 @@
 LICENSE END */
 SuperSimple := Rectangle {
     property<duration> p1: 3s + 1ms;
-//           ^warning{Properties of type duration are not supported yet for public API. The property will not be exposed}
     property<int> p2: 3s + 1;
 //                        ^error{Cannot convert float to duration}
     property<int> p3: 3s - 1;
@@ -18,10 +17,8 @@ SuperSimple := Rectangle {
 //                   ^error{Cannot convert \(ms⁻¹\) to int}
 
     property<duration> p5: 3ms * 1;
-//           ^warning{Properties of type duration are not supported yet for public API. The property will not be exposed}
     property<duration> p6: 3ms * 1s;
 //                        ^error{Cannot convert \(ms²\) to duration}
-//           ^^warning{Properties of type duration are not supported yet for public API. The property will not be exposed}
 
     property<int> p7: "hello" * 1;
 //                    ^error{Cannot convert string to float}

--- a/tests/cases/types/angles.60
+++ b/tests/cases/types/angles.60
@@ -1,0 +1,48 @@
+/* LICENSE BEGIN
+    This file is part of the SixtyFPS Project -- https://sixtyfps.io
+    Copyright (c) 2021 Olivier Goffart <olivier.goffart@sixtyfps.io>
+    Copyright (c) 2021 Simon Hausmann <simon.hausmann@sixtyfps.io>
+
+    SPDX-License-Identifier: GPL-3.0-only
+    This file is also available under commercial licensing terms.
+    Please contact info@sixtyfps.io for more information.
+LICENSE END */
+Test := Rectangle {
+    property<angle> angle: 0.25turn;
+    property<bool> test: abs((angle - 0.5rad * 3.1415926535)/1grad) < 0.00001;
+}
+
+/*
+```cpp
+auto handle = Test::create();
+const Test &t = *handle;
+assert_eq(t.get_angle(), 90.);
+assert_eq(t.get_test(), true);
+
+t.set_angle(91.);
+assert_eq(t.get_angle(), 91.);
+assert_eq(t.get_test(), false);
+```
+
+
+```rust
+let t = Test::new();
+assert_eq!(t.get_angle(), 90.);
+assert_eq!(t.get_test(), true);
+
+t.set_angle(91.);
+assert_eq!(t.get_angle(), 91.);
+assert_eq!(t.get_test(), false);
+```
+
+```js
+var t = new sixtyfps.Test({});
+assert.equal(t.angle, 90);
+assert(t.test);
+t.angle = 91;
+assert.equal(t.angle, 91);
+assert(!t.test);
+
+```
+*/
+


### PR DESCRIPTION
One of the commit fix the angle conversion.

The other sets of commit make public than angle and duration in the public API.
Rationale for making the duration public is that we document that it is converted to i64 and that it is the number of millisecond
An argument against making it public is that one would want to use some Rust or C++ duration type instead.
Similarly, should we make angle properties public?