### PR TITLE
Fix SharedVector creation from iterators with default size hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
  - Support of `*=` and `/=` on types with unit such as length.
  - Proper compilation error when using a self assignment operator on an invalid type instead of a panic
  - Angle conversion for values specified in radians, gradians and turns
+ - SharedVector was sometimes not allocating big enough storage.
 
 ## [0.1.0] - 2021-06-30
 


### PR DESCRIPTION
* In capacity_for_grow, don't compare the number of elements
  (current_cap) with the size of an element in bytes.
  That fixes the capacity not growing.
* When re-allocating due to growth and copying elements from the old
  inner to the new inner, make sure to copy all old elements from the beginning,
  not only the last element repeatedly.