### PR TITLE
GL backend: Avoid run-time opengl errors with clipped zero width or h…

### DIFF
--- a/sixtyfps_runtime/rendering_backends/gl/images.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/images.rs
@@ -139,7 +139,10 @@ impl CachedImage {
         Self(RefCell::new(Texture { id: image_id, canvas: canvas.clone() }.into()))
     }
 
-    pub fn new_empty_on_gpu(canvas: &CanvasRc, width: usize, height: usize) -> Self {
+    pub fn new_empty_on_gpu(canvas: &CanvasRc, width: usize, height: usize) -> Option<Self> {
+        if width == 0 || height == 0 {
+            return None;
+        }
         let image_id = canvas
             .borrow_mut()
             .create_image_empty(
@@ -149,7 +152,7 @@ impl CachedImage {
                 femtovg::ImageFlags::PREMULTIPLIED | femtovg::ImageFlags::FLIP_Y,
             )
             .unwrap();
-        Self::new_on_gpu(canvas, image_id)
+        Self::new_on_gpu(canvas, image_id).into()
     }
 
     #[cfg(feature = "svg")]
@@ -344,6 +347,9 @@ impl CachedImage {
             &canvas,
             size.width.ceil() as usize,
             size.height.ceil() as usize,
+        )
+        .expect(
+            "internal error: this can only fail if the filtered image was zero width or height",
         );
 
         let filtered_image_id = match &*filtered_image.0.borrow() {

--- a/sixtyfps_runtime/rendering_backends/gl/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/lib.rs
@@ -934,7 +934,7 @@ impl ItemRenderer for GLItemRenderer {
             return;
         }
 
-        let cache_entry = match self
+        let cache_entry = self
             .graphics_window
             .graphics_cache
             .borrow_mut()
@@ -1033,12 +1033,12 @@ impl ItemRenderer for GLItemRenderer {
                     Rc::new(shadow_image)
                 })
                 .into()
-            }) {
-            Some(cached_shadow_image) => cached_shadow_image,
+            });
+
+        let shadow_image = match &cache_entry {
+            Some(cached_shadow_image) => cached_shadow_image.as_image(),
             None => return, // Zero width or height shadow
         };
-
-        let shadow_image = cache_entry.as_image();
 
         let shadow_image_size = match shadow_image.size() {
             Some(size) => size,


### PR DESCRIPTION
…eight rectangles

If a Rectangle has a border-radius and clipping, we use an FBO to render
the children and then use femtovg's stencil clipping. If the Rectangle
has a zero width or height, we would end up trying to create a texture
with such dimensions, which produces run-time opengl errors.

We can detect this situation and avoid it early on. The same might happen for shadows.

Fixes #377