### PR TITLE
Produce an error message when using if or for in grid layouts

### DIFF
--- a/sixtyfps_compiler/passes/lower_layout.rs
+++ b/sixtyfps_compiler/passes/lower_layout.rs
@@ -202,7 +202,7 @@ impl GridLayout {
         if let Some(layout_item) = create_layout_item(item_element, diag) {
             if layout_item.repeater_index.is_some() {
                 diag.push_error(
-                    format!("if or for expressions are not currently supported in grid layouts"),
+                    format!("'if' or 'for' expressions are not currently supported in grid layouts"),
                     &*item_element.borrow(),
                 );
                 return;

--- a/sixtyfps_compiler/passes/lower_layout.rs
+++ b/sixtyfps_compiler/passes/lower_layout.rs
@@ -202,7 +202,9 @@ impl GridLayout {
         if let Some(layout_item) = create_layout_item(item_element, diag) {
             if layout_item.repeater_index.is_some() {
                 diag.push_error(
-                    format!("'if' or 'for' expressions are not currently supported in grid layouts"),
+                    format!(
+                        "'if' or 'for' expressions are not currently supported in grid layouts"
+                    ),
                     &*item_element.borrow(),
                 );
                 return;

--- a/sixtyfps_compiler/passes/lower_layout.rs
+++ b/sixtyfps_compiler/passes/lower_layout.rs
@@ -200,6 +200,14 @@ impl GridLayout {
 
         let index = self.elems.len();
         if let Some(layout_item) = create_layout_item(item_element, diag) {
+            if layout_item.repeater_index.is_some() {
+                diag.push_error(
+                    format!("if or for expressions are not currently supported in grid layouts"),
+                    &*item_element.borrow(),
+                );
+                return;
+            }
+
             let e = &layout_item.elem;
             set_prop_from_cache(e, "x", layout_cache_prop_h, index * 2, &None, diag);
             if !layout_item.item.constraints.fixed_width {

--- a/sixtyfps_compiler/tests/syntax/layout/if_in_grid.60
+++ b/sixtyfps_compiler/tests/syntax/layout/if_in_grid.60
@@ -13,17 +13,17 @@ Test := Rectangle {
     GridLayout {
         Row {
             if (condition): Text {
-//                          ^error{if or for expressions are not currently supported in grid layouts}
+//                          ^error{'if' or 'for' expressions are not currently supported in grid layouts}
             }
         }
 
         if (condition): Text {
-//                      ^error{if or for expressions are not currently supported in grid layouts}
+//                      ^error{'if' or 'for' expressions are not currently supported in grid layouts}
 
         }
 
         for x in 5: Text {
-//                  ^error{if or for expressions are not currently supported in grid layouts}
+//                  ^error{'if' or 'for' expressions are not currently supported in grid layouts}
             
          }
     }

--- a/sixtyfps_compiler/tests/syntax/layout/if_in_grid.60
+++ b/sixtyfps_compiler/tests/syntax/layout/if_in_grid.60
@@ -1,0 +1,31 @@
+/* LICENSE BEGIN
+    This file is part of the SixtyFPS Project -- https://sixtyfps.io
+    Copyright (c) 2021 Olivier Goffart <olivier.goffart@sixtyfps.io>
+    Copyright (c) 2021 Simon Hausmann <simon.hausmann@sixtyfps.io>
+
+    SPDX-License-Identifier: GPL-3.0-only
+    This file is also available under commercial licensing terms.
+    Please contact info@sixtyfps.io for more information.
+LICENSE END */
+Test := Rectangle {
+    property <bool> condition;
+
+    GridLayout {
+        Row {
+            if (condition): Text {
+//                          ^error{if or for expressions are not currently supported in grid layouts}
+            }
+        }
+
+        if (condition): Text {
+//                      ^error{if or for expressions are not currently supported in grid layouts}
+
+        }
+
+        for x in 5: Text {
+//                  ^error{if or for expressions are not currently supported in grid layouts}
+            
+         }
+    }
+}
+


### PR DESCRIPTION
An early error is better than a build error at compile time of generated code.

Fixes #349