### PR TITLE
Fix disappearing elements with implicit width/height

### DIFF
--- a/sixtyfps_compiler/expression_tree.rs
+++ b/sixtyfps_compiler/expression_tree.rs
@@ -13,7 +13,7 @@ use crate::layout::Orientation;
 use crate::object_tree::*;
 use crate::parser::{NodeOrToken, SyntaxNode};
 use core::cell::RefCell;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::rc::{Rc, Weak};
 
 // FIXME remove the pub
@@ -1177,7 +1177,7 @@ pub enum Path {
 #[derive(Debug, Clone)]
 pub struct PathElement {
     pub element_type: Rc<BuiltinElement>,
-    pub bindings: BTreeMap<String, BindingExpression>,
+    pub bindings: BindingsMap,
 }
 
 #[derive(Clone, Debug)]

--- a/sixtyfps_compiler/passes/apply_default_properties_from_style.rs
+++ b/sixtyfps_compiler/passes/apply_default_properties_from_style.rs
@@ -37,22 +37,24 @@ pub async fn apply_default_properties_from_style(
             let mut elem = elem.borrow_mut();
             match elem.base_type.to_string().as_str() {
                 "TextInput" => {
-                    elem.bindings.entry("text_cursor_width".into()).or_insert_with(|| {
+                    elem.bindings.set_binding_if_not_set(
+                        "text_cursor_width".into(),
                         Expression::PropertyReference(NamedReference::new(
                             &style_metrics.root_element,
                             "text_cursor_width",
                         ))
-                        .into()
-                    });
+                        .into(),
+                    );
                 }
                 "Window" => {
-                    elem.bindings.entry("background".into()).or_insert_with(|| {
+                    elem.bindings.set_binding_if_not_set(
+                        "background".into(),
                         Expression::PropertyReference(NamedReference::new(
                             &style_metrics.root_element,
                             "window_background",
                         ))
-                        .into()
-                    });
+                        .into(),
+                    );
                 }
 
                 _ => {}

--- a/sixtyfps_compiler/passes/default_geometry.rs
+++ b/sixtyfps_compiler/passes/default_geometry.rs
@@ -92,19 +92,17 @@ pub fn default_geometry(root_component: &Rc<Component>, diag: &mut BuildDiagnost
                                     property_type: image_fit_prop_type,
                                 } = elem.borrow().lookup_property("image_fit");
 
-                                elem.borrow_mut()
-                                    .bindings
-                                    .entry(image_fit_prop_name.into())
-                                    .or_insert_with(|| {
-                                        Expression::EnumerationValue(
-                                            image_fit_prop_type
-                                                .as_enum()
-                                                .clone()
-                                                .try_value_from_string("contain")
-                                                .unwrap(),
-                                        )
-                                        .into()
-                                    });
+                                elem.borrow_mut().bindings.set_binding_if_not_set(
+                                    image_fit_prop_name.into(),
+                                    Expression::EnumerationValue(
+                                        image_fit_prop_type
+                                            .as_enum()
+                                            .clone()
+                                            .try_value_from_string("contain")
+                                            .unwrap(),
+                                    )
+                                    .into(),
+                                );
                             }
                         }
                     }
@@ -205,20 +203,22 @@ fn make_default_100(elem: &ElementRc, parent_element: &ElementRc, property: &str
     if property_type != Type::LogicalLength {
         return;
     }
-    elem.borrow_mut().bindings.entry(resolved_name.to_string()).or_insert_with(|| {
+    elem.borrow_mut().bindings.set_binding_if_not_set(
+        resolved_name.to_string(),
         Expression::PropertyReference(NamedReference::new(parent_element, resolved_name.as_ref()))
-            .into()
-    });
+            .into(),
+    );
 }
 
 fn make_default_implicit(elem: &ElementRc, property: &str, orientation: Orientation) {
-    elem.borrow_mut().bindings.entry(property.into()).or_insert_with(|| {
+    elem.borrow_mut().bindings.set_binding_if_not_set(
+        property.into(),
         Expression::StructFieldAccess {
             base: implicit_layout_info_call(elem, orientation).into(),
             name: "preferred".into(),
         }
-        .into()
-    });
+        .into(),
+    );
 }
 
 // For an element with `width`, `height`, `preferred-width` and `preferred-height`, make an aspect

--- a/sixtyfps_compiler/passes/move_declarations.rs
+++ b/sixtyfps_compiler/passes/move_declarations.rs
@@ -54,7 +54,7 @@ pub fn move_declarations(component: &Rc<Component>, diag: &mut BuildDiagnostics)
 
         // take the bindings so we do nt keep the borrow_mut of the element
         let bindings = core::mem::take(&mut elem.borrow_mut().bindings);
-        let mut new_bindings = BTreeMap::new();
+        let mut new_bindings = BindingsMap::default();
         for (k, e) in bindings {
             let will_be_moved = elem.borrow().property_declarations.contains_key(&k);
             if will_be_moved {

--- a/tests/cases/bindings/animated_default_geometry.60
+++ b/tests/cases/bindings/animated_default_geometry.60
@@ -1,0 +1,43 @@
+/* LICENSE BEGIN
+    This file is part of the SixtyFPS Project -- https://sixtyfps.io
+    Copyright (c) 2021 Olivier Goffart <olivier.goffart@sixtyfps.io>
+    Copyright (c) 2021 Simon Hausmann <simon.hausmann@sixtyfps.io>
+
+    SPDX-License-Identifier: GPL-3.0-only
+    This file is also available under commercial licensing terms.
+    Please contact info@sixtyfps.io for more information.
+LICENSE END */
+
+
+TestCase := Rectangle {
+
+    width: 100px;
+    height: 200px;
+
+    r := Rectangle {
+        // default geometry for width & height
+        animate height { duration: 1s; }
+        animate width { duration: 1s; }
+    }
+
+    property<bool> test: r.width == 100px && r.height == 200px;
+}
+
+/*
+```rust
+let instance = TestCase::new();
+assert!(instance.get_test());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+```js
+let instance = new sixtyfps.TestCase({});
+assert(instance.test, 1);
+```
+
+*/


### PR DESCRIPTION
When an element gets its width and height from the parent through an implicit 100% binding,
those bindings were missing when an animation was pre-defined.

The provided new-type wrapper offers a function to deal with replacing just
binding expression, instead of the
expression *and* the animation.

Fixes #376