### PR TITLE
Rust: defaults to the `native` style when Qt is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
  - Fixed lookup scope when resolving model expression in `for` or `if` construct:
    the `self` element now refer to the correct element instead of the root.
+ - Rust: defaults to the native style if Qt is available
 
 ### Added
 

--- a/api/sixtyfps-rs/sixtyfps-build/lib.rs
+++ b/api/sixtyfps-rs/sixtyfps-build/lib.rs
@@ -203,6 +203,7 @@ pub fn compile_with_config(
     };
     if std::env::var_os("SIXTYFPS_STYLE").is_none() && compiler_config.style.is_none() {
         compiler_config.style = std::env::var_os("OUT_DIR").and_then(|path| {
+            // Same logic as in sixtyfps-rendering-backend-default's build script to get the path
             let path = Path::new(&path).parent()?.parent()?.join("SIXTYFPS_DEFAULT_STYLE.txt");
             let style = std::fs::read_to_string(path).ok()?;
             Some(style.trim().into())

--- a/api/sixtyfps-rs/sixtyfps-build/lib.rs
+++ b/api/sixtyfps-rs/sixtyfps-build/lib.rs
@@ -201,6 +201,13 @@ pub fn compile_with_config(
             compiler_config.embed_resources = true;
         }
     };
+    if std::env::var_os("SIXTYFPS_STYLE").is_none() && compiler_config.style.is_none() {
+        compiler_config.style = std::env::var_os("OUT_DIR").and_then(|path| {
+            let path = Path::new(&path).parent()?.parent()?.join("SIXTYFPS_DEFAULT_STYLE.txt");
+            let style = std::fs::read_to_string(path).ok()?;
+            Some(style.trim().into())
+        });
+    }
 
     let syntax_node = syntax_node.expect("diags contained no compilation errors");
 

--- a/api/sixtyfps-rs/sixtyfps-build/lib.rs
+++ b/api/sixtyfps-rs/sixtyfps-build/lib.rs
@@ -205,6 +205,10 @@ pub fn compile_with_config(
         compiler_config.style = std::env::var_os("OUT_DIR").and_then(|path| {
             // Same logic as in sixtyfps-rendering-backend-default's build script to get the path
             let path = Path::new(&path).parent()?.parent()?.join("SIXTYFPS_DEFAULT_STYLE.txt");
+            // unfortunately, if for some reason the file is changed by the sixtyfps-rendering-backend-default's build script,
+            // it is changed after cargo decide to re-run this build script or not. So that means one will need two build
+            // to settle the right thing.
+            println!("cargo:rerun-if-changed={}", path.display());
             let style = std::fs::read_to_string(path).ok()?;
             Some(style.trim().into())
         });

--- a/api/sixtyfps-rs/sixtyfps-macros/build.rs
+++ b/api/sixtyfps-rs/sixtyfps-macros/build.rs
@@ -1,0 +1,21 @@
+/* LICENSE BEGIN
+    This file is part of the SixtyFPS Project -- https://sixtyfps.io
+    Copyright (c) 2021 Olivier Goffart <olivier.goffart@sixtyfps.io>
+    Copyright (c) 2021 Simon Hausmann <simon.hausmann@sixtyfps.io>
+
+    SPDX-License-Identifier: GPL-3.0-only
+    This file is also available under commercial licensing terms.
+    Please contact info@sixtyfps.io for more information.
+LICENSE END */
+
+use std::path::Path;
+
+fn main() {
+    // This file is written by the sixtyfps-rendering-backend-default's built script. At this point
+    // the build script might not have ran yet, but we just need to pass the path to the build directory
+    // to the macro crate itself.
+    let out_dir = std::env::var_os("OUT_DIR").unwrap();
+    let target_path =
+        Path::new(&out_dir).parent().unwrap().parent().unwrap().join("SIXTYFPS_DEFAULT_STYLE.txt");
+    println!("cargo:rustc-env=SIXTYFPS_DEFAULT_STYLE_PATH={}", target_path.display());
+}

--- a/api/sixtyfps-rs/sixtyfps-macros/lib.rs
+++ b/api/sixtyfps-rs/sixtyfps-macros/lib.rs
@@ -340,6 +340,13 @@ pub fn sixtyfps(stream: TokenStream) -> TokenStream {
     //println!("{:#?}", syntax_node);
     let mut compiler_config =
         CompilerConfiguration::new(sixtyfps_compilerlib::generator::OutputFormat::Rust);
+
+    if std::env::var_os("SIXTYFPS_STYLE").is_none() {
+        compiler_config.style = std::fs::read_to_string(env!("SIXTYFPS_DEFAULT_STYLE_PATH"))
+            .map(|style| style.trim().into())
+            .ok()
+    }
+
     compiler_config.include_paths = include_paths;
     let (root_component, mut diag) =
         spin_on::spin_on(compile_syntax_node(syntax_node, diag, compiler_config));

--- a/sixtyfps_runtime/rendering_backends/default/build.rs
+++ b/sixtyfps_runtime/rendering_backends/default/build.rs
@@ -17,10 +17,10 @@ fn main() {
     // The way this work is this
     // 1. `qttypes`' crate's build script already detects Qt and set the DEP_QT_VERSION
     // 2. The qt rendering backend's build script will check if the qttype crates found Qt and
-    //    look at the SIXTYFPS_NO_QT env variable, and sets the DEP_SIXTYFPS_RENDERING_BACKEND_QT_HAS_NATIVE_STYLE
+    //    look at the SIXTYFPS_NO_QT env variable, and sets the DEP_SIXTYFPS_RENDERING_BACKEND_QT_SUPPORTS_NATIVE_STYLE
     //    env variable so that the default rendering backend can know if Qt was there.
     // 3. here, in the default rendering backend, we know if we depends on the qt backend and if it
-    //    has set the DEP_SIXTYFPS_RENDERING_BACKEND_QT_HAS_NATIVE_STYLE env variable.
+    //    has set the DEP_SIXTYFPS_RENDERING_BACKEND_QT_SUPPORTS_NATIVE_STYLE env variable.
     //    We then write a file in the build directory with the default style that depends on the
     //    Qt availability
     // 4a. When using the sixtyfps-build crate from a build script, it will be able to read this file
@@ -29,7 +29,7 @@ fn main() {
     //     the location of that file, the build script of sixtyfps-macros had to save the path in an env
     //     variable
 
-    let has_native_style = std::env::var("DEP_SIXTYFPS_RENDERING_BACKEND_QT_HAS_NATIVE_STYLE")
+    let has_native_style = std::env::var("DEP_SIXTYFPS_RENDERING_BACKEND_QT_SUPPORTS_NATIVE_STYLE")
         .unwrap_or_default()
         == "1";
 

--- a/sixtyfps_runtime/rendering_backends/default/build.rs
+++ b/sixtyfps_runtime/rendering_backends/default/build.rs
@@ -1,0 +1,44 @@
+/* LICENSE BEGIN
+    This file is part of the SixtyFPS Project -- https://sixtyfps.io
+    Copyright (c) 2021 Olivier Goffart <olivier.goffart@sixtyfps.io>
+    Copyright (c) 2021 Simon Hausmann <simon.hausmann@sixtyfps.io>
+
+    SPDX-License-Identifier: GPL-3.0-only
+    This file is also available under commercial licensing terms.
+    Please contact info@sixtyfps.io for more information.
+LICENSE END */
+
+use std::path::Path;
+
+fn main() {
+    // This is part code tries to detect automatically what default style to use and tries to
+    // use the native style automatically if Qt is available.
+    //
+    // The way this work is this
+    // 1. `qttypes`' crate's build script already detects Qt and set the DEP_QT_VERSION
+    // 2. The qt rendering backend's build script will check if the qttype crates found Qt and
+    //    look at the SIXTYFPS_NO_QT env variable, and sets the DEP_SIXTYFPS_RENDERING_BACKEND_QT_HAS_NATIVE_STYLE
+    //    env variable so that the default rendering backend can know if Qt was there.
+    // 3. here, in the default rendering backend, we know if we depends on the qt backend and if it
+    //    has set the DEP_SIXTYFPS_RENDERING_BACKEND_QT_HAS_NATIVE_STYLE env variable.
+    //    We then write a file in the build directory with the default style that depends on the
+    //    Qt availability
+    // 4a. When using the sixtyfps-build crate from a build script, it will be able to read this file
+    //     from `sixtyfps_build::compile_with_config`
+    // 4b. When using the `sixtyfps!` macro, the macro itself can read the file. But in order to know
+    //     the location of that file, the build script of sixtyfps-macros had to save the path in an env
+    //     variable
+
+    let has_native_style = std::env::var("DEP_SIXTYFPS_RENDERING_BACKEND_QT_HAS_NATIVE_STYLE")
+        .unwrap_or_default()
+        == "1";
+
+    let out_dir = std::env::var_os("OUT_DIR").unwrap();
+    // out_dir is something like
+    // <target_dir>/build/sixtyfps-rendering-backend-default-1fe5c4ab61eb0584/out
+    // and we want to write to a common directory, so write in the build/ dir
+    let target_path =
+        Path::new(&out_dir).parent().unwrap().parent().unwrap().join("SIXTYFPS_DEFAULT_STYLE.txt");
+    std::fs::write(target_path, if has_native_style { b"native\n" as &[u8] } else { b"ugly\n" })
+        .unwrap();
+}

--- a/sixtyfps_runtime/rendering_backends/qt/Cargo.toml
+++ b/sixtyfps_runtime/rendering_backends/qt/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0-only"
 description = "Qt rendering backend for SixtyFPS"
 repository = "https://github.com/sixtyfpsui/sixtyfps"
 homepage = "https://sixtyfps.io"
+links = "sixtyfps_rendering_backend_qt" # just so we can pass metadata to the dependee's build script
 
 [features]
 rtti = ["sixtyfps-corelib/rtti"]

--- a/sixtyfps_runtime/rendering_backends/qt/build.rs
+++ b/sixtyfps_runtime/rendering_backends/qt/build.rs
@@ -49,5 +49,5 @@ fn main() {
     println!("cargo:rerun-if-changed=qt_window.rs");
     println!("cargo:rerun-if-changed=widgets.rs");
     println!("cargo:rerun-if-changed=lib.rs");
-    println!("cargo:HAS_NATIVE_STYLE=1");
+    println!("cargo:SUPPORTS_NATIVE_STYLE=1");
 }

--- a/sixtyfps_runtime/rendering_backends/qt/build.rs
+++ b/sixtyfps_runtime/rendering_backends/qt/build.rs
@@ -49,4 +49,5 @@ fn main() {
     println!("cargo:rerun-if-changed=qt_window.rs");
     println!("cargo:rerun-if-changed=widgets.rs");
     println!("cargo:rerun-if-changed=lib.rs");
+    println!("cargo:HAS_NATIVE_STYLE=1");
 }


### PR DESCRIPTION
This requires some gymnastics to get right as the information
need to be passed to the compiler despite having no direct dependency
between the compiler and the runtime or backends.
So use a file in the build directory to tell the default style

cc: #83