### PR TITLE
Fix regression of two-way binding on default geom'ed properties causi…

### DIFF
--- a/sixtyfps_compiler/object_tree.rs
+++ b/sixtyfps_compiler/object_tree.rs
@@ -361,14 +361,21 @@ impl Clone for PropertyAnimation {
 pub struct BindingsMap(BTreeMap<String, BindingExpression>);
 
 impl BindingsMap {
-    pub fn set_binding_if_not_set(&mut self, property_name: String, expression: BindingExpression) {
+    pub fn set_binding_if_not_set(
+        &mut self,
+        property_name: String,
+        expression_fn: impl FnOnce() -> BindingExpression,
+    ) {
         match self.0.entry(property_name) {
             Entry::Vacant(vacant_entry) => {
-                vacant_entry.insert(expression);
+                vacant_entry.insert(expression_fn());
             }
-            Entry::Occupied(mut existing_entry) => {
-                existing_entry.get_mut().merge_with(&expression);
+            Entry::Occupied(mut existing_entry)
+                if matches!(existing_entry.get().expression, Expression::Invalid) =>
+            {
+                existing_entry.get_mut().merge_with(&expression_fn());
             }
+            _ => {}
         };
     }
 }

--- a/sixtyfps_compiler/passes/apply_default_properties_from_style.rs
+++ b/sixtyfps_compiler/passes/apply_default_properties_from_style.rs
@@ -37,24 +37,22 @@ pub async fn apply_default_properties_from_style(
             let mut elem = elem.borrow_mut();
             match elem.base_type.to_string().as_str() {
                 "TextInput" => {
-                    elem.bindings.set_binding_if_not_set(
-                        "text_cursor_width".into(),
+                    elem.bindings.set_binding_if_not_set("text_cursor_width".into(), || {
                         Expression::PropertyReference(NamedReference::new(
                             &style_metrics.root_element,
                             "text_cursor_width",
                         ))
-                        .into(),
-                    );
+                        .into()
+                    });
                 }
                 "Window" => {
-                    elem.bindings.set_binding_if_not_set(
-                        "background".into(),
+                    elem.bindings.set_binding_if_not_set("background".into(), || {
                         Expression::PropertyReference(NamedReference::new(
                             &style_metrics.root_element,
                             "window_background",
                         ))
-                        .into(),
-                    );
+                        .into()
+                    });
                 }
 
                 _ => {}

--- a/sixtyfps_compiler/passes/default_geometry.rs
+++ b/sixtyfps_compiler/passes/default_geometry.rs
@@ -94,14 +94,16 @@ pub fn default_geometry(root_component: &Rc<Component>, diag: &mut BuildDiagnost
 
                                 elem.borrow_mut().bindings.set_binding_if_not_set(
                                     image_fit_prop_name.into(),
-                                    Expression::EnumerationValue(
-                                        image_fit_prop_type
-                                            .as_enum()
-                                            .clone()
-                                            .try_value_from_string("contain")
-                                            .unwrap(),
-                                    )
-                                    .into(),
+                                    || {
+                                        Expression::EnumerationValue(
+                                            image_fit_prop_type
+                                                .as_enum()
+                                                .clone()
+                                                .try_value_from_string("contain")
+                                                .unwrap(),
+                                        )
+                                        .into()
+                                    },
                                 );
                             }
                         }
@@ -203,22 +205,20 @@ fn make_default_100(elem: &ElementRc, parent_element: &ElementRc, property: &str
     if property_type != Type::LogicalLength {
         return;
     }
-    elem.borrow_mut().bindings.set_binding_if_not_set(
-        resolved_name.to_string(),
+    elem.borrow_mut().bindings.set_binding_if_not_set(resolved_name.to_string(), || {
         Expression::PropertyReference(NamedReference::new(parent_element, resolved_name.as_ref()))
-            .into(),
-    );
+            .into()
+    });
 }
 
 fn make_default_implicit(elem: &ElementRc, property: &str, orientation: Orientation) {
-    elem.borrow_mut().bindings.set_binding_if_not_set(
-        property.into(),
+    elem.borrow_mut().bindings.set_binding_if_not_set(property.into(), || {
         Expression::StructFieldAccess {
             base: implicit_layout_info_call(elem, orientation).into(),
             name: "preferred".into(),
         }
-        .into(),
-    );
+        .into()
+    });
 }
 
 // For an element with `width`, `height`, `preferred-width` and `preferred-height`, make an aspect

--- a/tests/cases/bindings/issue_385_default_geom.60
+++ b/tests/cases/bindings/issue_385_default_geom.60
@@ -1,0 +1,41 @@
+/* LICENSE BEGIN
+    This file is part of the SixtyFPS Project -- https://sixtyfps.io
+    Copyright (c) 2021 Olivier Goffart <olivier.goffart@sixtyfps.io>
+    Copyright (c) 2021 Simon Hausmann <simon.hausmann@sixtyfps.io>
+
+    SPDX-License-Identifier: GPL-3.0-only
+    This file is also available under commercial licensing terms.
+    Please contact info@sixtyfps.io for more information.
+LICENSE END */
+
+
+TestCase := Rectangle {
+    width: 100px;
+    height: 200px;
+
+    r := Rectangle {
+        width <=> root.width;
+        height <=> root.height;
+    }
+
+    property<bool> test: r.width == 100px && r.height == 200px;
+}
+
+/*
+```rust
+let instance = TestCase::new();
+assert!(instance.get_test());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+```js
+let instance = new sixtyfps.TestCase({});
+assert(instance.test, 1);
+```
+
+*/


### PR DESCRIPTION
…ng binding loop

Commit 064c39d625395b9ac74961e4ded7606cdbfe16ba introduced the regression that
if a two-way binding was set on a property that we'd also set a default geometry
on, we'd end up applying that on the two-way binding, causing a binding loop.

set_binding_if_not_set needs to only set the binding if... there's really none yet.

Fixes #385