### PR TITLE
Pr/janitor

### DIFF
--- a/api/sixtyfps-node/native/lib.rs
+++ b/api/sixtyfps-node/native/lib.rs
@@ -67,7 +67,7 @@ fn load(mut cx: FunctionContext) -> JsResult<JsValue> {
     compiler.set_include_paths(include_paths);
     let c = spin_on::spin_on(compiler.build_from_path(path));
 
-    sixtyfps_interpreter::print_diagnostics(&compiler.diagnostics());
+    sixtyfps_interpreter::print_diagnostics(compiler.diagnostics());
 
     let c = if let Some(c) = c { c } else { return cx.throw_error("Compilation error") };
 

--- a/api/sixtyfps-node/native/lib.rs
+++ b/api/sixtyfps-node/native/lib.rs
@@ -135,12 +135,12 @@ fn create<'cx>(
                         prop_name.as_str(),
                         make_callback_handler(cx, &persistent_context, fun, return_type),
                     )
-                    .or_else(|_| cx.throw_error(format!("Cannot set callback")))?;
+                    .or_else(|_| cx.throw_error("Cannot set callback".to_string()))?;
             } else {
                 let value = to_eval_value(value, ty, cx, &persistent_context)?;
                 component
                     .set_property(prop_name.as_str(), value)
-                    .or_else(|_| cx.throw_error(format!("Cannot assign property")))?;
+                    .or_else(|_| cx.throw_error("Cannot assign property".to_string()))?;
             }
         }
     }
@@ -361,7 +361,7 @@ declare_types! {
             let component = component.ok_or(()).or_else(|()| cx.throw_error("Invalid type"))?;
             let value = run_scoped(&mut cx,this.downcast().unwrap(), || {
                 component.get_property(prop_name.as_str())
-                    .map_err(|_| format!("Cannot read property"))
+                    .map_err(|_| "Cannot read property".to_string())
             })?;
             to_js_value(value, &mut cx)
         }
@@ -382,7 +382,7 @@ declare_types! {
 
             let value = to_eval_value(cx.argument::<JsValue>(1)?, ty, &mut cx, &persistent_context)?;
             component.set_property(prop_name.as_str(), value)
-                .or_else(|_| cx.throw_error(format!("Cannot assign property")))?;
+                .or_else(|_| cx.throw_error("Cannot assign property".to_string()))?;
 
             Ok(JsUndefined::new().as_value(&mut cx))
         }
@@ -442,7 +442,7 @@ declare_types! {
                 component.set_callback(
                     callback_name.as_str(),
                     make_callback_handler(&mut cx, &persistent_context, handler, return_type)
-                ).or_else(|_| cx.throw_error(format!("Cannot set callback")))?;
+                ).or_else(|_| cx.throw_error("Cannot set callback".to_string()))?;
                 Ok(JsUndefined::new().as_value(&mut cx))
             } else {
                 cx.throw_error(format!("{} is not a callback", callback_name))?;

--- a/api/sixtyfps-node/native/lib.rs
+++ b/api/sixtyfps-node/native/lib.rs
@@ -483,7 +483,7 @@ declare_types! {
 
         method show(mut cx) {
             let this = cx.this();
-            let window = cx.borrow(&this, |x| x.0.as_ref().map(|c| c.clone()));
+            let window = cx.borrow(&this, |x| x.0.as_ref().cloned());
             let window = window.ok_or(()).or_else(|()| cx.throw_error("Invalid type"))?;
             window.show();
             Ok(JsUndefined::new().as_value(&mut cx))
@@ -491,7 +491,7 @@ declare_types! {
 
         method hide(mut cx) {
             let this = cx.this();
-            let window = cx.borrow(&this, |x| x.0.as_ref().map(|c| c.clone()));
+            let window = cx.borrow(&this, |x| x.0.as_ref().cloned());
             let window = window.ok_or(()).or_else(|()| cx.throw_error("Invalid type"))?;
             window.hide();
             Ok(JsUndefined::new().as_value(&mut cx))

--- a/api/sixtyfps-node/native/lib.rs
+++ b/api/sixtyfps-node/native/lib.rs
@@ -35,15 +35,14 @@ fn run_scoped<'cx, T>(
 ) -> NeonResult<T> {
     let persistent_context =
         persistent_context::PersistentContext::from_object(cx, object_with_persistent_context)?;
-    Ok(cx
-        .execute_scoped(|cx| {
-            let cx = RefCell::new(cx);
-            let cx_fn = move |callback: &GlobalContextCallback| {
-                callback(&mut *cx.borrow_mut(), &persistent_context)
-            };
-            GLOBAL_CONTEXT.set(&&cx_fn, functor)
-        })
-        .or_else(|e| cx.throw_error(e))?)
+    cx.execute_scoped(|cx| {
+        let cx = RefCell::new(cx);
+        let cx_fn = move |callback: &GlobalContextCallback| {
+            callback(&mut *cx.borrow_mut(), &persistent_context)
+        };
+        GLOBAL_CONTEXT.set(&&cx_fn, functor)
+    })
+    .or_else(|e| cx.throw_error(e))
 }
 
 fn run_with_global_context(f: &GlobalContextCallback) {

--- a/api/sixtyfps-rs/lib.rs
+++ b/api/sixtyfps-rs/lib.rs
@@ -369,7 +369,7 @@ pub mod internal {
 /// Creates a new window to render components in.
 #[doc(hidden)]
 pub fn create_window() -> re_exports::WindowRc {
-    sixtyfps_rendering_backend_default::backend().create_window().into()
+    sixtyfps_rendering_backend_default::backend().create_window()
 }
 
 /// Enters the main event loop. This is necessary in order to receive
@@ -587,7 +587,7 @@ pub mod testing {
             &dyn_rc,
             x,
             y,
-            &rc.window_handle().clone().into(),
+            &rc.window_handle().clone(),
         );
     }
 
@@ -616,7 +616,7 @@ pub mod testing {
         sixtyfps_corelib::tests::send_keyboard_string_sequence(
             &super::SharedString::from(sequence),
             KEYBOARD_MODIFIERS.with(|x| x.get()),
-            &component.window_handle().clone().into(),
+            &component.window_handle().clone(),
         )
     }
 

--- a/api/sixtyfps-rs/lib.rs
+++ b/api/sixtyfps-rs/lib.rs
@@ -271,7 +271,7 @@ pub mod internal {
     impl<C: 'static> StrongComponentRef for VRc<ComponentVTable, C> {
         type Weak = VWeak<ComponentVTable, C>;
         fn to_weak(&self) -> Self::Weak {
-            VRc::downgrade(&self)
+            VRc::downgrade(self)
         }
         fn from_weak(weak: &Self::Weak) -> Option<Self> {
             weak.upgrade()
@@ -490,7 +490,7 @@ mod weak_handle {
     impl<T: ComponentHandle> Weak<T> {
         #[doc(hidden)]
         pub fn new(rc: &vtable::VRc<re_exports::ComponentVTable, T::Inner>) -> Self {
-            Self { inner: vtable::VRc::downgrade(&rc), thread: std::thread::current().id() }
+            Self { inner: vtable::VRc::downgrade(rc), thread: std::thread::current().id() }
         }
 
         /// Returns a new strongly referenced component if some other instance still

--- a/api/sixtyfps-rs/lib.rs
+++ b/api/sixtyfps-rs/lib.rs
@@ -483,7 +483,7 @@ mod weak_handle {
 
     impl<T: ComponentHandle> Clone for Weak<T> {
         fn clone(&self) -> Self {
-            Self { inner: self.inner.clone(), thread: self.thread.clone() }
+            Self { inner: self.inner.clone(), thread: self.thread }
         }
     }
 

--- a/api/sixtyfps-rs/sixtyfps-build/lib.rs
+++ b/api/sixtyfps-rs/sixtyfps-build/lib.rs
@@ -233,7 +233,7 @@ pub fn compile_with_config(
         .join(
             path.file_stem()
                 .map(Path::new)
-                .unwrap_or(Path::new("sixtyfps_out"))
+                .unwrap_or_else(|| Path::new("sixtyfps_out"))
                 .with_extension("rs"),
         );
 

--- a/sixtyfps_compiler/generator/cpp.rs
+++ b/sixtyfps_compiler/generator/cpp.rs
@@ -420,7 +420,7 @@ fn handle_property_binding(
             } else {
                 match animation {
                     Some(crate::object_tree::PropertyAnimation::Static(anim)) => {
-                        let anim = property_animation_code(&component, anim);
+                        let anim = property_animation_code(component, anim);
                         format!("{}.set_animated_binding({}, {});", cpp_prop, binding_code, anim)
                     }
                     Some(crate::object_tree::PropertyAnimation::Transition {
@@ -693,7 +693,7 @@ fn generate_component(
                 args.iter().map(|t| get_cpp_type(t, property_decl, diag)).collect::<Vec<_>>();
             let return_type = return_type
                 .as_ref()
-                .map_or("void".into(), |t| get_cpp_type(&t, property_decl, diag));
+                .map_or("void".into(), |t| get_cpp_type(t, property_decl, diag));
             if property_decl.expose_in_public_api && is_root {
                 let callback_emitter = vec![format!(
                     "return {}.call({});",
@@ -1633,11 +1633,11 @@ fn compile_expression(
             _ => {
                 let mut args = arguments.iter().map(|e| compile_expression(e, component));
 
-                format!("{}({})", compile_expression(&function, component), args.join(", "))
+                format!("{}({})", compile_expression(function, component), args.join(", "))
             }
         },
         Expression::SelfAssignment { lhs, rhs, op } => {
-            let rhs = compile_expression(&*rhs, &component);
+            let rhs = compile_expression(&*rhs, component);
             compile_assignment(lhs, *op, rhs, component)
         }
         Expression::BinaryExpression { lhs, rhs, op } => {
@@ -1746,7 +1746,7 @@ fn compile_expression(
         Expression::LayoutCacheAccess { layout_cache_prop, index, repeater_index } => {
             let cache = access_named_reference(layout_cache_prop, component, "self");
             if let Some(ri) = repeater_index {
-                format!("[&](auto cache) {{ return cache[int(cache[{}]) + {} * 2]; }} ({}.get())", index, compile_expression(&ri, component), cache)
+                format!("[&](auto cache) {{ return cache[int(cache[{}]) + {} * 2]; }} ({}.get())", index, compile_expression(ri, component), cache)
             } else {
                 format!("{}.get()[{}]", cache, index)
             }
@@ -2089,7 +2089,7 @@ fn compile_path(path: &crate::expression_tree::Path, component: &Rc<Component>) 
                         .cpp_type
                         .as_ref()
                         .map(|cpp_type| {
-                            new_struct_with_bindings(&cpp_type, &element.bindings, component)
+                            new_struct_with_bindings(cpp_type, &element.bindings, component)
                         })
                         .unwrap_or_default();
                     format!(

--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -703,7 +703,7 @@ fn generate_component(
     } else {
         let item_fields = item_names
             .iter()
-            .map(|field_name| access_component_field_offset(&format_ident!("Self"), &field_name));
+            .map(|field_name| access_component_field_offset(&format_ident!("Self"), field_name));
         (
             Some(quote!(impl sixtyfps::re_exports::PinnedDrop for #inner_component_id {
                 fn drop(self: core::pin::Pin<&mut #inner_component_id>) {

--- a/sixtyfps_compiler/load_builtins.rs
+++ b/sixtyfps_compiler/load_builtins.rs
@@ -252,7 +252,7 @@ fn parse_annotation(key: &str, node: &SyntaxNode) -> Option<Option<String>> {
                 if comment.is_empty() {
                     return Some(None);
                 }
-                if let Some(comment) = comment.strip_prefix(":") {
+                if let Some(comment) = comment.strip_prefix(':') {
                     return Some(Some(comment.to_owned()));
                 }
             }

--- a/sixtyfps_compiler/passes/collect_structs.rs
+++ b/sixtyfps_compiler/passes/collect_structs.rs
@@ -81,7 +81,7 @@ fn visit_named_object(ty: &Type, visitor: &mut impl FnMut(&String, &Type)) {
         Type::Array(x) => visit_named_object(x, visitor),
         Type::Callback { return_type, args } => {
             if let Some(rt) = return_type {
-                visit_named_object(&rt, visitor);
+                visit_named_object(rt, visitor);
             }
             for a in args {
                 visit_named_object(a, visitor);

--- a/sixtyfps_compiler/passes/default_geometry.rs
+++ b/sixtyfps_compiler/passes/default_geometry.rs
@@ -32,7 +32,7 @@ use crate::{
 
 pub fn default_geometry(root_component: &Rc<Component>, diag: &mut BuildDiagnostics) {
     crate::object_tree::recurse_elem_including_sub_components(
-        &root_component,
+        root_component,
         &None,
         &mut |elem: &ElementRc, parent: &Option<ElementRc>| {
             fix_percent_size(elem, parent, "width", diag);

--- a/sixtyfps_compiler/passes/remove_aliases.rs
+++ b/sixtyfps_compiler/passes/remove_aliases.rs
@@ -108,7 +108,7 @@ pub fn remove_aliases(component: &Rc<Component>, diag: &mut BuildDiagnostics) {
     }
 
     // Do the replacements
-    visit_all_named_references(&component, &mut |nr: &mut NamedReference| {
+    visit_all_named_references(component, &mut |nr: &mut NamedReference| {
         if let Some(new) = aliases_to_remove.get(nr) {
             *nr = new.clone();
         }

--- a/sixtyfps_compiler/passes/remove_unused_properties.rs
+++ b/sixtyfps_compiler/passes/remove_unused_properties.rs
@@ -14,7 +14,7 @@ use std::collections::HashSet;
 
 pub fn remove_unused_properties(component: &Component) {
     crate::object_tree::recurse_elem_including_sub_components_no_borrow(
-        &component,
+        component,
         &(),
         &mut |elem, _| {
             let mut to_remove = HashSet::new();

--- a/sixtyfps_runtime/corelib/items/text.rs
+++ b/sixtyfps_runtime/corelib/items/text.rs
@@ -482,7 +482,7 @@ impl TextInput {
         window: &WindowRc,
     ) -> bool {
         let text = self.text();
-        if text.len() == 0 {
+        if text.is_empty() {
             return false;
         }
 

--- a/sixtyfps_runtime/corelib/model.rs
+++ b/sixtyfps_runtime/corelib/model.rs
@@ -687,6 +687,11 @@ impl<C: RepeatedComponent> Repeater<C> {
         self.inner.borrow().borrow().components.len()
     }
 
+    /// Return true if the Repeater is empty
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Returns a vector containing all components
     pub fn components_vec(&self) -> Vec<ComponentRc<C>> {
         self.inner.borrow().borrow().components.iter().flat_map(|x| x.1.clone()).collect()

--- a/sixtyfps_runtime/corelib/sharedvector.rs
+++ b/sixtyfps_runtime/corelib/sharedvector.rs
@@ -138,6 +138,11 @@ impl<T> SharedVector<T> {
         unsafe { self.inner.cast::<SharedVectorHeader>().as_ref().size }
     }
 
+    /// Return true if the SharedVector is empty
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Return a slice to the array
     pub fn as_slice(&self) -> &[T] {
         if self.len() == 0 {

--- a/sixtyfps_runtime/corelib/sharedvector.rs
+++ b/sixtyfps_runtime/corelib/sharedvector.rs
@@ -145,7 +145,7 @@ impl<T> SharedVector<T> {
 
     /// Return a slice to the array
     pub fn as_slice(&self) -> &[T] {
-        if self.len() == 0 {
+        if self.is_empty() {
             &[]
         } else {
             // Safety: When len > 0, we know that the pointer holds an array of the size of len

--- a/sixtyfps_runtime/corelib/string.rs
+++ b/sixtyfps_runtime/corelib/string.rs
@@ -41,6 +41,11 @@ impl SharedString {
         self.inner.header.header
     }
 
+    /// Return true if the String is empty
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Return a slice to the string
     pub fn as_str(&self) -> &str {
         unsafe {

--- a/sixtyfps_runtime/corelib/string.rs
+++ b/sixtyfps_runtime/corelib/string.rs
@@ -271,9 +271,15 @@ impl From<&String> for SharedString {
     }
 }
 
-impl Into<String> for SharedString {
-    fn into(self) -> String {
-        self.as_str().to_string()
+impl From<SharedString> for String {
+    fn from(s: SharedString) -> String {
+        s.as_str().to_string()
+    }
+}
+
+impl From<&SharedString> for String {
+    fn from(s: &SharedString) -> String {
+        s.as_str().to_string()
     }
 }
 

--- a/sixtyfps_runtime/corelib/window.rs
+++ b/sixtyfps_runtime/corelib/window.rs
@@ -242,12 +242,12 @@ impl Window {
             old_focus_item
                 .borrow()
                 .as_ref()
-                .focus_event(&crate::input::FocusEvent::FocusOut, &window);
+                .focus_event(&crate::input::FocusEvent::FocusOut, window);
         }
 
         *self.as_ref().focus_item.borrow_mut() = focus_item.downgrade();
 
-        focus_item.borrow().as_ref().focus_event(&crate::input::FocusEvent::FocusIn, &window);
+        focus_item.borrow().as_ref().focus_event(&crate::input::FocusEvent::FocusIn, window);
     }
 
     /// Sets the focus on the window to true or false, depending on the have_focus argument.
@@ -261,7 +261,7 @@ impl Window {
         };
 
         if let Some(focus_item) = self.as_ref().focus_item.borrow().upgrade() {
-            focus_item.borrow().as_ref().focus_event(&event, &window);
+            focus_item.borrow().as_ref().focus_event(&event, window);
         }
     }
 

--- a/sixtyfps_runtime/corelib/window.rs
+++ b/sixtyfps_runtime/corelib/window.rs
@@ -197,7 +197,7 @@ impl Window {
         self.mouse_input_state.set(crate::input::process_mouse_input(
             component,
             event,
-            &self.clone().into(),
+            &self.clone(),
             self.mouse_input_state.take(),
         ));
     }
@@ -210,7 +210,7 @@ impl Window {
     pub fn process_key_input(self: Rc<Self>, event: &KeyEvent) {
         let mut item = self.focus_item.borrow().clone();
         while let Some(focus_item) = item.upgrade() {
-            if focus_item.borrow().as_ref().key_event(event, &self.clone().into())
+            if focus_item.borrow().as_ref().key_event(event, &self.clone())
                 == crate::input::KeyEventResult::EventAccepted
             {
                 return;
@@ -236,7 +236,7 @@ impl Window {
     /// Sets the focus to the item pointed to by item_ptr. This will remove the focus from any
     /// currently focused item.
     pub fn set_focus_item(self: Rc<Self>, focus_item: &ItemRc) {
-        let window = &self.clone().into();
+        let window = &self.clone();
 
         if let Some(old_focus_item) = self.as_ref().focus_item.borrow().upgrade() {
             old_focus_item
@@ -253,7 +253,7 @@ impl Window {
     /// Sets the focus on the window to true or false, depending on the have_focus argument.
     /// This results in WindowFocusReceived and WindowFocusLost events.
     pub fn set_focus(self: Rc<Self>, have_focus: bool) {
-        let window = &self.clone().into();
+        let window = &self.clone();
         let event = if have_focus {
             crate::input::FocusEvent::WindowReceivedFocus
         } else {

--- a/sixtyfps_runtime/corelib/window.rs
+++ b/sixtyfps_runtime/corelib/window.rs
@@ -236,24 +236,21 @@ impl Window {
     /// Sets the focus to the item pointed to by item_ptr. This will remove the focus from any
     /// currently focused item.
     pub fn set_focus_item(self: Rc<Self>, focus_item: &ItemRc) {
-        let window = &self.clone();
-
         if let Some(old_focus_item) = self.as_ref().focus_item.borrow().upgrade() {
             old_focus_item
                 .borrow()
                 .as_ref()
-                .focus_event(&crate::input::FocusEvent::FocusOut, window);
+                .focus_event(&crate::input::FocusEvent::FocusOut, &self);
         }
 
         *self.as_ref().focus_item.borrow_mut() = focus_item.downgrade();
 
-        focus_item.borrow().as_ref().focus_event(&crate::input::FocusEvent::FocusIn, window);
+        focus_item.borrow().as_ref().focus_event(&crate::input::FocusEvent::FocusIn, &self);
     }
 
     /// Sets the focus on the window to true or false, depending on the have_focus argument.
     /// This results in WindowFocusReceived and WindowFocusLost events.
     pub fn set_focus(self: Rc<Self>, have_focus: bool) {
-        let window = &self.clone();
         let event = if have_focus {
             crate::input::FocusEvent::WindowReceivedFocus
         } else {
@@ -261,7 +258,7 @@ impl Window {
         };
 
         if let Some(focus_item) = self.as_ref().focus_item.borrow().upgrade() {
-            focus_item.borrow().as_ref().focus_event(&event, window);
+            focus_item.borrow().as_ref().focus_event(&event, &self);
         }
     }
 

--- a/sixtyfps_runtime/interpreter/api.rs
+++ b/sixtyfps_runtime/interpreter/api.rs
@@ -765,7 +765,7 @@ impl ComponentInstance {
     pub fn invoke_callback(&self, name: &str, args: &[Value]) -> Result<Value, CallCallbackError> {
         generativity::make_guard!(guard);
         let comp = self.inner.unerase(guard);
-        comp.description().invoke_callback(comp.borrow(), name, &args).map_err(|()| todo!())
+        comp.description().invoke_callback(comp.borrow(), name, args).map_err(|()| todo!())
     }
 
     /// Marks the window of this component to be shown on the screen. This registers
@@ -897,7 +897,7 @@ pub mod testing {
             &vtable::VRc::into_dyn(comp.inner.clone()),
             x,
             y,
-            &comp.window().window_handle(),
+            comp.window().window_handle(),
         );
     }
     /// Wrapper around [`sixtyfps_corelib::tests::send_keyboard_string_sequence`]
@@ -908,7 +908,7 @@ pub mod testing {
         sixtyfps_corelib::tests::send_keyboard_string_sequence(
             &string,
             Default::default(),
-            &comp.window().window_handle(),
+            comp.window().window_handle(),
         );
     }
 }

--- a/sixtyfps_runtime/interpreter/api.rs
+++ b/sixtyfps_runtime/interpreter/api.rs
@@ -765,7 +765,7 @@ impl ComponentInstance {
     pub fn invoke_callback(&self, name: &str, args: &[Value]) -> Result<Value, CallCallbackError> {
         generativity::make_guard!(guard);
         let comp = self.inner.unerase(guard);
-        Ok(comp.description().invoke_callback(comp.borrow(), name, &args).map_err(|()| todo!())?)
+        comp.description().invoke_callback(comp.borrow(), name, &args).map_err(|()| todo!())
     }
 
     /// Marks the window of this component to be shown on the screen. This registers

--- a/sixtyfps_runtime/interpreter/dynamic_component.rs
+++ b/sixtyfps_runtime/interpreter/dynamic_component.rs
@@ -1106,7 +1106,7 @@ pub fn instantiate(
                 let mut e = Some(&binding.expression);
                 while let Some(Expression::TwoWayBinding(nr, next)) = &e {
                     // Safety: The compiler must have ensured that the properties exist and are of the same type
-                    prop_info.link_two_ways(item, get_property_ptr(&nr, instance_ref));
+                    prop_info.link_two_ways(item, get_property_ptr(nr, instance_ref));
                     e = next.as_deref();
                 }
                 if let Some(e) = e {
@@ -1143,7 +1143,7 @@ pub fn instantiate(
                     let mut e = Some(&binding.expression);
                     while let Some(Expression::TwoWayBinding(nr, next)) = &e {
                         // Safety: The compiler must have ensured that the properties exist and are of the same type
-                        prop_rtti.link_two_ways(item, get_property_ptr(&nr, instance_ref));
+                        prop_rtti.link_two_ways(item, get_property_ptr(nr, instance_ref));
                         e = next.as_deref();
                     }
                     if let Some(e) = e {

--- a/sixtyfps_runtime/interpreter/dynamic_component.rs
+++ b/sixtyfps_runtime/interpreter/dynamic_component.rs
@@ -1367,7 +1367,7 @@ unsafe extern "C" fn parent_item(component: ComponentRefPin, index: usize, resul
             .original
             .parent_element
             .upgrade()
-            .and_then(|e| e.borrow().item_index.get().map(|x| *x));
+            .and_then(|e| e.borrow().item_index.get().cloned());
         if let (Some(parent_offset), Some(parent_index)) =
             (instance_ref.component_type.parent_component_offset, parent_item_index)
         {

--- a/sixtyfps_runtime/interpreter/dynamic_component.rs
+++ b/sixtyfps_runtime/interpreter/dynamic_component.rs
@@ -334,7 +334,7 @@ impl<'id> ComponentDescription<'id> {
             sixtyfps_rendering_backend_default::backend();
             sixtyfps_rendering_backend_gl::create_gl_window_with_canvas_id(canvas_id)
         };
-        self.create_with_existing_window(&window.into())
+        self.create_with_existing_window(&window)
     }
 
     #[doc(hidden)]
@@ -536,7 +536,7 @@ extern "C" fn visit_children_item(
     sixtyfps_corelib::item_tree::visit_item_tree(
         instance_ref.instance,
         &vtable::VRc::into_dyn(comp_rc),
-        instance_ref.component_type.item_tree.as_slice().into(),
+        instance_ref.component_type.item_tree.as_slice(),
         index,
         order,
         v,
@@ -998,7 +998,7 @@ pub fn instantiate(
     if !component_type.original.is_global() {
         sixtyfps_corelib::component::init_component_items(
             instance_ref.instance,
-            instance_ref.component_type.item_tree.as_slice().into(),
+            instance_ref.component_type.item_tree.as_slice(),
             eval::window_ref(instance_ref).unwrap(),
         );
     }

--- a/sixtyfps_runtime/interpreter/dynamic_component.rs
+++ b/sixtyfps_runtime/interpreter/dynamic_component.rs
@@ -963,7 +963,7 @@ pub fn animation_for_property(
                             );
                         }
                     }
-                    return Default::default();
+                    Default::default()
                 },
             ))
         }

--- a/sixtyfps_runtime/interpreter/eval_layout.rs
+++ b/sixtyfps_runtime/interpreter/eval_layout.rs
@@ -218,7 +218,7 @@ fn box_layout_data(
                 let instance = crate::dynamic_component::instantiate(
                     rep.1.clone(),
                     Some(component.borrow()),
-                    Some(&window),
+                    Some(window),
                 );
                 instance.run_setup_code();
                 instance
@@ -276,7 +276,7 @@ fn repeater_indices(children: &[ElementRc], component: InstanceRef) -> Vec<u32> 
                 let instance = crate::dynamic_component::instantiate(
                     rep.1.clone(),
                     Some(component.borrow()),
-                    Some(&window),
+                    Some(window),
                 );
                 instance.run_setup_code();
                 instance

--- a/sixtyfps_runtime/interpreter/eval_layout.rs
+++ b/sixtyfps_runtime/interpreter/eval_layout.rs
@@ -235,7 +235,7 @@ fn box_layout_data(
             );
         } else {
             let mut layout_info =
-                get_layout_info(&cell.element, component, &window.clone().into(), orientation);
+                get_layout_info(&cell.element, component, &window.clone(), orientation);
             fill_layout_info_constraints(
                 &mut layout_info,
                 &cell.constraints,

--- a/sixtyfps_runtime/rendering_backends/default/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/default/lib.rs
@@ -59,7 +59,7 @@ pub fn backend() -> &'static dyn sixtyfps_corelib::backend::Backend {
             // If Qt is not available always fallback to Gl
             return Box::new(sixtyfps_rendering_backend_gl::Backend);
         }
-        return Box::new(default_backend::Backend);
+        Box::new(default_backend::Backend)
     })
 }
 

--- a/sixtyfps_runtime/rendering_backends/gl/eventloop.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/eventloop.rs
@@ -63,7 +63,7 @@ impl<'a> EventLoopInterface for RunningEventLoop<'a> {
     }
 
     fn event_loop_proxy(&self) -> &winit::event_loop::EventLoopProxy<CustomEvent> {
-        &self.event_loop_proxy
+        self.event_loop_proxy
     }
 }
 
@@ -273,7 +273,7 @@ pub fn run(quit_behavior: sixtyfps_corelib::backend::EventLoopQuitBehavior) {
                     corelib::animations::update_animations();
                     ALL_WINDOWS.with(|windows| {
                         if let Some(Some(window)) =
-                            windows.borrow().get(&window_id).map(|weakref| weakref.upgrade())
+                            windows.borrow().get(window_id).map(|weakref| weakref.upgrade())
                         {
                             let ev = match state {
                                 winit::event::ElementState::Pressed => {
@@ -297,7 +297,7 @@ pub fn run(quit_behavior: sixtyfps_corelib::backend::EventLoopQuitBehavior) {
                     corelib::animations::update_animations();
                     ALL_WINDOWS.with(|windows| {
                         if let Some(Some(window)) =
-                            windows.borrow().get(&window_id).map(|weakref| weakref.upgrade())
+                            windows.borrow().get(window_id).map(|weakref| weakref.upgrade())
                         {
                             let location = touch.location.to_logical(window.scale_factor() as f64);
                             let pos = euclid::point2(location.x, location.y);
@@ -360,7 +360,7 @@ pub fn run(quit_behavior: sixtyfps_corelib::backend::EventLoopQuitBehavior) {
                     corelib::animations::update_animations();
                     ALL_WINDOWS.with(|windows| {
                         if let Some(Some(window)) =
-                            windows.borrow().get(&window_id).map(|weakref| weakref.upgrade())
+                            windows.borrow().get(window_id).map(|weakref| weakref.upgrade())
                         {
                             let delta = match delta {
                                 winit::event::MouseScrollDelta::LineDelta(lx, ly) => {
@@ -385,7 +385,7 @@ pub fn run(quit_behavior: sixtyfps_corelib::backend::EventLoopQuitBehavior) {
                     corelib::animations::update_animations();
                     ALL_WINDOWS.with(|windows| {
                         if let Some(Some(window)) =
-                            windows.borrow().get(&window_id).map(|weakref| weakref.upgrade())
+                            windows.borrow().get(window_id).map(|weakref| weakref.upgrade())
                         {
                             if let Some(key_code) =
                                 input.virtual_keycode.and_then(|virtual_keycode| {
@@ -444,7 +444,7 @@ pub fn run(quit_behavior: sixtyfps_corelib::backend::EventLoopQuitBehavior) {
                         corelib::animations::update_animations();
                         ALL_WINDOWS.with(|windows| {
                             if let Some(Some(window)) =
-                                windows.borrow().get(&window_id).map(|weakref| weakref.upgrade())
+                                windows.borrow().get(window_id).map(|weakref| weakref.upgrade())
                             {
                                 let modifiers = window.current_keyboard_modifiers();
 
@@ -468,7 +468,7 @@ pub fn run(quit_behavior: sixtyfps_corelib::backend::EventLoopQuitBehavior) {
                 } => {
                     ALL_WINDOWS.with(|windows| {
                         if let Some(Some(window)) =
-                            windows.borrow().get(&window_id).map(|weakref| weakref.upgrade())
+                            windows.borrow().get(window_id).map(|weakref| weakref.upgrade())
                         {
                             // To provide an easier cross-platform behavior, we map the command key to control
                             // on macOS, and control to meta.
@@ -493,7 +493,7 @@ pub fn run(quit_behavior: sixtyfps_corelib::backend::EventLoopQuitBehavior) {
                 } => {
                     ALL_WINDOWS.with(|windows| {
                         if let Some(Some(window)) =
-                            windows.borrow().get(&window_id).map(|weakref| weakref.upgrade())
+                            windows.borrow().get(window_id).map(|weakref| weakref.upgrade())
                         {
                             window.self_weak.upgrade().unwrap().set_focus(have_focus);
                         }

--- a/sixtyfps_runtime/rendering_backends/gl/graphics_window.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/graphics_window.rs
@@ -581,7 +581,7 @@ impl GraphicsWindowBackendState {
             GraphicsWindowBackendState::Unmapped => panic!(
                 "internal error: tried to access window functions that require a mapped window"
             ),
-            GraphicsWindowBackendState::Mapped(mw) => &mw,
+            GraphicsWindowBackendState::Mapped(mw) => mw,
         }
     }
 }

--- a/sixtyfps_runtime/rendering_backends/gl/graphics_window.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/graphics_window.rs
@@ -348,7 +348,7 @@ impl GraphicsWindow {
         self.mouse_input_state.set(corelib::input::process_mouse_input(
             component,
             event,
-            &self.self_weak.upgrade().unwrap().into(),
+            &self.self_weak.upgrade().unwrap(),
             self.mouse_input_state.take(),
         ));
 

--- a/sixtyfps_runtime/rendering_backends/gl/images.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/images.rs
@@ -296,7 +296,7 @@ impl CachedImage {
                 Some(Self::new_on_gpu(canvas, image_id))
             }
             #[cfg(feature = "svg")]
-            ImageData::Svg(svg_tree) => match super::svg::render(&svg_tree, target_size) {
+            ImageData::Svg(svg_tree) => match super::svg::render(svg_tree, target_size) {
                 Ok(rendered_svg_image) => Some(Self::new_on_cpu(rendered_svg_image)),
                 Err(err) => {
                     eprintln!("Error rendering SVG: {}", err);
@@ -352,7 +352,7 @@ impl CachedImage {
         .expect("internal error: Cannot filter non-GPU images");
 
         let filtered_image = Self::new_empty_on_gpu(
-            &canvas,
+            canvas,
             size.width.ceil() as usize,
             size.height.ceil() as usize,
         )

--- a/sixtyfps_runtime/rendering_backends/gl/images.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/images.rs
@@ -96,7 +96,7 @@ enum ImageData {
     Texture(Texture),
     DecodedImage(image::DynamicImage),
     #[cfg(feature = "svg")]
-    SVG(usvg::Tree),
+    Svg(usvg::Tree),
     #[cfg(target_arch = "wasm32")]
     HTMLImage(HTMLImage),
 }
@@ -111,7 +111,7 @@ impl std::fmt::Debug for ImageData {
             ImageData::DecodedImage(i) => {
                 write!(f, "ImageData::DecodedImage({}x{})", i.width(), i.height())
             }
-            ImageData::SVG(_) => {
+            ImageData::Svg(_) => {
                 write!(f, "ImageData::SVG(...)")
             }
             #[cfg(target_arch = "wasm32")]
@@ -157,7 +157,7 @@ impl CachedImage {
 
     #[cfg(feature = "svg")]
     fn new_on_cpu_svg(tree: usvg::Tree) -> Self {
-        Self(RefCell::new(ImageData::SVG(tree)))
+        Self(RefCell::new(ImageData::Svg(tree)))
     }
 
     pub fn new_from_resource(resource: &ImageInner) -> Option<Self> {
@@ -296,7 +296,7 @@ impl CachedImage {
                 Some(Self::new_on_gpu(canvas, image_id))
             }
             #[cfg(feature = "svg")]
-            ImageData::SVG(svg_tree) => match super::svg::render(&svg_tree, target_size) {
+            ImageData::Svg(svg_tree) => match super::svg::render(&svg_tree, target_size) {
                 Ok(rendered_svg_image) => Some(Self::new_on_cpu(rendered_svg_image)),
                 Err(err) => {
                     eprintln!("Error rendering SVG: {}", err);
@@ -325,7 +325,7 @@ impl CachedImage {
             }
 
             #[cfg(feature = "svg")]
-            ImageData::SVG(tree) => {
+            ImageData::Svg(tree) => {
                 let size = tree.svg_node().size.to_screen_size();
                 Some([size.width() as f32, size.height() as f32].into())
             }

--- a/sixtyfps_runtime/rendering_backends/gl/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/lib.rs
@@ -1154,7 +1154,7 @@ impl ItemRenderer for GLItemRenderer {
             cached_image
         });
         let image_id = match cache_entry {
-            Some(ItemGraphicsCacheEntry::Image(image)) => image.ensure_uploaded_to_gpu(&self),
+            Some(ItemGraphicsCacheEntry::Image(image)) => image.ensure_uploaded_to_gpu(self),
             Some(ItemGraphicsCacheEntry::ColorizedImage { .. }) => unreachable!(),
             Some(ItemGraphicsCacheEntry::Font(_)) => unreachable!(),
             None => return,
@@ -1267,7 +1267,7 @@ impl GLItemRenderer {
             None => return original_cache_entry,
         };
 
-        let image_id = original_image.ensure_uploaded_to_gpu(&self);
+        let image_id = original_image.ensure_uploaded_to_gpu(self);
         let colorized_image = self
             .shared_data
             .canvas
@@ -1352,12 +1352,12 @@ impl GLItemRenderer {
                         .lookup_image_in_cache_or_create(cache_key, || {
                             crate::IMAGE_CACHE
                                 .with(|global_cache| {
-                                    global_cache.borrow_mut().load_image_resource(&image_inner)
+                                    global_cache.borrow_mut().load_image_resource(image_inner)
                                 })
                                 .and_then(|image| {
                                     image
                                         .upload_to_gpu(
-                                            &self, // The condition at the entry of the function ensures that width/height are positive
+                                            self, // The condition at the entry of the function ensures that width/height are positive
                                             [
                                                 (target_width.get() * self.scale_factor) as u32,
                                                 (target_height.get() * self.scale_factor) as u32,
@@ -1394,7 +1394,7 @@ impl GLItemRenderer {
             break cached_image.as_image().clone();
         };
 
-        let image_id = cached_image.ensure_uploaded_to_gpu(&self);
+        let image_id = cached_image.ensure_uploaded_to_gpu(self);
         let image_size = cached_image.size().unwrap_or_default();
 
         let (source_width, source_height) = if source_clip_rect.is_empty() {

--- a/sixtyfps_runtime/rendering_backends/gl/svg.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/svg.rs
@@ -33,7 +33,7 @@ pub fn render(
     let skya_buffer =
         tiny_skia::PixmapMut::from_bytes(buffer.as_mut_slice(), size.width(), size.height())
             .ok_or(usvg::Error::InvalidSize)?;
-    resvg::render(&tree, fit, skya_buffer).ok_or(usvg::Error::InvalidSize)?;
+    resvg::render(tree, fit, skya_buffer).ok_or(usvg::Error::InvalidSize)?;
     Ok(image::DynamicImage::ImageRgba8(
         image::RgbaImage::from_raw(size.width(), size.height(), buffer)
             .ok_or(usvg::Error::InvalidSize)?,

--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -80,7 +80,7 @@ fn main() -> std::io::Result<()> {
             write!(f, " {}", resource)?;
         }
 
-        writeln!(f, "")?;
+        writeln!(f)?;
     }
     diag.print_warnings_and_exit_on_error();
     Ok(())

--- a/tools/lsp/completion.rs
+++ b/tools/lsp/completion.rs
@@ -112,7 +112,7 @@ pub(crate) fn completion_at(
         SyntaxKind::Type | SyntaxKind::ArrayType | SyntaxKind::ObjectType | SyntaxKind::ReturnType
     ) {
         return resolve_type_scope(token, document_cache);
-    } else if let Some(_) = syntax_nodes::PropertyDeclaration::new(node.clone()) {
+    } else if syntax_nodes::PropertyDeclaration::new(node.clone()).is_some() {
         if token.kind() == SyntaxKind::LAngle {
             return resolve_type_scope(token, document_cache);
         }

--- a/tools/lsp/completion.rs
+++ b/tools/lsp/completion.rs
@@ -206,7 +206,7 @@ pub(crate) fn completion_at(
             _ => (),
         }
     }
-    return None;
+    None
 }
 
 fn with_insert_text(

--- a/tools/lsp/completion.rs
+++ b/tools/lsp/completion.rs
@@ -298,7 +298,7 @@ fn resolve_element_scope(
 fn resolve_expression_scope(lookup_context: &LookupCtx) -> Option<Vec<CompletionItem>> {
     let mut r = Vec::new();
     let global = sixtyfps_compilerlib::lookup::global_lookup();
-    global.for_each_entry(&lookup_context, &mut |str, expr| -> Option<()> {
+    global.for_each_entry(lookup_context, &mut |str, expr| -> Option<()> {
         r.push(completion_item_from_expression(str, expr));
         None
     });

--- a/tools/lsp/completion.rs
+++ b/tools/lsp/completion.rs
@@ -357,7 +357,7 @@ fn complete_path_in_string(base: &Path, text: &str, offset: u32) -> Option<Vec<C
     if offset as usize > text.len() || offset == 0 {
         return None;
     }
-    let mut text = text.strip_prefix("\"")?;
+    let mut text = text.strip_prefix('\"')?;
     text = &text[..(offset - 1) as usize];
     let path = if let Some(last_slash) = text.rfind('/') {
         base.parent()?.join(Path::new(&text[..last_slash]))

--- a/tools/lsp/goto.rs
+++ b/tools/lsp/goto.rs
@@ -122,7 +122,7 @@ pub fn goto_definition(
             }) {
                 return goto_node(document_cache, &p);
             }
-            let n = find_property_declaration_in_base(&document_cache, element, prop_name)?;
+            let n = find_property_declaration_in_base(document_cache, element, prop_name)?;
             return goto_node(document_cache, &n);
         } else if let Some(n) = syntax_nodes::TwoWayBinding::new(node.clone()) {
             if token.kind() != SyntaxKind::Identifier {
@@ -140,7 +140,7 @@ pub fn goto_definition(
             }) {
                 return goto_node(document_cache, &p);
             }
-            let n = find_property_declaration_in_base(&document_cache, element, prop_name)?;
+            let n = find_property_declaration_in_base(document_cache, element, prop_name)?;
             return goto_node(document_cache, &n);
         } else if let Some(n) = syntax_nodes::CallbackConnection::new(node.clone()) {
             if token.kind() != SyntaxKind::Identifier {
@@ -158,7 +158,7 @@ pub fn goto_definition(
             }) {
                 return goto_node(document_cache, &p);
             }
-            let n = find_property_declaration_in_base(&document_cache, element, prop_name)?;
+            let n = find_property_declaration_in_base(document_cache, element, prop_name)?;
             return goto_node(document_cache, &n);
         }
         node = node.parent()?;

--- a/tools/lsp/goto.rs
+++ b/tools/lsp/goto.rs
@@ -106,7 +106,7 @@ pub fn goto_definition(
             let doc = document_cache.documents.get_document(&import_file)?;
             let doc_node = doc.node.clone()?;
             return goto_node(document_cache, &*doc_node);
-        } else if let Some(_) = syntax_nodes::BindingExpression::new(node.clone()) {
+        } else if syntax_nodes::BindingExpression::new(node.clone()).is_some() {
             // don't fallback to the Binding
             return None;
         } else if let Some(n) = syntax_nodes::Binding::new(node.clone()) {

--- a/tools/lsp/goto.rs
+++ b/tools/lsp/goto.rs
@@ -100,7 +100,7 @@ pub fn goto_definition(
                 .source_file
                 .path()
                 .parent()
-                .unwrap_or(Path::new("/"))
+                .unwrap_or_else(|| Path::new("/"))
                 .join(n.child_text(SyntaxKind::StringLiteral)?.trim_matches('\"'));
             let import_file = dunce::canonicalize(&import_file).unwrap_or(import_file);
             let doc = document_cache.documents.get_document(&import_file)?;

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -363,7 +363,7 @@ fn show_preview_command(
     let component = params.get(1).and_then(|v| v.as_str()).map(|v| v.to_string());
     preview::load_preview(
         connection.sender.clone(),
-        preview::PreviewComponent { path: path_canon.into(), component },
+        preview::PreviewComponent { path: path_canon, component },
         preview::PostLoadBehavior::ShowAfterLoad,
     );
     Ok(())

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -531,8 +531,8 @@ fn get_document_color(
                 let shift = |s: u32| -> f32 { ((col >> s) & 0xff) as f32 / 255. };
                 result.push(ColorInformation {
                     range: Range::new(
-                        document_cache.byte_offset_to_position(range.start().into(), &uri)?,
-                        document_cache.byte_offset_to_position(range.end().into(), &uri)?,
+                        document_cache.byte_offset_to_position(range.start().into(), uri)?,
+                        document_cache.byte_offset_to_position(range.end().into(), uri)?,
                     ),
                     color: Color {
                         alpha: shift(24),
@@ -569,8 +569,8 @@ fn get_document_symbols(
     let mut make_range = |node: &SyntaxNode| {
         let r = node.text_range();
         Some(Range::new(
-            document_cache.byte_offset_to_position(r.start().into(), &uri)?,
-            document_cache.byte_offset_to_position(r.end().into(), &uri)?,
+            document_cache.byte_offset_to_position(r.start().into(), uri)?,
+            document_cache.byte_offset_to_position(r.end().into(), uri)?,
         ))
     };
 
@@ -616,8 +616,8 @@ fn get_code_lenses(
     let mut make_range = |node: &SyntaxNode| {
         let r = node.text_range();
         Some(Range::new(
-            document_cache.byte_offset_to_position(r.start().into(), &uri)?,
-            document_cache.byte_offset_to_position(r.end().into(), &uri)?,
+            document_cache.byte_offset_to_position(r.start().into(), uri)?,
+            document_cache.byte_offset_to_position(r.end().into(), uri)?,
         ))
     };
 

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -240,7 +240,7 @@ async fn reload_preview(
             let mut preview_state = preview_state.borrow_mut();
             if let Some(handle) = preview_state.handle.take() {
                 let window = handle.window();
-                let handle = compiled.create_with_existing_window(&window);
+                let handle = compiled.create_with_existing_window(window);
                 match post_load_behavior {
                     PostLoadBehavior::ShowAfterLoad => handle.show(),
                     PostLoadBehavior::DoNothing => {}
@@ -269,7 +269,7 @@ fn notify_diagnostics(
             continue;
         }
         let uri = lsp_types::Url::from_file_path(d.source_file().unwrap()).unwrap();
-        lsp_diags.entry(uri).or_default().push(crate::util::to_lsp_diag(&d));
+        lsp_diags.entry(uri).or_default().push(crate::util::to_lsp_diag(d));
     }
 
     for (uri, diagnostics) in lsp_diags {

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -188,7 +188,7 @@ pub fn set_contents(path: &Path, content: String) {
 /// In any was, register it as a dependency
 fn get_file_from_cache(path: PathBuf) -> Option<String> {
     let mut cache = CONTENT_CACHE.get_or_init(Default::default).lock().unwrap();
-    let r = cache.source_code.get(&path).map(|r| r.clone());
+    let r = cache.source_code.get(&path).cloned();
     cache.dependency.insert(path);
     r
 }

--- a/tools/syntax_updater/main.rs
+++ b/tools/syntax_updater/main.rs
@@ -160,7 +160,7 @@ fn process_file(
     }
 
     let mut diag = BuildDiagnostics::default();
-    let syntax_node = sixtyfps_compilerlib::parser::parse(source.clone(), Some(&path), &mut diag);
+    let syntax_node = sixtyfps_compilerlib::parser::parse(source.clone(), Some(path), &mut diag);
     let len = syntax_node.node.text_range().end().into();
     visit_node(syntax_node, &mut file, &mut State::default(), args)?;
     if diag.has_error() {
@@ -202,12 +202,12 @@ fn visit_node(
         _ => (),
     }
 
-    if fold_node(&node, file, &mut state, &args)? {
+    if fold_node(&node, file, &mut state, args)? {
         return Ok(());
     }
     for n in node.children_with_tokens() {
         match n {
-            NodeOrToken::Node(n) => visit_node(n, file, &mut state, &args)?,
+            NodeOrToken::Node(n) => visit_node(n, file, &mut state, args)?,
             NodeOrToken::Token(t) => fold_token(t, file, &mut state)?,
         };
     }

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -53,7 +53,7 @@ fn main() -> Result<()> {
     let mut compiler = init_compiler(&args, fswatcher);
 
     let c = spin_on::spin_on(compiler.build_from_path(args.path));
-    sixtyfps_interpreter::print_diagnostics(&compiler.diagnostics());
+    sixtyfps_interpreter::print_diagnostics(compiler.diagnostics());
 
     let c = match c {
         Some(c) => c,
@@ -126,14 +126,14 @@ fn start_fswatch_thread(args: Cli) -> Result<Arc<Mutex<notify::RecommendedWatche
 async fn reload(args: Cli, fswatcher: Arc<Mutex<notify::RecommendedWatcher>>) {
     let mut compiler = init_compiler(&args, Some(fswatcher));
     let c = compiler.build_from_path(&args.path).await;
-    sixtyfps_interpreter::print_diagnostics(&compiler.diagnostics());
+    sixtyfps_interpreter::print_diagnostics(compiler.diagnostics());
 
     if let Some(c) = c {
         CURRENT_INSTANCE.with(|current| {
             let mut current = current.borrow_mut();
             if let Some(handle) = current.take() {
                 let window = handle.window();
-                current.replace(c.create_with_existing_window(&window));
+                current.replace(c.create_with_existing_window(window));
             } else {
                 let handle = c.create();
                 handle.show();


### PR DESCRIPTION
More janitor commits, most are pretty small and simple.

`Remove unnecessary clone() calls` is the only not automatic change in the batch: It removes some code that seems unnecessary after earlier janitorial changes. The clone() is marked as useless, removing that makes the variable unnecessary.

With this applied and #388 applied and ignoring `clippy::vtable_address_comparisons` I got down to 97 warnings (72 of them being unique) in all of sixtyfps. The remaining ones are a bit harder to fix than this set.