### PR TITLE
Fix cursor navigation and text selection rendering when using combining characters

### DIFF
--- a/sixtyfps_runtime/corelib/Cargo.toml
+++ b/sixtyfps_runtime/corelib/Cargo.toml
@@ -40,6 +40,7 @@ auto_enums = "0.7"
 weak-table =  "0.3"
 scopeguard = "1.1.0"
 cfg-if = "1"
+unicode-segmentation = "1.8.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 instant = { version = "0.1", features = [ "wasm-bindgen", "now" ] }

--- a/sixtyfps_runtime/rendering_backends/gl/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/lib.rs
@@ -743,13 +743,19 @@ impl ItemRenderer for GLItemRenderer {
             let (anchor_pos, cursor_pos) = text_input.selection_anchor_and_cursor();
             let mut selection_start_x = 0.;
             let mut selection_end_x = 0.;
+            // Determine the first and last (inclusive) glyph of the selection. The anchor
+            // will always be at the start of a grapheme boundary, so there's at ShapedGlyph
+            // that has a matching byte index. For the selection end we have to look for the
+            // visual end of glyph before the cursor, because due to for example ligatures
+            // (or generally glyph substitution) there may not be a dedicated glyph.
             for glyph in &metrics.glyphs {
                 if glyph.byte_index == anchor_pos {
                     selection_start_x = glyph.x;
                 }
-                if glyph.byte_index == (cursor_pos as i32 - 1).max(0) as usize {
-                    selection_end_x = glyph.x + glyph.advance_x;
+                if glyph.byte_index == cursor_pos {
+                    break;
                 }
+                selection_end_x = glyph.x + glyph.advance_x;
             }
 
             let selection_rect = Rect::new(

--- a/tests/cases/text/cursor_move_grapheme.60
+++ b/tests/cases/text/cursor_move_grapheme.60
@@ -1,0 +1,57 @@
+/* LICENSE BEGIN
+    This file is part of the SixtyFPS Project -- https://sixtyfps.io
+    Copyright (c) 2021 Olivier Goffart <olivier.goffart@sixtyfps.io>
+    Copyright (c) 2021 Simon Hausmann <simon.hausmann@sixtyfps.io>
+
+    SPDX-License-Identifier: GPL-3.0-only
+    This file is also available under commercial licensing terms.
+    Please contact info@sixtyfps.io for more information.
+LICENSE END */
+TestCase := TextInput {
+    width: 100phx;
+    height: 100phx;
+    property<string> test_text: self.text;
+    property<int> test_cursor_pos: self.cursor_position;
+    property<int> test_anchor_pos: self.anchor_position;
+    property<bool> has_selection: self.cursor_position != self.anchor_position;
+    property<bool> input_focused: self.has_focus;
+}
+
+/*
+```rust
+
+// from input.rs
+const LEFT_CODE: char = '\u{000E}'; // shift out
+const BACK_CODE: char = '\u{0007}'; // backspace \b
+
+let shift_modifier = sixtyfps::re_exports::KeyboardModifiers {
+    shift: true,
+    ..Default::default()
+};
+
+let instance = TestCase::new();
+sixtyfps::testing::send_mouse_click(&instance, 50., 50.);
+assert!(instance.get_input_focused());
+assert_eq!(instance.get_test_text(), "");
+sixtyfps::testing::send_keyboard_string_sequence(&instance, "e\u{0301}");
+assert_eq!(instance.get_test_text(), "e\u{0301}");
+assert!(!instance.get_has_selection());
+
+// Test that selecting the grapheme works
+sixtyfps::testing::set_current_keyboard_modifiers(&instance, shift_modifier);
+sixtyfps::testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+sixtyfps::testing::set_current_keyboard_modifiers(&instance, sixtyfps::re_exports::KeyboardModifiers::default());
+assert!(instance.get_has_selection());
+sixtyfps::testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
+
+assert_eq!(instance.get_test_text(), "");
+
+sixtyfps::testing::send_keyboard_string_sequence(&instance, "e\u{0301}");
+
+// Test that backspace does not operate on the grapheme and just removes the
+// diacritic.
+sixtyfps::testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
+assert_eq!(instance.get_test_cursor_pos(), 1);
+assert_eq!(instance.get_test_text(), "e");
+```
+*/


### PR DESCRIPTION
The cursor navigation left/right (and subsequently text selection) needs
to respect grapheme boundaries. Since we already depend on the
unicode-segmentation crate through femtovg, we might as well use the
functionality for determining grapheme boundaries from there.

The only place where the cursor navigation is allowed to break that is
when using backspace, as that allows the user to break glyph clusters.

Along the same lines, this merge request also includes a fix for rendering text
selections when using combining characters, where the shaper may use
one glyph to represent multiple characters and therefore our attempt to finding
a glyph for the selection end may fail.