### PR TITLE
Mention forward-focus in the FocusScope example

### DIFF
--- a/docs/builtin_elements.md
+++ b/docs/builtin_elements.md
@@ -463,7 +463,8 @@ The FocusScope exposes callback to intercept the pressed key when it has focus.
 
 ```60
 Example := Window {
-    FocusScope {
+    forward-focus: my_key_handler;
+    my_key_handler := FocusScope {
         key-pressed(event) => {
             debug(event.text);
             if (event.modifiers.control) {


### PR DESCRIPTION
This makes the example a bit more useful out of the box,
at least to let the user know that this property exists.