### PR TITLE
Fix clippy errors in generated code of sliding puzzle

### DIFF
--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -126,6 +126,10 @@ pub fn generate(doc: &Document, diag: &mut BuildDiagnostics) -> Option<TokenStre
         #[allow(non_snake_case)]
         #[allow(clippy::style)]
         #[allow(clippy::complexity)]
+        #[allow(clippy::approx_constant)]
+        #[allow(clippy::float_cmp)]
+        #[allow(clippy::if_same_then_else)]
+        #[allow(clippy::erasing_op)]
         mod #compo_module {
             use sixtyfps::re_exports::*;
             #(#structs)*


### PR DESCRIPTION
Disable all the clippy checks that are registered as errors in
the sliding puzzle example.

The following warnings are allowed in this change:

* clippy::approx_constant: This is probably the right thing to do
  as we do not want to get errors for all possible constants defined in
  `.60` files
* clippy::float_cmp: This is probably wrong! We should do the proper
  float comparisson dance for these values.
* clippy::if_same_then_else: Probably ok
* clippy::erasing_op: This is about multiplying indices with 0 in some
  places, which seems to be ok for generated code.