### PR TITLE
Minor reduction in generated Rust code (llvm lines)

### DIFF
--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -215,6 +215,9 @@ fn handle_property_binding(
         init.push(if is_constant {
             let t = rust_type(&prop_type).unwrap_or(quote!(_));
 
+            // When there is a `return` statement, we must use a lambda expression in the generated code so that the 
+            // generated code can have an actual return in it. We only want to do that if necessary because otherwise
+            // this would slow down the rust compilation
             let mut uses_return = false;
             binding_expression.visit_recursive(&mut |e| {
                 if matches!(e, Expression::ReturnStatement(..)) {


### PR DESCRIPTION
When setting a constant, we only need to use a closure for the
expression if it contains a return statement.

This saves about ~14000 llvm lines for a debug build of the printer
demo.