### PR TITLE
Another minor reduction in generated code

### DIFF
--- a/api/sixtyfps-rs/lib.rs
+++ b/api/sixtyfps-rs/lib.rs
@@ -295,7 +295,6 @@ pub mod internal {
     ) {
         let weak = component_strong.to_weak();
         property.set_binding(move || {
-            //let strong = ;
             binding(<StrongRef as StrongComponentRef>::from_weak(&weak).unwrap())
         })
     }


### PR DESCRIPTION
Further build on b3529d1b75b9e8f970ecc17e16037d80e11385be and move the
strong/weak reference dance into the API crate out of the generated
code.

Saves ~21k llvm lines on the printer demo (debug).

It's also possible to move the as_pin_ref() bit, but that didn't
really give any savings overall.