### PR TITLE
Normalize identifiers to `-` instead of `_`

### DIFF
--- a/api/sixtyfps-cpp/tests/interpreter.cpp
+++ b/api/sixtyfps-cpp/tests/interpreter.cpp
@@ -184,7 +184,7 @@ SCENARIO("Struct API")
     for (auto [k, value] : struc) {
         REQUIRE(count == 0);
         count++;
-        REQUIRE(k == "field_a");
+        REQUIRE(k == "field-a");
         REQUIRE(value.to_string().value() == "Hallo");
     }
 
@@ -195,8 +195,8 @@ SCENARIO("Struct API")
 
     REQUIRE(map
             == std::map<std::string, sixtyfps::SharedString> {
-                    { "field_a", sixtyfps::SharedString("Hallo") },
-                    { "field_b", sixtyfps::SharedString("World") } });
+                    { "field-a", sixtyfps::SharedString("Hallo") },
+                    { "field-b", sixtyfps::SharedString("World") } });
 }
 
 SCENARIO("Struct Iterator Constructor")
@@ -244,9 +244,9 @@ SCENARIO("Struct field iteration")
     REQUIRE(it != end);
 
     auto check_valid_entry = [](const auto &key, const auto &value) -> bool {
-        if (key == "field_a")
+        if (key == "field-a")
             return value == Value(true);
-        if (key == "field_b")
+        if (key == "field-b")
             return value == Value(42.0);
         return false;
     };
@@ -362,17 +362,17 @@ SCENARIO("Invoke callback")
     SECTION("valid")
     {
         auto result = compiler.build_from_source(
-                "export Dummy := Rectangle { callback foo(string, int) -> string; }", "");
+                "export Dummy := Rectangle { callback some_callback(string, int) -> string; }", "");
         REQUIRE(result.has_value());
         auto instance = result->create();
-        REQUIRE(instance->set_callback("foo", [](auto args) {
+        REQUIRE(instance->set_callback("some_callback", [](auto args) {
             SharedString arg1 = *args[0].to_string();
             int arg2 = int(*args[1].to_number());
             std::string res = std::string(arg1) + ":" + std::to_string(arg2);
             return Value(SharedString(res));
         }));
         Value args[] = { SharedString("Hello"), 42. };
-        auto res = instance->invoke_callback("foo", Slice<Value> { args, 2 });
+        auto res = instance->invoke_callback("some_callback", Slice<Value> { args, 2 });
         REQUIRE(res.has_value());
         REQUIRE(*res->to_string() == SharedString("Hello:42"));
     }
@@ -434,13 +434,13 @@ SCENARIO("Angle between .60 and C++")
     ComponentCompiler compiler;
 
     auto result = compiler.build_from_source(
-            "export Dummy := Rectangle { property <angle> angle: 0.25turn;  property <bool> test: angle == 0.5turn; }", "");
+            "export Dummy := Rectangle { property <angle> the_angle: 0.25turn;  property <bool> test: the_angle == 0.5turn; }", "");
     REQUIRE(result.has_value());
     auto instance = result->create();
 
     SECTION("Read property")
     {
-        auto angle_value = instance->get_property("angle");
+        auto angle_value = instance->get_property("the-angle");
         REQUIRE(angle_value.has_value());
         REQUIRE(angle_value->type() == Value::Type::Number);
         auto angle = angle_value->to_number();
@@ -450,9 +450,9 @@ SCENARIO("Angle between .60 and C++")
     SECTION("Write property")
     {
         REQUIRE(!*instance->get_property("test")->to_bool());
-        bool ok = instance->set_property("angle", 180.);
+        bool ok = instance->set_property("the_angle", 180.);
         REQUIRE(ok);
-        REQUIRE(*instance->get_property("angle")->to_number() == 180);
+        REQUIRE(*instance->get_property("the_angle")->to_number() == 180);
         REQUIRE(*instance->get_property("test")->to_bool());
     }
 }

--- a/api/sixtyfps-node/lib/index.ts
+++ b/api/sixtyfps-node/lib/index.ts
@@ -77,18 +77,18 @@ interface Callback {
 require.extensions['.60'] =
     function (module, filename) {
         var c = native.load(filename);
-        module.exports[c.name().replaceAll('-', '_')] = function (init_properties: any) {
+        module.exports[c.name().replace(/-/g, '_')] = function (init_properties: any) {
             let comp = c.create(init_properties);
             let ret = new Component(comp);
             c.properties().forEach((x: string) => {
-                Object.defineProperty(ret, x.replaceAll('-', '_'), {
+                Object.defineProperty(ret, x.replace(/-/g, '_'), {
                     get() { return comp.get_property(x); },
                     set(newValue) { comp.set_property(x, newValue); },
                     enumerable: true,
                 })
             });
             c.callbacks().forEach((x: string) => {
-                Object.defineProperty(ret, x.replaceAll('-', '_'), {
+                Object.defineProperty(ret, x.replace(/-/g, '_'), {
                     get() {
                         let callback = function () { return comp.invoke_callback(x, [...arguments]); } as Callback;
                         callback.setHandler = function (callback) { comp.connect_callback(x, callback) };

--- a/api/sixtyfps-node/lib/index.ts
+++ b/api/sixtyfps-node/lib/index.ts
@@ -77,18 +77,18 @@ interface Callback {
 require.extensions['.60'] =
     function (module, filename) {
         var c = native.load(filename);
-        module.exports[c.name()] = function (init_properties: any) {
+        module.exports[c.name().replaceAll('-', '_')] = function (init_properties: any) {
             let comp = c.create(init_properties);
             let ret = new Component(comp);
             c.properties().forEach((x: string) => {
-                Object.defineProperty(ret, x, {
+                Object.defineProperty(ret, x.replaceAll('-', '_'), {
                     get() { return comp.get_property(x); },
                     set(newValue) { comp.set_property(x, newValue); },
                     enumerable: true,
                 })
             });
             c.callbacks().forEach((x: string) => {
-                Object.defineProperty(ret, x, {
+                Object.defineProperty(ret, x.replaceAll('-', '_'), {
                     get() {
                         let callback = function () { return comp.invoke_callback(x, [...arguments]); } as Callback;
                         callback.setHandler = function (callback) { comp.connect_callback(x, callback) };

--- a/api/sixtyfps-node/native/lib.rs
+++ b/api/sixtyfps-node/native/lib.rs
@@ -119,7 +119,7 @@ fn create<'cx>(
         let properties =
             component_type.properties_and_callbacks().collect::<std::collections::HashMap<_, _>>();
         for x in args.get_own_property_names(cx)?.to_vec(cx)? {
-            let prop_name = x.to_string(cx)?.value();
+            let prop_name = x.to_string(cx)?.value().replace('_', "-");
             let value = args.get(cx, x)?;
             let ty = properties
                 .get(&prop_name)
@@ -212,7 +212,7 @@ fn to_eval_value<'cx>(
                         Ok((
                             pro_name.clone(),
                             to_eval_value(
-                                obj.get(cx, pro_name.as_str())?,
+                                obj.get(cx, pro_name.replace('-', "_").as_str())?,
                                 pro_ty.clone(),
                                 cx,
                                 persistent_context,
@@ -271,7 +271,7 @@ fn to_js_value<'cx>(
             let js_object = JsObject::new(cx);
             for (k, e) in o.iter() {
                 let v = to_js_value(e.clone(), cx)?;
-                js_object.set(cx, k, v)?;
+                js_object.set(cx, k.replace('-', "_").as_str(), v)?;
             }
             js_object.as_value(cx)
         }

--- a/docs/builtin_elements.md
+++ b/docs/builtin_elements.md
@@ -7,11 +7,11 @@ These properties are valid on all visible items
 * **`x`** and **`y`** (*length*): the position of the element relative to its parent
 * **`z`** (*float*): Allows to specify a different order to stack the items with its siblings. (default: 0)
 * **`width`** and **`height`** (*length*): The size of the element. When set, this overrides the default size.
-* **`max_width`** and **`max_height`** (*length*): The maximum size of an element when used in a layout.
-* **`min_width`** and **`min_height`** (*length*): The minimum size of an element when used in a layout.
-* **`preferred_width`** and **`preferred_height`** (*length*): The minimum size of an element when used in a layout.
+* **`max-width`** and **`max-height`** (*length*): The maximum size of an element when used in a layout.
+* **`min-width`** and **`min-height`** (*length*): The minimum size of an element when used in a layout.
+* **`preferred-width`** and **`preferred-height`** (*length*): The minimum size of an element when used in a layout.
 * **`col`**, **`row`**, **`colspan`**, **`rowspan`** (*int*): See [`GridLayout`](#gridlayout).
-* **`horizontal_stretch`** and **`vertical_stretch`** (*float*): Specify how much relative space these elements are stretching in a layout.
+* **`horizontal-stretch`** and **`vertical-stretch`** (*float*): Specify how much relative space these elements are stretching in a layout.
   When 0, this means that the elements will not be stretched unless all elements are 0. Builtin widgets have a value of either 0 or 1
 * **`opacity`** (*float*): A value between 0 and 1 (or a percentage) that is used to draw the element and its
   children with transparency. 0 is fully transparent (invisible), and 1 is fully opaque. (default: 1)
@@ -63,9 +63,9 @@ When not part of a layout, its width or height defaults to 100% of the parent el
 ### Properties
 
 * **`background`** (*brush*): The background brush of the Rectangle, typically a color. (default value: transparent)
-* **`border_width`** (*length*): The width of the border. (default value: 0)
-* **`border_color`** (*brush*): The color of the border. (default value: transparent)
-* **`border_radius`** (*length*): The size of the radius. (default value: 0)
+* **`border-width`** (*length*): The width of the border. (default value: 0)
+* **`border-color`** (*brush*): The color of the border. (default value: transparent)
+* **`border-radius`** (*length*): The size of the radius. (default value: 0)
 * **`clip`** (*bool*): By default, when an item is bigger or outside another item, it is still shown.
   But when this property is set to `true`, then the children element of this Rectangle are going
   to be clipped. (default: `false`)
@@ -92,8 +92,8 @@ Example := Window {
         width: 50px;
         height: 50px;
         background: green;
-        border_width: 2px;
-        border_color: red;
+        border-width: 2px;
+        border-color: red;
     }
 
     // Transparent Rectangle with a border and a radius
@@ -102,9 +102,9 @@ Example := Window {
         y: 10px;
         width: 50px;
         height: 50px;
-        border_width: 4px;
-        border_color: black;
-        border_radius: 10px;
+        border-width: 4px;
+        border-color: black;
+        border-radius: 10px;
     }
 
     // A radius of width/2 makes it a circle
@@ -114,9 +114,9 @@ Example := Window {
         width: 50px;
         height: 50px;
         background: yellow;
-        border_width: 2px;
-        border_color: blue;
-        border_radius: width/2;
+        border-width: 2px;
+        border-color: blue;
+        border-radius: width/2;
     }
 }
 ```
@@ -186,15 +186,15 @@ and the text itself.
 ### Properties
 
 * **`text`** (*string*): The actual text.
-* **`font_family`** (*string*): The font name
-* **`font_size`** (*length*): The font size of the text
-* **`font_weight`** (*int*): The weight of the font. The values range from 100 (lightest) to 900 (thickest). 400 is the normal weight.
+* **`font-family`** (*string*): The font name
+* **`font-size`** (*length*): The font size of the text
+* **`font-weight`** (*int*): The weight of the font. The values range from 100 (lightest) to 900 (thickest). 400 is the normal weight.
 * **`color`** (*brush*): The color of the text (default: black)
-* **`horizontal_alignment`** (*enum [`TextHorizontalAlignment`](#texthorizontalalignment)*): The horizontal alignment of the text.
-* **`vertical_alignment`** (*enum [`TextVerticalAlignment`](#textverticalalignment)*): The vertical alignment of the text.
+* **`horizontal-alignment`** (*enum [`TextHorizontalAlignment`](#texthorizontalalignment)*): The horizontal alignment of the text.
+* **`vertical-alignment`** (*enum [`TextVerticalAlignment`](#textverticalalignment)*): The vertical alignment of the text.
 * **`wrap`** (*enum [`TextWrap`](#textwrap)*): The way the text wraps (default: no-wrap).
 * **`overflow`** (*enum [`TextOverflow`](#textoverflow)*): What happens when the text overflows (default: clip).
-* **`letter_spacing`** (*length*): The letter spacing allows changing the spacing between the glyphs. A positive value increases the spacing
+* **`letter-spacing`** (*length*): The letter spacing allows changing the spacing between the glyphs. A positive value increases the spacing
   and a negative value decreases the distance. The default value is 0.
 
 ### Example
@@ -409,9 +409,9 @@ When not part of a layout, its width or height default to 100% of the parent ele
 ### Properties
 
 * **`pressed`** (*bool*): Set to `true` by the TouchArea when the mouse is pressed over it.
-* **`has_hover`** (*bool*): Set to `true` by the TouchArea when the mouse is over it.
-* **`mouse_x`**, **`mouse_y`** (*length*): Set by the TouchArea to the position of the mouse within it.
-* **`pressed_x`**, **`mouse_y`** (*length*): Set to `true` by the TouchArea to the position of the mouse at the moment it was last pressed.
+* **`has-hover`** (*bool*): Set to `true` by the TouchArea when the mouse is over it.
+* **`mouse-x`**, **`mouse-y`** (*length*): Set by the TouchArea to the position of the mouse within it.
+* **`pressed-x`**, **`mouse-y`** (*length*): Set to `true` by the TouchArea to the position of the mouse at the moment it was last pressed.
 
 ### Callbacks
 
@@ -449,7 +449,7 @@ The FocusScope exposes callback to intercept the pressed key when it has focus.
 
 ### Properties
 
-* **`has_focus`** (*bool*): Set to `true` when item is focused and receives keyboard events.
+* **`has-focus`** (*bool*): Set to `true` when item is focused and receives keyboard events.
 
 ### Methods
 
@@ -457,15 +457,15 @@ The FocusScope exposes callback to intercept the pressed key when it has focus.
 
 ### Callbacks
 
-* **`key_pressed(KeyEvent) -> EventResult`**: Emitted when a key is pressed, the argument is a `KeyEvent` struct
-* **`key_released(KeyEvent) -> EventResult`**: Emitted when a key is released, the argument is a `KeyEvent` struct
+* **`key-pressed(KeyEvent) -> EventResult`**: Emitted when a key is pressed, the argument is a `KeyEvent` struct
+* **`key-released(KeyEvent) -> EventResult`**: Emitted when a key is released, the argument is a `KeyEvent` struct
 
 ### Example
 
 ```60
 Example := Window {
-    forward-focus: my_key_handler;
-    my_key_handler := FocusScope {
+    forward-focus: my-key-handler;
+    my-key-handler := FocusScope {
         key-pressed(event) => {
             debug(event.text);
             if (event.modifiers.control) {
@@ -487,10 +487,10 @@ they will be computed by the layout respecting the minimum and maximum sizes and
 
 * **`spacing`** (*length*): The distance between the elements in the layout.
 * **`padding`** (*length*): the padding within the layout.
-* **`padding_left`**, **`padding_right`**, **`padding_top`** and **`padding_bottom`** (*length*):
+* **`padding-left`**, **`padding-right`**, **`padding-top`** and **`padding-bottom`** (*length*):
   override the padding in specific sides.
 * **`alignment`** (*FIXME enum*): Can be one of  `stretch`, `center`, `start`, `end`,
-  `space_between`, `space_around`. Defaults to `stretch`. Matches the CSS flex.
+  `space-between`, `space-around`. Defaults to `stretch`. Matches the CSS flex.
 
 ## Example
 
@@ -519,7 +519,7 @@ Alternatively, the item can be put in a `Row` element.
 
 * **`spacing`** (*length*): The distance between the elements in the layout.
 * **`padding`** (*length*): the padding within the layout.
-* **`padding_left`**, **`padding_right`**, **`padding_top`** and **`padding_bottom`** (*length*):
+* **`padding-left`**, **`padding-right`**, **`padding-top`** and **`padding-bottom`** (*length*):
   override the padding in specific sides.
 
 ### Examples
@@ -579,14 +579,14 @@ When not part of a layout, its width or height defaults to 100% of the parent el
 ### Properties
 
 * **`text`** (*string*): The actual text.
-* **`font_family`** (*string*): The font name
-* **`font_size`** (*length*): The font size of the text
-* **`font_weight`** (*int*): The weight of the font. The values range from 100 (lightest) to 900 (thickest). 400 is the normal weight.
+* **`font-family`** (*string*): The font name
+* **`font-size`** (*length*): The font size of the text
+* **`font-weight`** (*int*): The weight of the font. The values range from 100 (lightest) to 900 (thickest). 400 is the normal weight.
 * **`color`** (*brush*): The color of the text (default: transparent)
-* **`horizontal_alignment`** (enum *[`TextHorizontalAlignment`](#texthorizontalalignment)*): The horizontal alignment of the text.
-* **`vertical_alignment`** (enum *[`TextVerticalAlignment`](#textverticalalignment)*): The vertical alignment of the text.
-* **`has_focus`** (*bool*): Set to `true` when item is focused and receives keyboard events.
-* **`letter_spacing`** (*length*): The letter spacing allows changing the spacing between the glyphs. A positive value increases the spacing
+* **`horizontal-alignment`** (enum *[`TextHorizontalAlignment`](#texthorizontalalignment)*): The horizontal alignment of the text.
+* **`vertical-alignment`** (enum *[`TextVerticalAlignment`](#textverticalalignment)*): The vertical alignment of the text.
+* **`has-focus`** (*bool*): Set to `true` when item is focused and receives keyboard events.
+* **`letter-spacing`** (*length*): The letter spacing allows changing the spacing between the glyphs. A positive value increases the spacing
   and a negative value decreases the distance. The default value is 0.
 
 ### Methods

--- a/docs/langref.md
+++ b/docs/langref.md
@@ -118,7 +118,7 @@ C-style comments are supported:
 
 Identifiers can be composed of letter (`a-zA-Z`), of numbers (`0-9`), or of the underscore (`_`) or the dash (`-`).
 They cannot start with a number or a dash (but they can start with underscore)
-The dashes are normalized to underscore. Which means that these two identifiers are the same: `foo-bar` and `foo_bar`.
+The underscore are normalized to dashes. Which means that these two identifiers are the same: `foo_bar` and `foo-bar`.
 
 ## Properties
 
@@ -140,11 +140,11 @@ language bindings:
 
 ```60
 Example := Rectangle {
-    // declare a property of type int with the name `my_property`
-    property<int> my_property;
+    // declare a property of type int with the name `my-property`
+    property<int> my-property;
 
     // declare a property with a default value
-    property<int> my_second_property: 42;
+    property<int> my-second-property: 42;
 }
 ```
 
@@ -173,9 +173,9 @@ The type can be omitted in a property declaration to have the type automatically
 
 ```60
 Example := Window {
-    property<brush> rect_color <=> r.background;
+    property<brush> rect-color <=> r.background;
     // it is allowed to omit the type to have it automatically inferred
-    property rect_color2 <=> r.background;
+    property rect-color2 <=> r.background;
     r:= Rectangle {
         width: parent.width;
         height: parent.height;
@@ -195,7 +195,7 @@ All properties in elements have a type. The following types are supported:
 | `string` | UTF-8 encoded, reference counted string. |
 | `color` | RGB color with an alpha channel, with 8 bit precision for each channel. CSS color names as well as the hexadecimal color encodings are supported, such as `#RRGGBBAA` or `#RGB`. |
 | `brush` | A brush is a special type that can be either initialized from a color or a gradient specification. See the [Colors Section](#colors) for more information. |
-| `physical_length` | This is an amount of physical pixels. To convert from an integer to a length unit, one can simply multiply by `1px`.  Or to convert from a length to a float, one can divide by `1phx`. |
+| `physical-length` | This is an amount of physical pixels. To convert from an integer to a length unit, one can simply multiply by `1px`.  Or to convert from a length to a float, one can divide by `1phx`. |
 | `length` | The type used for `x`, `y`, `width` and `height` coordinates. Corresponds to a literal like `1px`, `1pt`, `1in`, `1mm`, or `1cm`. It can be converted to and from length provided the binding is run in a context where there is an access to the device pixel ratio. |
 | `duration` | Type for the duration of animations. A suffix like `ms` (millisecond) or `s` (second) is used to indicate the precision. |
 | `angle` | Angle measurement, corresponds to a literal like `90deg`, `1.2rad`, `0.25turn` |
@@ -240,8 +240,8 @@ basically used as models for the `for` expression.
 
 ```60
 Example := Window {
-    property<[int]> list_of_int: [1,2,3];
-    property<[{a: int, b: string}]> list_of_structs: [{ a: 1, b: "hello" }, {a: 2, b: "world"}];
+    property<[int]> list-of-int: [1,2,3];
+    property<[{a: int, b: string}]> list-of-structs: [{ a: 1, b: "hello" }, {a: 2, b: "world"}];
 }
 ```
 
@@ -249,17 +249,17 @@ Example := Window {
 
 * `int` can be converted implicitly to `float` and vice-versa
 * `int` and `float` can be converted implicitly to `string`
-* `physical_length` and `length` can be converted implicitly to each other only in
+* `physical-length` and `length` can be converted implicitly to each other only in
    context where the pixel ratio is known.
-* the units type (`length`, `physical_length`, `duration`, ...) cannot be converted to numbers (`float` or `int`)
+* the units type (`length`, `physical-length`, `duration`, ...) cannot be converted to numbers (`float` or `int`)
   but they can be divided by themselves to result in a number. Similarly, a number can be multiplied by one of
   these unit. The idea is that one would multiply by `1px` or divide by `1px` to do such conversions
 * The literal `0` can be converted to any of these types that have associated unit.
 * Struct types convert with another struct type if they have the same property names and their types can be converted.
     The source struct can have either missing properties, or extra properties. But not both.
 * Array generally do not convert between each other. But array literal can be converted if the type does convert.
-* String can be converted to float by using the `to_float` function. That function returns 0 if the string is not
-   a valid number. you can check with `is_float` if the string contains a valid number
+* String can be converted to float by using the `to-float` function. That function returns 0 if the string is not
+   a valid number. you can check with `is-float` if the string contains a valid number
 
 ```60
 Example := Window {
@@ -273,8 +273,8 @@ Example := Window {
     // property<{a: string, b: int}> prop4: { a: "x", c: 42 };
 
     property<string> xxx: "42.1";
-    property<float> xxx1: xxx.to_float(); // 42.1
-    property<bool> xxx2: xxx.is_float(); // true
+    property<float> xxx1: xxx.to-float(); // 42.1
+    property<bool> xxx2: xxx.is-float(); // true
 }
 ```
 
@@ -378,15 +378,15 @@ to the property the expression is associated with:
 ```60
 Example := Rectangle {
     // declare a property of type int
-    property<int> my_property;
+    property<int> my-property;
 
     // This accesses the property
-    width: root.my_property * 20px;
+    width: root.my-property * 20px;
 
 }
 ```
 
-If something changes `my_property`, the width will be updated automatically.
+If something changes `my-property`, the width will be updated automatically.
 
 Arithmetic in expression works like in most programming language with the operators `*`, `+`, `-`, `/`:
 
@@ -520,19 +520,19 @@ Inside callback handlers, more complicated statements are allowed:
 Assignment:
 
 ```ignore
-clicked => { some_property = 42; }
+clicked => { some-property = 42; }
 ```
 
 Self-assignment with `+=` `-=` `*=` `/=`
 
 ```ignore
-clicked => { some_property += 42; }
+clicked => { some-property += 42; }
 ```
 
 Calling a callback
 
 ```ignore
-clicked => { root.some_callback(); }
+clicked => { root.some-callback(); }
 ```
 
 Conditional expression
@@ -541,7 +541,7 @@ Conditional expression
 clicked => {
     if (condition) {
         foo = 42;
-    } else if (other_condition) {
+    } else if (other-condition) {
         bar = 28;
     } else {
         foo = 4;
@@ -578,11 +578,11 @@ The *id* is also optional.
 Example := Window {
     height: 100px;
     width: 300px;
-    for my_color[index] in [ #e11, #1a2, #23d ]: Rectangle {
+    for my-color[index] in [ #e11, #1a2, #23d ]: Rectangle {
         height: 100px;
         width: 60px;
         x: width * index;
-        background: my_color;
+        background: my-color;
     }
 }
 ```
@@ -596,7 +596,7 @@ Example := Window {
         {foo: "def", col: #00f },
     ];
     VerticalLayout {
-        for data in root.model: my_repeated_text := Text {
+        for data in root.model: my-repeated-text := Text {
             color: data.col;
             text: data.foo;
         }
@@ -637,8 +637,8 @@ This will animate the color property for 100ms when it changes.
 Animation can be configured with the following parameter:
 
 * `duration`: the amount of time it takes for the animation to complete
-* `loop_count`: FIXME
-* `easing`: can be `linear`, `ease`, `ease_in`, `ease_out`, `ease_in_out`, `cubic_bezier(a, b, c, d)` as in CSS
+* `loop-count`: FIXME
+* `easing`: can be `linear`, `ease`, `ease-in`, `ease-out`, `ease-in-out`, `cubic-bezier(a, b, c, d)` as in CSS
 
 It is also possible to animate several properties with the same animation:
 
@@ -659,10 +659,10 @@ The `states` statement allow to declare states like this:
 Example := Rectangle {
     text := Text { text: "hello"; }
     property<bool> pressed;
-    property<bool> is_enabled;
+    property<bool> is-enabled;
 
     states [
-        disabled when !is_enabled : {
+        disabled when !is-enabled : {
             color: gray; // same as root.color: gray;
             text.color: white;
         }
@@ -673,7 +673,7 @@ Example := Rectangle {
 }
 ```
 
-In that example, when the `is_enabled` property is set to false, the `disabled` state will be entered
+In that example, when the `is-enabled` property is set to false, the `disabled` state will be entered
 This will change the color of the Rectangle and of the Text.
 
 ### Transitions
@@ -684,10 +684,10 @@ Complex animations can be declared on state transitions:
 Example := Rectangle {
     text := Text { text: "hello"; }
     property<bool> pressed;
-    property<bool> is_enabled;
+    property<bool> is-enabled;
 
     states [
-        disabled when !is_enabled : {
+        disabled when !is-enabled : {
             color: gray; // same as root.color: gray;
             text.color: white;
         }
@@ -787,11 +787,11 @@ of assigning a different name at import time:
 
 ```60,ignore
 import { Button } from "./button.60";
-import { Button as CoolButton } from "../other_theme/button.60";
+import { Button as CoolButton } from "../other-theme/button.60";
 
 App := Rectangle {
     // ...
-    CoolButton {} // from cool_button.60
+    CoolButton {} // from cool-button.60
     Button {} // from button.60
 }
 ```
@@ -802,7 +802,7 @@ Elements, globals and structs can be exported and imported.
 
 Certain elements such as ```TextInput``` accept not only input from the mouse/finger but
 also key events originating from (virtual) keyboards. In order for an item to receive
-these events, it must have the focus. This is visible through the `has_focus` property.
+these events, it must have the focus. This is visible through the `has-focus` property.
 
 You can manually activate the focus on an element by calling `focus()`:
 

--- a/docs/langref.md
+++ b/docs/langref.md
@@ -118,7 +118,7 @@ C-style comments are supported:
 
 Identifiers can be composed of letter (`a-zA-Z`), of numbers (`0-9`), or of the underscore (`_`) or the dash (`-`).
 They cannot start with a number or a dash (but they can start with underscore)
-The underscore are normalized to dashes. Which means that these two identifiers are the same: `foo_bar` and `foo-bar`.
+The underscores are normalized to dashes. Which means that these two identifiers are the same: `foo_bar` and `foo-bar`.
 
 ## Properties
 
@@ -787,11 +787,11 @@ of assigning a different name at import time:
 
 ```60,ignore
 import { Button } from "./button.60";
-import { Button as CoolButton } from "../other-theme/button.60";
+import { Button as CoolButton } from "../other_theme/button.60";
 
 App := Rectangle {
     // ...
-    CoolButton {} // from cool-button.60
+    CoolButton {} // from other_theme/button.60
     Button {} // from button.60
 }
 ```

--- a/docs/layouting.md
+++ b/docs/layouting.md
@@ -94,10 +94,10 @@ You can tune the automatic placement using different constraints, to accommodate
 interface. For example each element has a minimum and a maximum size. Set these explicitly using the
 following properties:
 
-* `min_width`
-* `min_height`
-* `max_width`
-* `max_height`
+* `min-width`
+* `min-height`
+* `max-width`
+* `max-height`
 
 A layout element also affects the minimum and maximum size of its parent.
 
@@ -106,8 +106,8 @@ An element is considered to have a fixed size in a layout when the `width` and `
 When there is extra space in a layout, elements can stretch along the layout axis. You can control this stretch
 factor between the element and its siblings with these properties:
 
-* `horizontal_stretch`
-* `vertical_stretch`
+* `horizontal-stretch`
+* `vertical-stretch`
 
 A value of `0` means that the element will not be stretched at all; unless all siblings also have a stretch
 factor of `0`. Then all the elements will be equally stretched.
@@ -142,8 +142,8 @@ Example := Window {
     width: 200px;
     height: 200px;
     HorizontalLayout {
-        Rectangle { background: blue; min_width: 20px; }
-        Rectangle { background: yellow; min_width: 30px; }
+        Rectangle { background: blue; min-width: 20px; }
+        Rectangle { background: yellow; min-width: 30px; }
     }
 }
 ```
@@ -159,8 +159,8 @@ Example := Window {
     height: 200px;
     HorizontalLayout {
         alignment: start;
-        Rectangle { background: blue; min_width: 20px; }
-        Rectangle { background: yellow; min_width: 30px; }
+        Rectangle { background: blue; min-width: 20px; }
+        Rectangle { background: yellow; min-width: 30px; }
     }
 }
 ```
@@ -217,44 +217,44 @@ Example := Window {
         HorizontalLayout {
             alignment: stretch;
             Text { text: "stretch (default)"; }
-            Rectangle { background: blue; min_width: 20px; }
-            Rectangle { background: yellow; min_width: 30px; }
+            Rectangle { background: blue; min-width: 20px; }
+            Rectangle { background: yellow; min-width: 30px; }
         }
         HorizontalLayout {
             alignment: start;
             Text { text: "start"; }
-            Rectangle { background: blue; min_width: 20px; }
-            Rectangle { background: yellow; min_width: 30px; }
+            Rectangle { background: blue; min-width: 20px; }
+            Rectangle { background: yellow; min-width: 30px; }
         }
         HorizontalLayout {
             alignment: end;
             Text { text: "end"; }
-            Rectangle { background: blue; min_width: 20px; }
-            Rectangle { background: yellow; min_width: 30px; }
+            Rectangle { background: blue; min-width: 20px; }
+            Rectangle { background: yellow; min-width: 30px; }
         }
         HorizontalLayout {
             alignment: start;
             Text { text: "start"; }
-            Rectangle { background: blue; min_width: 20px; }
-            Rectangle { background: yellow; min_width: 30px; }
+            Rectangle { background: blue; min-width: 20px; }
+            Rectangle { background: yellow; min-width: 30px; }
         }
         HorizontalLayout {
             alignment: center;
             Text { text: "center"; }
-            Rectangle { background: blue; min_width: 20px; }
-            Rectangle { background: yellow; min_width: 30px; }
+            Rectangle { background: blue; min-width: 20px; }
+            Rectangle { background: yellow; min-width: 30px; }
         }
         HorizontalLayout {
             alignment: space-between;
             Text { text: "space-between"; }
-            Rectangle { background: blue; min_width: 20px; }
-            Rectangle { background: yellow; min_width: 30px; }
+            Rectangle { background: blue; min-width: 20px; }
+            Rectangle { background: yellow; min-width: 30px; }
         }
         HorizontalLayout {
             alignment: space-around;
             Text { text: "space-around"; }
-            Rectangle { background: blue; min_width: 20px; }
-            Rectangle { background: yellow; min_width: 30px; }
+            Rectangle { background: blue; min-width: 20px; }
+            Rectangle { background: yellow; min-width: 30px; }
         }
     }
 }

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -137,8 +137,8 @@ Example := Window {
 ### Properties
 
 * **`text`** (*string*): The test being edited
-* **`has_focus`**: (*bool*): Set to true when the line edit currently has the focus
-* **`placeholder_text`**: (*string*): A placeholder text being shown when there is no text in the edit field
+* **`has-focus`**: (*bool*): Set to true when the line edit currently has the focus
+* **`placeholder-text`**: (*string*): A placeholder text being shown when there is no text in the edit field
 * **`enabled`**: (*bool*): Defaults to true. When false, nothing can be entered
 
 ### Callbacks
@@ -156,7 +156,7 @@ Example := Window {
     LineEdit {
         width: parent.width;
         height: parent.height;
-        placeholder_text: "Enter text here";
+        placeholder-text: "Enter text here";
     }
 }
 ```
@@ -168,9 +168,9 @@ It has scrollbar to interact with.
 
 ### Properties
 
-* **`viewport_width`** and **`viewport_height`** (*length*): The `width` and `length` properties of the viewport
-* **`viewport_x`** and **`viewport_y`** (*length*): The `x` and `y` properties of the viewport. Usually these are negative
-* **`visible_width`** and **`visible_height`** (*length*): The size of the visible area of the ScrollView (not including the scrollbar)
+* **`viewport-width`** and **`viewport-height`** (*length*): The `width` and `length` properties of the viewport
+* **`viewport-x`** and **`viewport-y`** (*length*): The `x` and `y` properties of the viewport. Usually these are negative
+* **`visible-width`** and **`visible-height`** (*length*): The size of the visible area of the ScrollView (not including the scrollbar)
 
 ### Example
 
@@ -182,8 +182,8 @@ Example := Window {
     ScrollView {
         width: 200px;
         height: 200px;
-        viewport_width: 300px;
-        viewport_height: 300px;
+        viewport-width: 300px;
+        viewport-height: 300px;
         Rectangle { width: 30px; height: 30px; x: 275px; y: 50px; background: blue; }
         Rectangle { width: 30px; height: 30px; x: 175px; y: 130px; background: red; }
         Rectangle { width: 30px; height: 30px; x: 25px; y: 210px; background: yellow; }
@@ -246,7 +246,7 @@ The `StandardListViewItem` is equivalent to `{ text: string }` but will be impro
 Same as ListView, and in addition:
 
 * **`model`** (*`[StandardListViewItem]`*): The model
-* **`current_item`** (*int*): The index of the currently active item. -1 mean none is selected, which is the default
+* **`current-item`** (*int*): The index of the currently active item. -1 mean none is selected, which is the default
 
 ### Example
 
@@ -273,8 +273,8 @@ A button that, when clicked, opens a popup to select a value.
 ### Properties
 
 * **`model`** (*\[string\]*): The list of possible values
-* **`current_index`**: (*int*): The index of the selected value (-1 if no value is selected)
-* **`current_value`**: (*string*): The currently selected text
+* **`current-index`**: (*int*): The index of the selected value (-1 if no value is selected)
+* **`current-value`**: (*string*): The currently selected text
 * **`enabled`**: (*bool*): When false, the combobox cannot be opened (default: true)
 
 ### Callbacks
@@ -292,7 +292,7 @@ Example := Window {
         width: preferred-width;
         height: preferred-height;
         model: ["first", "second", "third"];
-        current_value: "first";
+        current-value: "first";
     }
 }
 ```

--- a/examples/7gui/booker.60
+++ b/examples/7gui/booker.60
@@ -12,56 +12,56 @@ import { LineEdit, Button, ComboBox, VerticalBox } from "sixtyfps_widgets.60";
 
 Booker := Window {
     // returns true if the string parameter is a valid date
-    callback validate_date(string) -> bool;
-    validate_date(_) => { true }
+    callback validate-date(string) -> bool;
+    validate-date(_) => { true }
     // returns true if the first date is before the second date and they are both valid
-    callback compare_date(string, string) -> bool;
-    compare_date(a, b) => { a <= b }
-    property <bool> message_visible;
+    callback compare-date(string, string) -> bool;
+    compare-date(a, b) => { a <= b }
+    property <bool> message-visible;
     VerticalBox {
         combo := ComboBox {
             model: ["one-way flight", "return flight"];
-            current_value: "one-way flight";
-            current_index: 0;
+            current-value: "one-way flight";
+            current-index: 0;
         }
         t1 := LineEdit {
             text: "27.03.2014";
             Rectangle {
                 width: 100%;
                 height: 100%;
-                background: validate_date(t1.text) ? transparent : #f008;
+                background: validate-date(t1.text) ? transparent : #f008;
             }
         }
         t2 := LineEdit {
             text: "27.03.2014";
-            enabled: combo.current_index == 1;
+            enabled: combo.current-index == 1;
             Rectangle {
                 width: 100%;
                 height: 100%;
-                background: validate_date(t2.text) ? transparent : #f008;
+                background: validate-date(t2.text) ? transparent : #f008;
             }
         }
         Button {
             text: "Book";
-            clicked() => { message_visible = true; }
-            enabled: combo.current_index != 1 ? validate_date(t1.text) : compare_date(t1.text, t2.text);
+            clicked() => { message-visible = true; }
+            enabled: combo.current-index != 1 ? validate-date(t1.text) : compare-date(t1.text, t2.text);
         }
     }
-    if (message_visible) : Rectangle {
+    if (message-visible) : Rectangle {
         width: 100%;
         height: 100%;
         background: #ee8;
         Text {
             width: 100%;
             height: 100%;
-            text: "You have booked a " + combo.current_value + " on " + t1.text;
+            text: "You have booked a " + combo.current-value + " on " + t1.text;
             vertical-alignment: center;
             horizontal-alignment: center;
         }
         TouchArea {
             width: 100%;
             height: 100%;
-            clicked => { message_visible = false; }
+            clicked => { message-visible = false; }
         }
     }
 }

--- a/examples/7gui/cells.60
+++ b/examples/7gui/cells.60
@@ -13,29 +13,29 @@ import { LineEdit, ScrollView} from "sixtyfps_widgets.60";
 
 Cells := Window {
 
-    property<length> cell_height: 32px;
-    property<length> cell_width: 80px;
+    property<length> cell-height: 32px;
+    property<length> cell-width: 80px;
 
     ScrollView {
         width: 100%;
         height: 100%;
-        viewport_width: 20px + 26 * cell_width;
-        viewport_height: 100 * cell_height;
+        viewport-width: 20px + 26 * cell-width;
+        viewport-height: 100 * cell-height;
 
         for letter[idx] in ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z" ] : Rectangle {
-            x: 20px + idx * cell_width;
-            height: cell_height;
-            width: cell_width;
+            x: 20px + idx * cell-width;
+            height: cell-height;
+            width: cell-width;
             Text { text: letter; }
         }
         for __[idx] in 100 : Rectangle {
-            y: cell_height + idx * cell_height;
-            height: cell_height;
+            y: cell-height + idx * cell-height;
+            height: cell-height;
             Text { text: idx; }
-            for ___[idx_x] in 26 :   LineEdit {
-                height: cell_height - 1px;
-                width: cell_width - 2px;
-                x: 20px + idx_x * cell_width;
+            for ___[idx-x] in 26 :   LineEdit {
+                height: cell-height - 1px;
+                width: cell-width - 2px;
+                x: 20px + idx-x * cell-width;
             }
 
         }

--- a/examples/7gui/circledraw.60
+++ b/examples/7gui/circledraw.60
@@ -13,8 +13,8 @@ import { LineEdit, Button, Slider, StandardListView, VerticalBox } from "sixtyfp
 struct Circle := { x: float, y: float, r: float }
 
 CircleDraw := Window {
-    preferred_width: 500px;
-    preferred_height: 400px;
+    preferred-width: 500px;
+    preferred-height: 400px;
 
     property <[Circle]> model: [
         { x: 0.1, y:0.1, r: 5  },
@@ -23,8 +23,8 @@ CircleDraw := Window {
         { x: 0.5, y:0.31, r:2  },
     ];
 
-    property<int> clicked_idx: -1;
-    property<Circle> selected_circle;
+    property<int> clicked-idx: -1;
+    property<Circle> selected-circle;
 
     VerticalBox {
         HorizontalLayout {
@@ -39,7 +39,7 @@ CircleDraw := Window {
             border-width: 2px;
 
             for circle[idx] in model : Rectangle {
-                background: clicked_idx == idx ? gray : white;
+                background: clicked-idx == idx ? gray : white;
                 border-color: black;
                 border-width: 2px;
                 border-radius: width / 2;
@@ -51,8 +51,8 @@ CircleDraw := Window {
                     height: 100%;
                     width: 100%;
                     clicked => {
-                        selected_circle = circle;
-                        clicked_idx = idx;
+                        selected-circle = circle;
+                        clicked-idx = idx;
                     }
                 }
             }
@@ -60,12 +60,12 @@ CircleDraw := Window {
         }
     }
 
-    if (clicked_idx != -1) : TouchArea {
+    if (clicked-idx != -1) : TouchArea {
         height: 100%;
         width: 100%;
-        clicked => { clicked_idx = -1; }
+        clicked => { clicked-idx = -1; }
     }
-    if (clicked_idx != -1) : Rectangle {
+    if (clicked-idx != -1) : Rectangle {
         background: lightgray;
         height: 30%;
         width: 70%;
@@ -78,12 +78,12 @@ CircleDraw := Window {
 
         VerticalBox {
             Text {
-                text: "Adjust diameter of cercle at (" + selected_circle.x + ", " +  selected_circle.y + ").";
+                text: "Adjust diameter of cercle at (" + selected-circle.x + ", " +  selected-circle.y + ").";
                 wrap: word-wrap;
             }
             Slider {
                 maximum: 100;
-                value: selected_circle.r;
+                value: selected-circle.r;
             }
         }
     }

--- a/examples/7gui/timer.60
+++ b/examples/7gui/timer.60
@@ -11,9 +11,9 @@ LICENSE END */
 import { LineEdit, Button, Slider, HorizontalBox, VerticalBox } from "sixtyfps_widgets.60";
 
 Timer := Window {
-    property <duration> total_time: slider.value * 1s;
+    property <duration> total-time: slider.value * 1s;
     property <float> progress: 0.5;
-    animate progress { duration: total_time; }
+    animate progress { duration: total-time; }
     VerticalBox {
         HorizontalBox {
             Text { text: "Elapsed Time:"; }
@@ -28,7 +28,7 @@ Timer := Window {
             }
         }
         Text{
-            text: (total_time / 1s) + "s";
+            text: (total-time / 1s) + "s";
         }
         HorizontalBox {
             Text { text: "Duration:"; }

--- a/examples/gallery/gallery.60
+++ b/examples/gallery/gallery.60
@@ -18,12 +18,12 @@ App := Window {
         HorizontalBox {
             Text {
                 text: "Below are some of the standard widgets that application developers can easily re-use.";
-                wrap: word_wrap;
+                wrap: word-wrap;
             }
 
             VerticalLayout {
                 alignment: start;
-                disable_toggle := CheckBox {
+                disable-toggle := CheckBox {
                     checked: false;
                     text: "Disable Widgets";
                 }
@@ -39,32 +39,32 @@ App := Window {
                         alignment: start;
                         GroupBox {
                             title: "Button";
-                            enabled: !disable_toggle.checked;
+                            enabled: !disable-toggle.checked;
 
                             Button {
                                 text: "Regular Button";
-                                enabled: !disable_toggle.checked;
+                                enabled: !disable-toggle.checked;
                             }
                         }
 
                         GroupBox {
                             title: "Button with Icon";
-                            enabled: !disable_toggle.checked;
+                            enabled: !disable-toggle.checked;
 
                             Button {
                                 text: "Regular Button";
                                 icon: @image-url("thumbsup.png");
-                                enabled: !disable_toggle.checked;
+                                enabled: !disable-toggle.checked;
                             }
                         }
 
                         GroupBox {
                             title: "CheckBox";
-                            enabled: !disable_toggle.checked;
+                            enabled: !disable-toggle.checked;
                             checkbox := CheckBox {
                                 text: checkbox.checked ? "(checked)" : "(unchecked)";
                                 checked: true;
-                                enabled: !disable_toggle.checked;
+                                enabled: !disable-toggle.checked;
                             }
                         }
                     }
@@ -73,38 +73,38 @@ App := Window {
                         alignment: start;
                         GroupBox {
                             title: "SpinBox";
-                            enabled: !disable_toggle.checked;
+                            enabled: !disable-toggle.checked;
                             SpinBox {
                                 value: 42;
-                                enabled: !disable_toggle.checked;
+                                enabled: !disable-toggle.checked;
                             }
                         }
 
                         GroupBox {
                             title: "ComboBox";
-                            enabled: !disable_toggle.checked;
+                            enabled: !disable-toggle.checked;
                             ComboBox {
                                 model: ["Select Something", "From this", "Combobox"];
-                                enabled: !disable_toggle.checked;
+                                enabled: !disable-toggle.checked;
                             }
                         }
                     }
 
                     GroupBox {
                         title: "Slider";
-                        enabled: !disable_toggle.checked;
+                        enabled: !disable-toggle.checked;
                         Slider {
                             value: 42;
-                            enabled: !disable_toggle.checked;
+                            enabled: !disable-toggle.checked;
                         }
                     }
 
                     GroupBox {
                         title: "LineEdit";
-                        enabled: !disable_toggle.checked;
+                        enabled: !disable-toggle.checked;
                         LineEdit {
                             placeholder-text: "Enter some text";
-                            enabled: !disable_toggle.checked;
+                            enabled: !disable-toggle.checked;
                         }
                     }
                 }
@@ -113,7 +113,7 @@ App := Window {
                 title: "List View";
                 GroupBox {
                     title: "StandardListView";
-                    enabled: !disable_toggle.checked;
+                    enabled: !disable-toggle.checked;
                     StandardListView {
                         model: [
                             {text: "Lorem"}, {text: "ipsum"},{text: "dolor"},{text: "sit"},{text: "amet"},{text: "consetetur"},

--- a/examples/imagefilter/imagefilter.60
+++ b/examples/imagefilter/imagefilter.60
@@ -16,9 +16,9 @@ export MainWindow := Window {
 
     property original-image <=> original.source;
     property filtered-image <=> filtered.source;
-    property filters <=> filter_combo.model;
-    property selected_filter <=> filter_combo.current_index;
-    callback filter_selected <=> filter_combo.selected;
+    property filters <=> filter-combo.model;
+    property selected-filter <=> filter-combo.current-index;
+    callback filter-selected <=> filter-combo.selected;
 
     HorizontalBox {
         VerticalBox {
@@ -31,7 +31,7 @@ export MainWindow := Window {
         }
         VerticalBox {
             alignment: center;
-            filter_combo := ComboBox {
+            filter-combo := ComboBox {
                 current-value: "Brighten";
                 current-index: 0;
                 vertical-stretch: 0;

--- a/examples/iot-dashboard/iot-dashboard.60
+++ b/examples/iot-dashboard/iot-dashboard.60
@@ -92,24 +92,24 @@ global Skin := {
 }
 
 export Clock :=  VerticalLayout {
-    property <string> time <=> time_label.text;
+    property <string> time <=> time-label.text;
     Text {
         text: "Current time";
-        font_size: Skin.TitleFont;
-        font_weight: 700;
+        font-size: Skin.TitleFont;
+        font-weight: 700;
     }
-    time_label := Text {
+    time-label := Text {
         // FIXME: actual time
         text: "10:02:45";
-        font_size: Skin.HugeFont;
-        font_weight: 700;
+        font-size: Skin.HugeFont;
+        font-weight: 700;
         color: #6776FF;
     }
 }
 
 PieChartBackground := Path {
     property <float> thickness;
-    property <float> inner_radius;
+    property <float> inner-radius;
 
     fill: #aaaaaa40;
 
@@ -139,14 +139,14 @@ PieChartBackground := Path {
         y: thickness;
     }
     ArcTo {
-        radius-x: inner_radius;
-        radius-y: inner_radius;
+        radius-x: inner-radius;
+        radius-y: inner-radius;
         x: 50;
         y: 100 - thickness;
     }
     ArcTo {
-        radius-x: inner_radius;
-        radius-y: inner_radius;
+        radius-x: inner-radius;
+        radius-y: inner-radius;
         x: 50;
         y: thickness;
     }
@@ -154,7 +154,7 @@ PieChartBackground := Path {
 
 PieChartFill := Path {
     property <float> thickness;
-    property <float> inner_radius;
+    property <float> inner-radius;
     property <float> progress;
     property <float> start : 0;
 
@@ -166,14 +166,14 @@ PieChartFill := Path {
         x: 50 - 50 * sin(-start * 360deg);
     }
     LineTo {
-        y: 50 - inner_radius * cos(-start * 360deg);
-        x: 50 - inner_radius * sin(-start * 360deg);
+        y: 50 - inner-radius * cos(-start * 360deg);
+        x: 50 - inner-radius * sin(-start * 360deg);
     }
     ArcTo {
-        radius-x: inner_radius;
-        radius-y: inner_radius;
-        y: 50 - inner_radius*cos(-(start + progress) * 360deg);
-        x: 50 - inner_radius*sin(-(start + progress) * 360deg);
+        radius-x: inner-radius;
+        radius-y: inner-radius;
+        y: 50 - inner-radius*cos(-(start + progress) * 360deg);
+        x: 50 - inner-radius*sin(-(start + progress) * 360deg);
         sweep: progress > 0;
         large-arc: progress > 0.5;
     }
@@ -200,20 +200,20 @@ PieChartPainted := Rectangle {
     property <float> progress;
 
     property <float> thickness: 15;
-    property <float> inner_radius: 50 - thickness;
+    property <float> inner-radius: 50 - thickness;
 
     back := PieChartBackground {
         width: 100%;
         height: 100%;
         thickness: root.thickness;
-        inner_radius: root.inner_radius;
+        inner-radius: root.inner-radius;
     }
 
     p := PieChartFill {
         width: 100%;
         height: 100%;
         thickness: root.thickness;
-        inner_radius: root.inner_radius;
+        inner-radius: root.inner-radius;
         progress: root.progress;
     }
 }
@@ -236,7 +236,7 @@ export TopBar := HorizontalLayout {
         padding: 0px;
         spacing: 0px;
         Text {
-            font_size: Skin.SmallFont;
+            font-size: Skin.SmallFont;
             text: item.string;
         }
         HorizontalLayout {
@@ -246,11 +246,11 @@ export TopBar := HorizontalLayout {
                 Text {
                     width: 100%;
                     height: 100%;
-                    vertical_alignment: center;
-                    horizontal_alignment: center;
+                    vertical-alignment: center;
+                    horizontal-alignment: center;
                     text: item.progress + "%";
                     color: item.color;
-                    font_size: Skin.TinyFont;
+                    font-size: Skin.TinyFont;
                 }
             }
             VerticalLayout {
@@ -285,8 +285,8 @@ Box := BoxBase {
     VerticalLayout {
         if (root.title != "") : Text {
             text <=> root.title;
-            font_size: Skin.TitleFont;
-            font_weight: 700;
+            font-size: Skin.TitleFont;
+            font-weight: 700;
         }
         spacing: 10px;
         padding: 15px;
@@ -298,7 +298,7 @@ Box := BoxBase {
 RoundedIcon := Rectangle {
     property <bool> isBright;
     property <bool> isSmall;
-    property <image> iconName <=> m_graphicLabel.source;
+    property <image> iconName <=> m-graphicLabel.source;
     property <float> background-opacity <=> background-fill.opacity;
     height: isSmall ? 60px : 68px;
     width: isSmall ? 60px : 68px;
@@ -307,7 +307,7 @@ RoundedIcon := Rectangle {
         border-radius: 6px;
         opacity: 1.0;
     }
-    m_graphicLabel := Image {
+    m-graphicLabel := Image {
         x: (parent.width - width) / 2;
         y: (parent.height - height) / 2;
     }
@@ -316,45 +316,45 @@ RoundedIcon := Rectangle {
 //from Usage.cpp
 UsageSpacer := Text {
     text: "_____";
-    font_size: Skin.SmallFont;
+    font-size: Skin.SmallFont;
     color: #dddddd;
-    horizontal_stretch: 2;
+    horizontal-stretch: 2;
 }
 
 // Deviation: To align the items visually better, this is using a grid layout
 export Usage := Box {
     title: "Usage";
-    horizontal_stretch: 1;
+    horizontal-stretch: 1;
     GridLayout {
         spacing: 0px;
-        vertical_stretch: 1;
-        Row { Rectangle { vertical_stretch: 0; } }
+        vertical-stretch: 1;
+        Row { Rectangle { vertical-stretch: 0; } }
         Row {
-            Text { text: "Usage Today"; font_size: Skin.SmallFont; }
+            Text { text: "Usage Today"; font-size: Skin.SmallFont; }
             UsageSpacer { }
-            Text { text: "0,5 kwH"; font_size: Skin.SmallFont; }
+            Text { text: "0,5 kwH"; font-size: Skin.SmallFont; }
         }
         Row {
-            Text { text: "Usage this month"; font_size: Skin.SmallFont; }
+            Text { text: "Usage this month"; font-size: Skin.SmallFont; }
             UsageSpacer { }
-            Text { text: "60 kwH"; font_size: Skin.SmallFont; }
+            Text { text: "60 kwH"; font-size: Skin.SmallFont; }
         }
         Row {
-            Text { text: "Total working hours"; font_size: Skin.SmallFont; }
+            Text { text: "Total working hours"; font-size: Skin.SmallFont; }
             UsageSpacer { }
-            Text { text: "125 hrs"; font_size: Skin.SmallFont; }
+            Text { text: "125 hrs"; font-size: Skin.SmallFont; }
         }
     }
 }
 
 // From UpAndDownButton.cpp
 RoundButton := Image { //### QskPushButton
-    property <bool> is_up; // ### QskAspect
+    property <bool> is-up; // ### QskAspect
     callback clicked <=> ta.clicked;
     property <color> color: #929CB2; // Taken from the fill in the svg itself.
     width: 30px;
     Image {
-        source: is_up ? @image-url("images/up.svg") : @image-url("images/down.svg");
+        source: is-up ? @image-url("images/up.svg") : @image-url("images/down.svg");
         x: (parent.width - width) / 2;
         y: (parent.height - height) / 2;
         // Deviation from qskinny: Show a darker color when pressing the button to provide feedback.
@@ -368,16 +368,16 @@ UpAndDownButton := Rectangle {
     border-radius: width/2;
     background: Skin.palette.roundButton;
     VerticalLayout {
-        u := RoundButton { is_up: true;  clicked => { changed(+1) }}
-        d := RoundButton { is_up: false; clicked => { changed(-1) }}
+        u := RoundButton { is-up: true;  clicked => { changed(+1) }}
+        d := RoundButton { is-up: false; clicked => { changed(-1) }}
     }
 }
 
 // From BoxWithButtons.cpp
 ButtonValueLabel := Text {
     property <string> value <=> text;
-    font_size: Skin.HugeFont;
-    font_weight: 700;
+    font-size: Skin.HugeFont;
+    font-weight: 700;
     color: #929cb2;
 }
 
@@ -392,14 +392,14 @@ BoxWithButtons := Box {
     property <image> iconFile <=> ri.iconName; //### in original, this is derived from title
     property <string> value <=> val.value;
     property <bool> isBright <=> ri.isBright;
-    property <string> title_ <=> titleLabel.text;
+    property <string> title- <=> titleLabel.text;
     HorizontalLayout {
         spacing: 20px;
         ri := RoundedIcon { }
         TitleAndValueBox {
             titleLabel := Text {
-                font_size: Skin.TitleFont;
-                font_weight: 700;
+                font-size: Skin.TitleFont;
+                font-weight: 700;
             }
             val := ButtonValueLabel { }
         }
@@ -409,19 +409,19 @@ BoxWithButtons := Box {
 
 export IndoorTemperature := BoxWithButtons {
     property <int> temperature: 24;
-    title_: "Indoor Temperature";
+    title-: "Indoor Temperature";
     iconFile: @image-url("images/indoor-temperature.png");
     value: (temperature < 0 ? "" : "+") + temperature;
     isBright: true;
     changed(delta) => { temperature += delta; }
 }
 export Humidity := BoxWithButtons {
-    property <int> humidity_percent : 30;
-    title_: "Humidity";
+    property <int> humidity-percent : 30;
+    title-: "Humidity";
     iconFile: @image-url("images/humidity.png");
-    value: humidity_percent + "%";
+    value: humidity-percent + "%";
     isBright: false;
-    changed(delta) => { humidity_percent += delta; }
+    changed(delta) => { humidity-percent += delta; }
 }
 
 // from MyDevices.cpp
@@ -435,8 +435,8 @@ Device := VerticalLayout {
         isSmall: true;
     }
     t := Text {
-        font_size: Skin.TinyFont;
-        horizontal_alignment: center;
+        font-size: Skin.TinyFont;
+        horizontal-alignment: center;
     }
 }
 
@@ -476,7 +476,7 @@ export UsageDiagram := Box {
     // WeekDayBox
     boxes := HorizontalLayout {
         padding: 0px;
-        padding_bottom: 6px;
+        padding-bottom: 6px;
         spacing: 6px;
         for _ in 7 : Rectangle {
             background: Skin.palette.box;
@@ -516,13 +516,13 @@ export UsageDiagram := Box {
                         Rectangle {
                             height: 8px;
                             width: 9px;
-                            border_radius: 4px;
+                            border-radius: 4px;
                             background: caption.color;
                         }
                     }
                     Text {
                         text: caption.text;
-                        horizontal_alignment: center;
+                        horizontal-alignment: center;
                         font-size: Skin.TinyFont;
                     }
                 }
@@ -545,75 +545,75 @@ export UsageDiagram := Box {
                 ] : Path {
                     opacity: 0.7;
                     fill: @linear-gradient(180deg, datapoints.color, transparent 100%);
-                    viewbox_width: width/1px;
-                    viewbox_height: height/1px;
+                    viewbox-width: width/1px;
+                    viewbox-height: height/1px;
                     MoveTo {
                         x: 0;
-                        y: viewbox_height;
+                        y: viewbox-height;
                     }
                     LineTo {
                         x: 0;
-                        y: viewbox_height - datapoints.values.a / 100 * viewbox_height;
+                        y: viewbox-height - datapoints.values.a / 100 * viewbox-height;
                     }
                     QuadraticTo {
-                        x: 0.5/7 * viewbox_width;
-                        y: viewbox_height - datapoints.values.b / 100 * viewbox_height;
-                        control_x: 0/7 * viewbox_width;
-                        control_y: viewbox_height - datapoints.values.b / 100 * viewbox_height;
+                        x: 0.5/7 * viewbox-width;
+                        y: viewbox-height - datapoints.values.b / 100 * viewbox-height;
+                        control-x: 0/7 * viewbox-width;
+                        control-y: viewbox-height - datapoints.values.b / 100 * viewbox-height;
                     }
                     CubicTo {
-                        x: 1.5/7 * viewbox_width;
-                        control_1_x: 1/7 * viewbox_width;
-                        control_2_x: 1/7 * viewbox_width;
-                        y: viewbox_height - datapoints.values.c / 100 * viewbox_height;
-                        control_1_y: viewbox_height - datapoints.values.b / 100 * viewbox_height;
-                        control_2_y: viewbox_height - datapoints.values.c / 100 * viewbox_height;
+                        x: 1.5/7 * viewbox-width;
+                        control-1-x: 1/7 * viewbox-width;
+                        control-2-x: 1/7 * viewbox-width;
+                        y: viewbox-height - datapoints.values.c / 100 * viewbox-height;
+                        control-1-y: viewbox-height - datapoints.values.b / 100 * viewbox-height;
+                        control-2-y: viewbox-height - datapoints.values.c / 100 * viewbox-height;
                     }
                     CubicTo {
-                        x: 3.5/7 * viewbox_width;
-                        control_1_x: 3/7 * viewbox_width;
-                        control_2_x: 3/7 * viewbox_width;
-                        y: viewbox_height - datapoints.values.e / 100 * viewbox_height;
-                        control_1_y: viewbox_height - datapoints.values.d / 100 * viewbox_height;
-                        control_2_y: viewbox_height - datapoints.values.e / 100 * viewbox_height;
+                        x: 3.5/7 * viewbox-width;
+                        control-1-x: 3/7 * viewbox-width;
+                        control-2-x: 3/7 * viewbox-width;
+                        y: viewbox-height - datapoints.values.e / 100 * viewbox-height;
+                        control-1-y: viewbox-height - datapoints.values.d / 100 * viewbox-height;
+                        control-2-y: viewbox-height - datapoints.values.e / 100 * viewbox-height;
                     }
                     CubicTo {
-                        x: 4.5/7 * viewbox_width;
-                        control_1_x: 4/7 * viewbox_width;
-                        control_2_x: 4/7 * viewbox_width;
-                        y: viewbox_height - datapoints.values.f / 100 * viewbox_height;
-                        control_1_y: viewbox_height - datapoints.values.e / 100 * viewbox_height;
-                        control_2_y: viewbox_height - datapoints.values.f / 100 * viewbox_height;
+                        x: 4.5/7 * viewbox-width;
+                        control-1-x: 4/7 * viewbox-width;
+                        control-2-x: 4/7 * viewbox-width;
+                        y: viewbox-height - datapoints.values.f / 100 * viewbox-height;
+                        control-1-y: viewbox-height - datapoints.values.e / 100 * viewbox-height;
+                        control-2-y: viewbox-height - datapoints.values.f / 100 * viewbox-height;
                     }
                     CubicTo {
-                        x: 5.5/7 * viewbox_width;
-                        control_1_x: 5/7 * viewbox_width;
-                        control_2_x: 5/7 * viewbox_width;
-                        y: viewbox_height - datapoints.values.g / 100 * viewbox_height;
-                        control_1_y: viewbox_height - datapoints.values.f / 100 * viewbox_height;
-                        control_2_y: viewbox_height - datapoints.values.g / 100 * viewbox_height;
+                        x: 5.5/7 * viewbox-width;
+                        control-1-x: 5/7 * viewbox-width;
+                        control-2-x: 5/7 * viewbox-width;
+                        y: viewbox-height - datapoints.values.g / 100 * viewbox-height;
+                        control-1-y: viewbox-height - datapoints.values.f / 100 * viewbox-height;
+                        control-2-y: viewbox-height - datapoints.values.g / 100 * viewbox-height;
                     }
                     CubicTo {
-                        x: 6.5/7 * viewbox_width;
-                        y: viewbox_height - datapoints.values.h / 100 * viewbox_height;
-                        control_1_x: 6/7 * viewbox_width;
-                        control_1_y: viewbox_height - datapoints.values.g / 100 * viewbox_height;
-                        control_2_x: 6/7 * viewbox_width;
-                        control_2_y: viewbox_height - datapoints.values.h / 100 * viewbox_height;
+                        x: 6.5/7 * viewbox-width;
+                        y: viewbox-height - datapoints.values.h / 100 * viewbox-height;
+                        control-1-x: 6/7 * viewbox-width;
+                        control-1-y: viewbox-height - datapoints.values.g / 100 * viewbox-height;
+                        control-2-x: 6/7 * viewbox-width;
+                        control-2-y: viewbox-height - datapoints.values.h / 100 * viewbox-height;
                     }
                     QuadraticTo {
-                        x: viewbox_width;
-                        y: viewbox_height - datapoints.values.i / 100 * viewbox_height;
-                        control_x: 7/7 * viewbox_width;
-                        control_y: viewbox_height - datapoints.values.h / 100 * viewbox_height;
+                        x: viewbox-width;
+                        y: viewbox-height - datapoints.values.i / 100 * viewbox-height;
+                        control-x: 7/7 * viewbox-width;
+                        control-y: viewbox-height - datapoints.values.h / 100 * viewbox-height;
                     }
                     LineTo {
-                        x: viewbox_width;
-                        y: viewbox_height;
+                        x: viewbox-width;
+                        y: viewbox-height;
                     }
                     LineTo {
                         x: 0;
-                        y: viewbox_height;
+                        y: viewbox-height;
                     }
                 }
             }
@@ -628,8 +628,8 @@ export UsageDiagram := Box {
             //background: blue;
             color: Skin.palette.text;
             text: day;
-            font_size: Skin.TinyFont;
-            horizontal_alignment: center;
+            font-size: Skin.TinyFont;
+            horizontal-alignment: center;
         }
 
     }
@@ -641,27 +641,27 @@ LightDimmer := Rectangle {
     property <brush> warmGradient <=> warm.fill;
 
     property <float> thickness: 8;
-    property <float> inner_radius: 50 - thickness;
+    property <float> inner-radius: 50 - thickness;
 
     property <float> value : 50%;
-    property <float> display_value : touch.pressed ? touch.new_value : value;
+    property <float> display-value : touch.pressed ? touch.new-value : value;
 
-    property <angle> angle : -180deg + 180deg * display_value;
+    property <angle> angle : -180deg + 180deg * display-value;
 
 
     back := PieChartBackground {
         width: 100%;
         height: 100%;
         thickness: root.thickness;
-        inner_radius: root.inner_radius;
+        inner-radius: root.inner-radius;
     }
 
     warm := PieChartFill {
         width: 100%;
         height: 100%;
         thickness: root.thickness;
-        inner_radius: root.inner_radius;
-        start: (display_value - 0.5) / 2;
+        inner-radius: root.inner-radius;
+        start: (display-value - 0.5) / 2;
         progress: 0.25 - start;
 
     }
@@ -670,8 +670,8 @@ LightDimmer := Rectangle {
         width: 100%;
         height: 100%;
         thickness: root.thickness;
-        inner_radius: root.inner_radius;
-        start: (display_value - 0.5) / 2;
+        inner-radius: root.inner-radius;
+        start: (display-value - 0.5) / 2;
         progress: -0.25 - start;
     }
 
@@ -706,10 +706,10 @@ LightDimmer := Rectangle {
 
     touch := TouchArea {
 
-        property<float> new_value : min(1, max(0, mouse_x / height));
+        property<float> new-value : min(1, max(0, mouse-x / height));
 
         clicked => {
-            root.value = new_value;
+            root.value = new-value;
         }
     }
 }
@@ -720,11 +720,11 @@ export LightIntensity := Box {
     preferred-height: width;
 
     Rectangle {
-        vertical_stretch: 1;
+        vertical-stretch: 1;
         HorizontalLayout {
             leftLabel := Text {
                 text: "  0";
-                font_size: Skin.SmallFont;
+                font-size: Skin.SmallFont;
                 vertical-alignment: center;
             }
 
@@ -735,7 +735,7 @@ export LightIntensity := Box {
 
             rightLabel := Text {
                 text: "100";
-                font_size: Skin.SmallFont;
+                font-size: Skin.SmallFont;
                 vertical-alignment: center;
             }
         }
@@ -746,8 +746,8 @@ export LightIntensity := Box {
             x: dimmer.x;
             y: dimmer.y;
             color: #929cb2;
-            text: "\{round(dimmer.display_value * 100)}%";
-            font_size: Skin.MediumFont;
+            text: "\{round(dimmer.display-value * 100)}%";
+            font-size: Skin.MediumFont;
             vertical-alignment: center;
             horizontal-alignment: center;
         }
@@ -759,7 +759,7 @@ MenuItem := Rectangle {
     property <image> icon <=> i.source;
     property<string> name <=> t.text;
     property<bool> active;
-    background: active ? rgba(100%, 100%, 100%, 14%) : ma.has_hover ? rgba(100%, 100%, 100%, 9%) : transparent;
+    background: active ? rgba(100%, 100%, 100%, 14%) : ma.has-hover ? rgba(100%, 100%, 100%, 9%) : transparent;
     ma := TouchArea {}
     HorizontalLayout {
         alignment: start;

--- a/examples/memory/memory.60
+++ b/examples/memory/memory.60
@@ -10,14 +10,14 @@ LICENSE END */
 
 struct TileData := {
     image: image,
-    image_visible: bool,
+    image-visible: bool,
     solved: bool,
 }
 
 MemoryTile := Rectangle {
     border-radius: 8px;
     callback clicked;
-    property <bool> open_curtain;
+    property <bool> open-curtain;
     property <bool> solved;
     property <image> icon;
 
@@ -36,7 +36,7 @@ MemoryTile := Rectangle {
     Rectangle {
         background: #193076;
         border-radius: 4px;
-        width: open_curtain ? 0px : parent.width / 2 + 4px;
+        width: open-curtain ? 0px : parent.width / 2 + 4px;
         height: parent.height;
         animate width { duration: 250ms; easing: ease-in; }
         clip: true;
@@ -51,11 +51,11 @@ MemoryTile := Rectangle {
     }
 
     // Right curtain
-    right_curtain := Rectangle {
+    right-curtain := Rectangle {
         background: #193076;
         border-radius: 4px;
-        x: open_curtain ? parent.width : parent.width / 2 - 4px;
-        width: open_curtain ? 0px : parent.width / 2 + 4px;
+        x: open-curtain ? parent.width : parent.width / 2 - 4px;
+        width: open-curtain ? 0px : parent.width / 2 + 4px;
         height: parent.height;
         animate width { duration: 250ms; easing: ease-in; }
         animate x { duration: 250ms; easing: ease-in; }
@@ -64,7 +64,7 @@ MemoryTile := Rectangle {
         Image {
             width: root.width - 32px;
             height: root.height - 32px;
-            x: right_curtain.width - width - 16px;
+            x: right-curtain.width - width - 16px;
             y: 16px;
             source: @image-url("icons/tile_logo.png");
         }
@@ -82,20 +82,20 @@ MemoryTile := Rectangle {
 export MainWindow := Window {
     title: "Memory Game - SixtyFPS Demo";
 
-    callback check_if_pair_solved();
-    property <bool> disable_tiles;
+    callback check-if-pair-solved();
+    property <bool> disable-tiles;
 
-    property<length> tile_size: 80px;
-    property<length> tile_spacing: 10px;
+    property<length> tile-size: 80px;
+    property<length> tile-spacing: 10px;
 
-    property <int> row_count: 4;
-    property <int> column_count: 4;
+    property <int> row-count: 4;
+    property <int> column-count: 4;
 
     // "column_count + 1" and "row_count + 1" are the number of gaps between the tiles.
-    width: (column_count * tile_size) + ((column_count + 1) * tile_spacing);
-    height: (row_count * tile_size) + ((row_count + 1) * tile_spacing);
+    width: (column-count * tile-size) + ((column-count + 1) * tile-spacing);
+    height: (row-count * tile-size) + ((row-count + 1) * tile-spacing);
 
-    property<[TileData]> memory_tiles : [
+    property<[TileData]> memory-tiles : [
         { image: @image-url("icons/at.png") },
         { image: @image-url("icons/balance-scale.png") },
         { image: @image-url("icons/bicycle.png") },
@@ -106,21 +106,21 @@ export MainWindow := Window {
         { image: @image-url("icons/video.png") },
     ];
 
-    for tile[i] in memory_tiles: MemoryTile {
-        x: tile_spacing + mod(i, column_count) * (tile_size + tile_spacing);
-        y: tile_spacing + floor(i / row_count) * (tile_size + tile_spacing);
-        width: tile_size;
-        height: tile_size;
+    for tile[i] in memory-tiles: MemoryTile {
+        x: tile-spacing + mod(i, column-count) * (tile-size + tile-spacing);
+        y: tile-spacing + floor(i / row-count) * (tile-size + tile-spacing);
+        width: tile-size;
+        height: tile-size;
 
         icon: tile.image;
 
-        open_curtain: tile.image_visible || tile.solved;
+        open-curtain: tile.image-visible || tile.solved;
         solved: tile.solved;
 
         clicked => {
-            if (!root.disable_tiles) {
-                tile.image_visible = !tile.image_visible;
-                root.check_if_pair_solved();
+            if (!root.disable-tiles) {
+                tile.image-visible = !tile.image-visible;
+                root.check-if-pair-solved();
             }
         }
     }

--- a/examples/plotter/plotter.60
+++ b/examples/plotter/plotter.60
@@ -14,8 +14,8 @@ export MainWindow := Window {
     preferred-width: 800px;
     preferred-height: 600px;
 
-    property plot_image <=> img.source;
-    property pitch <=> pitch_slider.value;
+    property plot-image <=> img.source;
+    property pitch <=> pitch-slider.value;
     callback redraw();
 
     VerticalLayout {
@@ -28,7 +28,7 @@ export MainWindow := Window {
         }
         GroupBox {
             title: "Pitch";
-            pitch_slider := Slider {
+            pitch-slider := Slider {
                 minimum: 0;
                 maximum: 180;
                 value: 42;

--- a/examples/printerdemo/ui/common.60
+++ b/examples/printerdemo/ui/common.60
@@ -16,63 +16,63 @@ struct ButtonColors := {
 
 export global DemoPalette := {
     // Color of the home/settings/ink buttons on the left side bar
-    property <color> active_page_icon_color: night_mode ? #6284FF : #122F7B;
-    property <color> inactive_page_icon_color: #BDC0D1;
+    property <color> active-page-icon-color: night-mode ? #6284FF : #122F7B;
+    property <color> inactive-page-icon-color: #BDC0D1;
 
-    property <color> main_background: #0E133F;
-    property <color> neutral_box: #BDC0D1;
+    property <color> main-background: #0E133F;
+    property <color> neutral-box: #BDC0D1;
 
-    property <color> page_background_color: night_mode ? #122F7B : white;
+    property <color> page-background-color: night-mode ? #122F7B : white;
 
-    property <color> text_foreground_color: night_mode ? #F4F6FF : black;
-    property <color> secondary_foreground_color: #6C6E7A; // FIXME: night mode
+    property <color> text-foreground-color: night-mode ? #F4F6FF : black;
+    property <color> secondary-foreground-color: #6C6E7A; // FIXME: night mode
 
-    property <color> printer_action_background_color: night_mode ? main_background : white;
-    property <color> printer_queue_item_background_color: page_background_color;
+    property <color> printer-action-background-color: night-mode ? main-background : white;
+    property <color> printer-queue-item-background-color: page-background-color;
 
-    property <color> status_label_text_color: night_mode ? #F1FF98 : #6284FF;
+    property <color> status-label-text-color: night-mode ? #F1FF98 : #6284FF;
 
     // Color used for the border / outline of items that can be clicked on, such as the
     // "Print"/"Scan" buttons, the printer queue items (for expansion) or controls such
     // as the combo box or spin box.
-    property <color> control_outline_color: #FFBF63;
-    property <color> control_secondary: #6284FF;
-    property <color> control_foreground: night_mode ? white : #122F7B;  // FIXME: the night mode color was not part of the design
+    property <color> control-outline-color: #FFBF63;
+    property <color> control-secondary: #6284FF;
+    property <color> control-foreground: night-mode ? white : #122F7B;  // FIXME: the night mode color was not part of the design
 
-    property <color> primary_push_button_base: #6284FF;
-    property <ButtonColors> primary_push_button_colors: {
-        base: primary_push_button_base,
-        pressed: primary_push_button_base.darker(40%),
-        hovered: primary_push_button_base.darker(20%),
+    property <color> primary-push-button-base: #6284FF;
+    property <ButtonColors> primary-push-button-colors: {
+        base: primary-push-button-base,
+        pressed: primary-push-button-base.darker(40%),
+        hovered: primary-push-button-base.darker(20%),
     };
 
-    property <color> secondary_push_button_base: #FFBF63;
-    property <ButtonColors> secondary_push_button_colors: {
-        base: secondary_push_button_base,
-        pressed: secondary_push_button_base.darker(40%),
-        hovered: secondary_push_button_base.darker(20%),
+    property <color> secondary-push-button-base: #FFBF63;
+    property <ButtonColors> secondary-push-button-colors: {
+        base: secondary-push-button-base,
+        pressed: secondary-push-button-base.darker(40%),
+        hovered: secondary-push-button-base.darker(20%),
     };
 
 
-    property <color> push_button_text_color: white;
+    property <color> push-button-text-color: white;
 
-    property <length> base_font_size: 16px;
+    property <length> base-font-size: 16px;
 
-    property <bool> night_mode: false;
+    property <bool> night-mode: false;
 }
 
 export Page := Rectangle {
     property<string> header <=> h.text;
-    background: DemoPalette.page_background_color;
-    property <bool> has_back_button: false;
+    background: DemoPalette.page-background-color;
+    property <bool> has-back-button: false;
     callback back;
 
     TouchArea {} // protect underneath controls
 
-    if (has_back_button) : Image {
+    if (has-back-button) : Image {
         source: @image-url("images/back.svg");
         image-fit: contain;
-        colorize: DemoPalette.control_secondary;
+        colorize: DemoPalette.control-secondary;
         y: h.y + (h.height - height) / 2;
         width: 14px;
         height: 24px;
@@ -84,13 +84,13 @@ export Page := Rectangle {
 
     h := Text {
         font-weight: 900;
-        font-size: DemoPalette.base_font_size * 2;
-        color: DemoPalette.text_foreground_color;
+        font-size: DemoPalette.base-font-size * 2;
+        color: DemoPalette.text-foreground-color;
         y: 46px - font-size;
-        x: has_back_button ? 24px + 16px : 0px;
+        x: has-back-button ? 24px + 16px : 0px;
         // Allow clicking on the title as well to get back easier when just
         // using fingers on a small screen.
-        if (has_back_button) : TouchArea {
+        if (has-back-button) : TouchArea {
             clicked => { back() }
         }
     }
@@ -103,11 +103,11 @@ export struct PrinterQueueItem := {
     owner: string,
     pages: int,
     size: string, // number instead and format in .60?
-    submission_date: string
+    submission-date: string
 }
 
 export Label := Text {
-    color: DemoPalette.text_foreground_color;
+    color: DemoPalette.text-foreground-color;
     vertical-alignment: center;
     font-weight: 700;
     vertical-stretch: 0;
@@ -118,7 +118,7 @@ SquareButton := Rectangle {
     property<image> img;
     border-radius: 3px;
     border-width: 2px;
-    border-color: DemoPalette.control_outline_color;
+    border-color: DemoPalette.control-outline-color;
     touch := TouchArea {
         clicked => {
             root.clicked();
@@ -131,7 +131,7 @@ SquareButton := Rectangle {
         y: (parent.height - height)/2;
         source <=> root.img;
         image-fit: contain;
-        colorize: DemoPalette.control_secondary;
+        colorize: DemoPalette.control-secondary;
     }
 }
 
@@ -157,14 +157,14 @@ export SpinBox := Rectangle {
         Rectangle {
             border-radius: 3px;
             border-width: 2px;
-            border-color: DemoPalette.control_outline_color;
+            border-color: DemoPalette.control-outline-color;
             Text {
                 width: 100%;
                 height: 100%;
                 vertical-alignment: center;
                 horizontal-alignment: center;
                 text: value;
-                color: DemoPalette.control_foreground;
+                color: DemoPalette.control-foreground;
             }
         }
 
@@ -185,20 +185,20 @@ export ComboBox := Rectangle {
     property<[string]> choices;
     border-radius: 3px;
     border-width: 2px;
-    border-color: DemoPalette.control_outline_color;
+    border-color: DemoPalette.control-outline-color;
     height: 32px;
     min-width: label.x + label.width + i.width;
     label := Text {
         vertical-alignment: center;
         horizontal-alignment: left;
         text <=> root.value;
-        color: DemoPalette.control_foreground;
+        color: DemoPalette.control-foreground;
         height: 100%;
         x: 12px;
     }
     i := Image {
         source: @image-url("images/down.svg");
-        colorize: DemoPalette.control_secondary;
+        colorize: DemoPalette.control-secondary;
         height: 40%;
         width: height;
         image-fit: contain;
@@ -216,25 +216,25 @@ export ComboBox := Rectangle {
         y: root.height;
         width: root.width;
         Rectangle {
-            background: DemoPalette.page_background_color;
+            background: DemoPalette.page-background-color;
             border-radius: 3px;
             border-width: 2px;
-            border-color: DemoPalette.control_outline_color;
+            border-color: DemoPalette.control-outline-color;
         }
         VerticalLayout {
             spacing: 6px;
             padding: 3px;
             for value[idx] in root.choices: Rectangle {
                 border-radius: 3px;
-                background: item_area.has_hover ? DemoPalette.primary_push_button_colors.hovered : #0000;
+                background: item-area.has-hover ? DemoPalette.primary-push-button-colors.hovered : #0000;
                 HorizontalLayout {
                     Text {
                         text: value;
-                        color: item_area.has_hover ? DemoPalette.push_button_text_color : DemoPalette.text_foreground_color;
-                        font-size: DemoPalette.base_font_size;
+                        color: item-area.has-hover ? DemoPalette.push-button-text-color : DemoPalette.text-foreground-color;
+                        font-size: DemoPalette.base-font-size;
                     }
                 }
-                item_area := TouchArea {
+                item-area := TouchArea {
                     clicked => {
                         root.value = value;
                     }
@@ -263,7 +263,7 @@ export CheckBox := Rectangle {
             text <=> root.text;
             vertical-alignment: center;
             horizontal-alignment: center;
-            color: DemoPalette.control_foreground;
+            color: DemoPalette.control-foreground;
             horizontal-stretch: 1;
         }
     }
@@ -280,13 +280,13 @@ export PushButton := Rectangle {
     property <string> text <=> label.text;
     property <image> icon <=> img.source;
     property <bool> primary: true;
-    property <bool> pressed: touch_area.pressed;
+    property <bool> pressed: touch-area.pressed;
 
-    property <ButtonColors> colors: primary ? DemoPalette.primary_push_button_colors : DemoPalette.secondary_push_button_colors;
+    property <ButtonColors> colors: primary ? DemoPalette.primary-push-button-colors : DemoPalette.secondary-push-button-colors;
 
     border-radius: 13.5px;
 
-    background: pressed ? colors.pressed : (touch_area.has_hover ? colors.hovered : colors.base);
+    background: pressed ? colors.pressed : (touch-area.has-hover ? colors.hovered : colors.base);
 
     height: 27px; // line-height in the design
     horizontal-stretch: 1;
@@ -294,24 +294,24 @@ export PushButton := Rectangle {
     HorizontalLayout {
         padding-top: 0px;
         padding-bottom: 0px;
-        padding-left: parent.border_radius;
-        padding-right: parent.border_radius;
+        padding-left: parent.border-radius;
+        padding-right: parent.border-radius;
 
         img := Image {
             horizontal-stretch: 0;
-            colorize: DemoPalette.push_button_text_color;
+            colorize: DemoPalette.push-button-text-color;
             image-fit: contain;
             width: 17px;
         }
 
         label := Text {
             font-weight: 900;
-            font-size: DemoPalette.base_font_size * 0.975;
-            color: DemoPalette.push_button_text_color;
+            font-size: DemoPalette.base-font-size * 0.975;
+            color: DemoPalette.push-button-text-color;
             horizontal-alignment: center;
             vertical-alignment: center;
         }
     }
 
-    touch_area := TouchArea { clicked => { root.clicked() } }
+    touch-area := TouchArea { clicked => { root.clicked() } }
 }

--- a/examples/printerdemo/ui/copy_page.60
+++ b/examples/printerdemo/ui/copy_page.60
@@ -12,8 +12,8 @@ import { DemoPalette, Page, SpinBox, Label, ComboBox, PushButton, CheckBox } fro
 
 
 export CopyPage := Page {
-    callback start_job(string);
-    has_back_button: true;
+    callback start-job(string);
+    has-back-button: true;
     header: "Copy";
 
     GridLayout {
@@ -23,8 +23,8 @@ export CopyPage := Page {
         Row {
             Text {
                 text: "Choose Settings";
-                color: DemoPalette.secondary_foreground_color;
-                font-size: DemoPalette.base_font_size * 1.125;
+                color: DemoPalette.secondary-foreground-color;
+                font-size: DemoPalette.base-font-size * 1.125;
                 font-weight: 800;
             }
         }
@@ -101,7 +101,7 @@ export CopyPage := Page {
                     icon: @image-url("images/copy.svg");
                     text: "Start copying";
                     clicked => {
-                        root.start_job("Copy");
+                        root.start-job("Copy");
                     }
                 }
                 Rectangle {

--- a/examples/printerdemo/ui/home_page.60
+++ b/examples/printerdemo/ui/home_page.60
@@ -27,21 +27,21 @@ ActionButton := Rectangle {
         Rectangle {
             border-radius: 25px;
             border-width: 5px;
-            border-color: DemoPalette.control_outline_color;
-            background: DemoPalette.printer_action_background_color;
+            border-color: DemoPalette.control-outline-color;
+            background: DemoPalette.printer-action-background-color;
 
             img := Image {
                 x: (parent.width / 2) - (self.width / 2);
                 y: (parent.height / 2) - (self.height / 2);
-                colorize: DemoPalette.text_foreground_color;
+                colorize: DemoPalette.text-foreground-color;
             }
         }
 
         label := Text {
-            font-size: DemoPalette.base_font_size * 1.375;
+            font-size: DemoPalette.base-font-size * 1.375;
             font-weight: 800;
             horizontal-alignment: center;
-            color: DemoPalette.text_foreground_color;
+            color: DemoPalette.text-foreground-color;
         }
     }
 
@@ -49,19 +49,19 @@ ActionButton := Rectangle {
 }
 
 export HomePage := Page {
-    callback start_job(string);
-    callback cancel_job(int);
-    callback pause_job(int);
-    property <length> header_row_height: 40px;
-    property <[PrinterQueueItem]> printer_queue;
+    callback start-job(string);
+    callback cancel-job(int);
+    callback pause-job(int);
+    property <length> header-row-height: 40px;
+    property <[PrinterQueueItem]> printer-queue;
 
-    property <length> button_spacing: 35px;
-    property <length> button_width: 127px;
-    property <length> button_height: button_width + 37px;
+    property <length> button-spacing: 35px;
+    property <length> button-width: 127px;
+    property <length> button-height: button-width + 37px;
 
     header: "Xerol 1347 hdp";
 
-    property <int> current_subpage: 0;
+    property <int> current-subpage: 0;
 
 
     for action[idx] in [
@@ -70,50 +70,50 @@ export HomePage := Page {
         { name: "Copy", icon: @image-url("images/copy.svg") },
         { name: "USB", icon: @image-url("images/usb.svg") },
     ]: ActionButton {
-        x: mod(idx, 2) * (button_width + button_spacing);
-        y: floor(idx / 2) * (button_height + button_spacing)
+        x: mod(idx, 2) * (button-width + button-spacing);
+        y: floor(idx / 2) * (button-height + button-spacing)
            + /* header row height */ 46px
            + /* top-padding of printer queue */ 27px; // align with the first item of the printer queue
-        width: button_width;
-        height: button_height;
+        width: button-width;
+        height: button-height;
         icon: action.icon;
         text: action.name;
-        clicked => { current_subpage = idx + 1; }
+        clicked => { current-subpage = idx + 1; }
     }
 
-    queue_view := PrinterQueue {
+    queue-view := PrinterQueue {
         x: parent.width - width;
         width: 313px;
-        printer_queue: root.printer_queue;
-        show_job_details(idx) => {
-            current_subpage = 1; // Not nice to hard-code the index here...
+        printer-queue: root.printer-queue;
+        show-job-details(idx) => {
+            current-subpage = 1; // Not nice to hard-code the index here...
         }
     }
 
     PrintPage {
-        x: current_subpage == 1 ? 0 : parent.width + parent.x + 2px;
+        x: current-subpage == 1 ? 0 : parent.width + parent.x + 2px;
         animate x { duration: 125ms; easing: ease; }
-        back => { current_subpage = 0 }
-        printer_queue: root.printer_queue;
-        cancel_job(id) => { root.cancel_job(id); }
-        pause_job(id) => { root.pause_job(id); }
+        back => { current-subpage = 0 }
+        printer-queue: root.printer-queue;
+        cancel-job(id) => { root.cancel-job(id); }
+        pause-job(id) => { root.pause-job(id); }
     }
     ScanPage {
-        x: current_subpage == 2 ? 0 : parent.width + parent.x + 2px;
+        x: current-subpage == 2 ? 0 : parent.width + parent.x + 2px;
         animate x { duration: 125ms; easing: ease; }
-        back => { current_subpage = 0 }
-        start_job(title) => { root.start_job(title); }
+        back => { current-subpage = 0 }
+        start-job(title) => { root.start-job(title); }
     }
     CopyPage {
-        x: current_subpage == 3 ? 0 : parent.width + parent.x + 2px;
+        x: current-subpage == 3 ? 0 : parent.width + parent.x + 2px;
         animate x { duration: 125ms; easing: ease; }
-        back => { current_subpage = 0 }
-        start_job(title) => { root.start_job(title); }
+        back => { current-subpage = 0 }
+        start-job(title) => { root.start-job(title); }
     }
     UsbPage {
-        x: current_subpage == 4 ? 0 : parent.width + parent.x + 2px;
+        x: current-subpage == 4 ? 0 : parent.width + parent.x + 2px;
         animate x { duration: 125ms; easing: ease; }
-        back => { current_subpage = 0 }
-        start_job(title) => { root.start_job(title); }
+        back => { current-subpage = 0 }
+        start-job(title) => { root.start-job(title); }
     }
 }

--- a/examples/printerdemo/ui/ink_page.60
+++ b/examples/printerdemo/ui/ink_page.60
@@ -18,8 +18,8 @@ export struct InkLevel := {
 export InkPage := Page {
     header: "Ink Level";
 
-    property <[InkLevel]> ink_levels;
-    property <bool> page_visible;
+    property <[InkLevel]> ink-levels;
+    property <bool> page-visible;
 
 
     Rectangle {
@@ -30,30 +30,30 @@ export InkPage := Page {
 
         HorizontalLayout {
             spacing: root.width * 5%;
-            for color_info in ink_levels : Rectangle {
+            for color-info in ink-levels : Rectangle {
                 ink := Rectangle {
                     width: parent.width;
-                    height: parent.height * color_info.level;
+                    height: parent.height * color-info.level;
                     y: parent.height - self.height;
                     clip: true;
                     Rectangle {
-                        background: color_info.color;
+                        background: color-info.color;
                         border-radius: width / 2;
                         border-width: 2px;
                         height: parent.height + parent.y;
                         y: -parent.y;
                     }
                     states [
-                        innactive when !root.page_visible : {
+                        innactive when !root.page-visible : {
                             height: 0;
                         }
                     ]
                     transitions [
                         out innactive : {
-                            animate height { duration: 750ms; easing: ease_in_out; }
+                            animate height { duration: 750ms; easing: ease-in-out; }
                         }
                         in innactive : {
-                            animate height { duration: 200ms; easing: ease_in; }
+                            animate height { duration: 200ms; easing: ease-in; }
                         }
                     ]
                 }
@@ -66,12 +66,12 @@ export InkPage := Page {
                     property <length> y2: max(0phx, max(r - y, y - parent.height + r));
                     width: 2*sqrt((r*r - y2*y2)/(1phx * 1phx))*1phx;  // FIXME: it would be nice if sqrt could do proper unit handling
                     x: (parent.width - width) / 2;
-                    background: DemoPalette.neutral_box;
+                    background: DemoPalette.neutral-box;
                 }
 
                 Rectangle {
                     border-radius: width / 2;
-                    border-color: DemoPalette.neutral_box;
+                    border-color: DemoPalette.neutral-box;
                     border-width: 2px;
                 }
             }

--- a/examples/printerdemo/ui/print_page.60
+++ b/examples/printerdemo/ui/print_page.60
@@ -13,12 +13,12 @@ import { WidePrinterQueueList } from "./printer_queue.60";
 
 
 export PrintPage := Page {
-    has_back_button: true;
+    has-back-button: true;
     header: "Print";
-    callback cancel_job(int);
-    callback pause_job(int);
+    callback cancel-job(int);
+    callback pause-job(int);
 
-    property <[PrinterQueueItem]> printer_queue <=> queue.printer_queue;
+    property <[PrinterQueueItem]> printer-queue <=> queue.printer-queue;
 
     GridLayout {
         padding-top: 46px /* header line height in design */
@@ -27,17 +27,17 @@ export PrintPage := Page {
         Row {
             Text {
                 text: "Printing-Queue";
-                color: DemoPalette.secondary_foreground_color;
-                font-size: DemoPalette.base_font_size * 1.125;
+                color: DemoPalette.secondary-foreground-color;
+                font-size: DemoPalette.base-font-size * 1.125;
                 font-weight: 800;
             }
         }
 
         Row {
             queue := WidePrinterQueueList {
-                cancel_job(id) => { root.cancel_job(id); }
-                pause_job(id) => { root.pause_job(id); }
-                viewport_width: width;
+                cancel-job(id) => { root.cancel-job(id); }
+                pause-job(id) => { root.pause-job(id); }
+                viewport-width: width;
             }
         }
     }

--- a/examples/printerdemo/ui/printer_queue.60
+++ b/examples/printerdemo/ui/printer_queue.60
@@ -12,9 +12,9 @@ import { DemoPalette, PrinterQueueItem, PushButton } from "./common.60";
 
 PrintQueueDetailsLabel := Text {
     font-weight: 500;
-    color: DemoPalette.control_foreground;
+    color: DemoPalette.control-foreground;
     horizontal-stretch: 0;
-    font-size: DemoPalette.base_font_size * 0.9375;
+    font-size: DemoPalette.base-font-size * 0.9375;
 }
 
 PrintQueueSeparator := Rectangle {
@@ -25,7 +25,7 @@ PrintQueueSeparator := Rectangle {
 }
 
 PrintDetails := GridLayout {
-    property <PrinterQueueItem> queue_item;
+    property <PrinterQueueItem> queue-item;
     spacing: 3px;
 
     Row {
@@ -33,11 +33,11 @@ PrintDetails := GridLayout {
             text: "Owner";
         }
         Text {
-            text: queue_item.owner;
-            color: DemoPalette.secondary_foreground_color;
+            text: queue-item.owner;
+            color: DemoPalette.secondary-foreground-color;
             overflow: elide;
             horizontal-stretch: 1;
-            font-size: DemoPalette.base_font_size * 0.9375;
+            font-size: DemoPalette.base-font-size * 0.9375;
         }
     }
     Row {
@@ -50,11 +50,11 @@ PrintDetails := GridLayout {
             text: "Pages";
         }
         Text {
-            text: queue_item.pages;
-            color: DemoPalette.secondary_foreground_color;
+            text: queue-item.pages;
+            color: DemoPalette.secondary-foreground-color;
             overflow: elide;
             horizontal-stretch: 1;
-            font-size: DemoPalette.base_font_size * 0.9375;
+            font-size: DemoPalette.base-font-size * 0.9375;
         }
     }
     Row {
@@ -67,11 +67,11 @@ PrintDetails := GridLayout {
             text: "Size";
         }
         Text {
-            text: queue_item.pages;
-            color: DemoPalette.secondary_foreground_color;
+            text: queue-item.pages;
+            color: DemoPalette.secondary-foreground-color;
             overflow: elide;
             horizontal-stretch: 1;
-            font-size: DemoPalette.base_font_size * 0.9375;
+            font-size: DemoPalette.base-font-size * 0.9375;
         }
     }
     Row {
@@ -84,43 +84,43 @@ PrintDetails := GridLayout {
             text: "Submitted";
         }
         Text {
-            text: queue_item.submission_date;
-            color: DemoPalette.secondary_foreground_color;
+            text: queue-item.submission-date;
+            color: DemoPalette.secondary-foreground-color;
             overflow: elide;
             horizontal-stretch: 1;
-            font-size: DemoPalette.base_font_size * 0.9375;
+            font-size: DemoPalette.base-font-size * 0.9375;
         }
     }
 }
 
 NarrowPrintQueueElement := Rectangle {
-    property <PrinterQueueItem> queue_item;
-    callback show_job_details();
+    property <PrinterQueueItem> queue-item;
+    callback show-job-details();
 
-    border-color: DemoPalette.control_outline_color;
+    border-color: DemoPalette.control-outline-color;
     border-radius: 14px;
     border-width: 2px;
-    background: DemoPalette.printer_queue_item_background_color;
+    background: DemoPalette.printer-queue-item-background-color;
     clip: true;
 
     property <bool> expanded;
-    property <float> expanded_opacity: 0;
+    property <float> expanded-opacity: 0;
 
-    height: always_visible.min-height + layout.padding * 2;
+    height: always-visible.min-height + layout.padding * 2;
     states [
         expanded when expanded : {
             height: layout.min-height;
-            expanded_opacity: 1;
+            expanded-opacity: 1;
         }
     ]
     transitions [
         in expanded : {
             animate height { duration: 200ms; easing: ease; }
-            animate expanded_opacity { duration: 200ms; }
+            animate expanded-opacity { duration: 200ms; }
         }
         out expanded : {
             animate height { duration: 200ms; easing: ease; }
-            animate expanded_opacity { duration: 200ms; }
+            animate expanded-opacity { duration: 200ms; }
         }
     ]
 
@@ -133,55 +133,55 @@ NarrowPrintQueueElement := Rectangle {
     Rectangle {
         height: 100%;
         layout := VerticalLayout {
-            padding: root.border_radius;
+            padding: root.border-radius;
             spacing: 4px;
             alignment: start;
 
-            always_visible := VerticalLayout {
+            always-visible := VerticalLayout {
                 padding: 0;
                 spacing: parent.spacing;
 
                 Text {
                     // TODO: text-transform: uppercase
                     text: {
-                        if (queue_item.status == "PRINTING") {
-                        "\{queue_item.progress}% - \{queue_item.status}"
+                        if (queue-item.status == "PRINTING") {
+                        "\{queue-item.progress}% - \{queue-item.status}"
                         } else {
-                            queue_item.status
+                            queue-item.status
                         }
                     }
-                    color: DemoPalette.status_label_text_color;
-                    font-size: DemoPalette.base_font_size * 0.75;
+                    color: DemoPalette.status-label-text-color;
+                    font-size: DemoPalette.base-font-size * 0.75;
                     font-weight: 800;
                     letter-spacing: 1.56px;
                 }
 
                 Text {
-                    text: queue_item.title;
+                    text: queue-item.title;
                     overflow: elide;
-                    color: DemoPalette.text_foreground_color;
+                    color: DemoPalette.text-foreground-color;
                     font-weight: 800;
-                    font-size: DemoPalette.base_font_size * 1.125;
+                    font-size: DemoPalette.base-font-size * 1.125;
                 }
             }
 
-            if (expanded || expanded_opacity > 0) : PrintDetails {
+            if (expanded || expanded-opacity > 0) : PrintDetails {
                 padding: 0px;
                 padding-bottom: root.border-radius / 2;
-                queue_item: root.queue_item;
-                opacity: expanded_opacity;
+                queue-item: root.queue-item;
+                opacity: expanded-opacity;
             }
 
-            if (expanded || expanded_opacity > 0) : HorizontalLayout {
+            if (expanded || expanded-opacity > 0) : HorizontalLayout {
                 Rectangle {
                     horizontal-stretch: 0;
                     width: 10%;
                 }
                 PushButton {
-                    opacity: expanded_opacity;
+                    opacity: expanded-opacity;
                     text: "More   ";
                     clicked => {
-                        root.show_job_details();
+                        root.show-job-details();
                     }
                 }
                 Rectangle {
@@ -194,18 +194,18 @@ NarrowPrintQueueElement := Rectangle {
 }
 
 NarrowPrinterQueueList := Flickable {
-    callback show_job_details(int);
-    property <[PrinterQueueItem]> printer_queue;
+    callback show-job-details(int);
+    property <[PrinterQueueItem]> printer-queue;
     VerticalLayout {
         alignment: start;
         padding: 0px;
         spacing: 13.5px;
 
-        for queue_item[idx] in root.printer_queue: NarrowPrintQueueElement {
+        for queue-item[idx] in root.printer-queue: NarrowPrintQueueElement {
             width: root.width;
-            queue_item: queue_item;
-            show_job_details => {
-                root.show_job_details(idx)
+            queue-item: queue-item;
+            show-job-details => {
+                root.show-job-details(idx)
             }
         }
     }
@@ -223,29 +223,29 @@ ProgressBar := Rectangle {
         height: 6px;
 
         border-radius: 3px;
-        background: DemoPalette.neutral_box;
+        background: DemoPalette.neutral-box;
 
         Rectangle {
             width: max(6px, progress * parent.width / 100);
             border-radius: parent.border-radius;
-            background: DemoPalette.control_foreground;
+            background: DemoPalette.control-foreground;
         }
     }
 }
 
 WidePrintQueueElement := Rectangle {
-    callback cancel_job();
-    callback pause_job();
+    callback cancel-job();
+    callback pause-job();
 
-    property <PrinterQueueItem> queue_item;
+    property <PrinterQueueItem> queue-item;
 
-    border-color: DemoPalette.neutral_box;
+    border-color: DemoPalette.neutral-box;
     border-radius: 14px;
     border-width: 2px;
-    background: DemoPalette.printer_queue_item_background_color;
+    background: DemoPalette.printer-queue-item-background-color;
 
     GridLayout {
-        padding: parent.border_radius;
+        padding: parent.border-radius;
         spacing: 3px;
 
         HorizontalLayout {
@@ -253,14 +253,14 @@ WidePrintQueueElement := Rectangle {
             Text {
                 // TODO: text-transform: uppercase
                 text: {
-                    if (queue_item.status == "PRINTING") {
-                    "\{queue_item.progress}% - \{queue_item.status}"
+                    if (queue-item.status == "PRINTING") {
+                    "\{queue-item.progress}% - \{queue-item.status}"
                     } else {
-                        queue_item.status
+                        queue-item.status
                     }
                 }
-                color: DemoPalette.status_label_text_color;
-                font-size: DemoPalette.base_font_size * 0.75;
+                color: DemoPalette.status-label-text-color;
+                font-size: DemoPalette.base-font-size * 0.75;
                 font-weight: 700;
                 letter-spacing: 1.56px;
                 horizontal-stretch: 1;
@@ -270,18 +270,18 @@ WidePrintQueueElement := Rectangle {
                 // In principle it should be the smaller size which would fit next to the text foe each entry
                 // But since it is too hard to compute, just hardcode that for now
                 width: 50%; // 164px;
-                progress: queue_item.progress;
+                progress: queue-item.progress;
             }
         }
 
         Text {
             col: 0;
             row: 1;
-            text: queue_item.title;
-            color: DemoPalette.text_foreground_color;
+            text: queue-item.title;
+            color: DemoPalette.text-foreground-color;
             overflow: elide;
             font-weight: 700;
-            font-size: DemoPalette.base_font_size * 1.125;
+            font-size: DemoPalette.base-font-size * 1.125;
             horizontal-stretch: 1;
         }
 
@@ -295,13 +295,13 @@ WidePrintQueueElement := Rectangle {
             PushButton {
                 text: "Pause";
                 icon: @image-url("images/pause.svg");
-                clicked => { pause_job(); }
+                clicked => { pause-job(); }
             }
             PushButton {
                 primary: false;
                 text: "Delete";
                 icon: @image-url("images/delete.svg");
-                clicked => { cancel_job(); }
+                clicked => { cancel-job(); }
             }
         }
 
@@ -312,37 +312,37 @@ WidePrintQueueElement := Rectangle {
             width: 40%;
             padding: 0px;
             padding-bottom: root.border-radius / 2;
-            queue_item: root.queue_item;
-            horizontal_stretch: 1;
+            queue-item: root.queue-item;
+            horizontal-stretch: 1;
         }
     }
 }
 
 
 export WidePrinterQueueList := Flickable {
-    callback cancel_job(int);
-    callback pause_job(int);
-    property <[PrinterQueueItem]> printer_queue;
+    callback cancel-job(int);
+    callback pause-job(int);
+    property <[PrinterQueueItem]> printer-queue;
 
     VerticalLayout {
         alignment: start;
         padding: 0px;
         spacing: 13.5px;
 
-        for queue_item[idx] in root.printer_queue: WidePrintQueueElement {
-            queue_item: queue_item;
-            cancel_job => { root.cancel_job(idx) }
-            pause_job => { root.pause_job(idx) }
+        for queue-item[idx] in root.printer-queue: WidePrintQueueElement {
+            queue-item: queue-item;
+            cancel-job => { root.cancel-job(idx) }
+            pause-job => { root.pause-job(idx) }
         }
     }
 }
 
 export PrinterQueue := Rectangle {
-    property <[PrinterQueueItem]> printer_queue <=> queue_list.printer_queue;
-    callback show_job_details(int);
+    property <[PrinterQueueItem]> printer-queue <=> queue-list.printer-queue;
+    callback show-job-details(int);
 
     border-radius: 27px;
-    background: DemoPalette.night_mode ? DemoPalette.printer_action_background_color : #F4F6FF;
+    background: DemoPalette.night-mode ? DemoPalette.printer-action-background-color : #F4F6FF;
 
     VerticalLayout {
         padding: 16px;
@@ -350,15 +350,15 @@ export PrinterQueue := Rectangle {
 
         Text {
             text: "Printing-Queue";
-            color: DemoPalette.text_foreground_color;
-            font-size: DemoPalette.base_font_size * 1.5;
+            color: DemoPalette.text-foreground-color;
+            font-size: DemoPalette.base-font-size * 1.5;
             font-weight: 700;
         }
 
-        queue_list := NarrowPrinterQueueList {
+        queue-list := NarrowPrinterQueueList {
             width: root.width - 2*parent.padding; // FIXME why do we need this? bug in layout?
-            show_job_details(idx) => {
-                root.show_job_details(idx)
+            show-job-details(idx) => {
+                root.show-job-details(idx)
             }
         }
     }

--- a/examples/printerdemo/ui/printerdemo.60
+++ b/examples/printerdemo/ui/printerdemo.60
@@ -32,67 +32,67 @@ SideBarIcon := Rectangle {
 
 MainWindow := Window {
     callback quit();
-    callback start_job(string);
-    callback cancel_job(int);
-    callback pause_job(int);
+    callback start-job(string);
+    callback cancel-job(int);
+    callback pause-job(int);
 
-    property <[PrinterQueueItem]> printer_queue: [
-        { status: "PRINTING", progress: 63, title: "210106-FinalPresentation.pdf", owner: "simon.hausmann@sixtyfps.io", pages: 6, size: "143kb", submission_date: "11:41 25/01/21" },
-        { status: "WAITING...", title: "Adressliste.docx", owner: "simon.hausmann@sixtyfps.io", pages: 6, size: "143kb", submission_date: "11:41 25/01/21" },
-        { status: "WAITING...", title: "210106-FinalPresentation.pdf", owner: "simon.hausmann@sixtyfps.io", pages: 6, size: "143kb", submission_date: "11:41 25/01/21" },
+    property <[PrinterQueueItem]> printer-queue: [
+        { status: "PRINTING", progress: 63, title: "210106-FinalPresentation.pdf", owner: "simon.hausmann@sixtyfps.io", pages: 6, size: "143kb", submission-date: "11:41 25/01/21" },
+        { status: "WAITING...", title: "Adressliste.docx", owner: "simon.hausmann@sixtyfps.io", pages: 6, size: "143kb", submission-date: "11:41 25/01/21" },
+        { status: "WAITING...", title: "210106-FinalPresentation.pdf", owner: "simon.hausmann@sixtyfps.io", pages: 6, size: "143kb", submission-date: "11:41 25/01/21" },
     ];
 
     width: 772px;
     height: 504px;
     title: "SixtyFPS printer demo";
-    background: DemoPalette.main_background;
+    background: DemoPalette.main-background;
     default-font-family: "Noto Sans";
-    default-font-size: DemoPalette.base_font_size;
+    default-font-size: DemoPalette.base-font-size;
 
     /// Note that this property is overwriten in the .cpp and .rs code.
     /// The data is only in this file so it looks good in the viewer
-    property <[InkLevel]> ink_levels: [
+    property <[InkLevel]> ink-levels: [
                 {color: #0ff, level: 60%},
                 {color: #ff0, level: 80%},
                 {color: #f0f, level: 70%},
                 {color: #000, level: 30%},
             ];
 
-    property<int> active_page: 0;
+    property<int> active-page: 0;
 
     HorizontalLayout {
         padding: 10px;
         padding-left: 67px;
 
-        main_view := Rectangle {
+        main-view := Rectangle {
             height: 100%;
             border-radius: 30px;
-            background: DemoPalette.page_background_color;
+            background: DemoPalette.page-background-color;
 
             Rectangle {
                 clip: true;
-                x: main_view.border_radius / 2;
-                y: main_view.border_radius / 2;
-                width: main_view.width - main_view.border_radius;
-                height: main_view.height - main_view.border_radius;
+                x: main-view.border-radius / 2;
+                y: main-view.border-radius / 2;
+                width: main-view.width - main-view.border-radius;
+                height: main-view.height - main-view.border-radius;
 
-                home_page := HomePage {
-                    y: active_page == 0 ? 0 : active_page < 0 ? - height - 1px : parent.height + 1px;
+                home-page := HomePage {
+                    y: active-page == 0 ? 0 : active-page < 0 ? - height - 1px : parent.height + 1px;
                     animate y { duration: 125ms; easing: ease; }
-                    printer_queue: root.printer_queue;
-                    start_job(title) => { root.start_job(title); }
-                    cancel_job(title) => { root.cancel_job(title); }
-                    pause_job(title) => { root.pause_job(title); }
+                    printer-queue: root.printer-queue;
+                    start-job(title) => { root.start-job(title); }
+                    cancel-job(title) => { root.cancel-job(title); }
+                    pause-job(title) => { root.pause-job(title); }
                 }
                 SettingsPage {
-                    y: active_page == 1 ? 0 : active_page < 1 ? - height - 1px : parent.height + 1px;
+                    y: active-page == 1 ? 0 : active-page < 1 ? - height - 1px : parent.height + 1px;
                     animate y { duration: 125ms; easing: ease; }
                 }
                 InkPage {
-                    y: active_page == 2 ? 0 : active_page < 2 ? - height - 1px : parent.height + 1px;
+                    y: active-page == 2 ? 0 : active-page < 2 ? - height - 1px : parent.height + 1px;
                     animate y { duration: 125ms; easing: ease; }
-                    ink_levels <=> root.ink_levels;
-                    page_visible: active_page == 2;
+                    ink-levels <=> root.ink-levels;
+                    page-visible: active-page == 2;
                 }
             }
         }
@@ -102,51 +102,51 @@ MainWindow := Window {
         width: 57px;
         x: 10px;
 
-        callback icon_y(int) -> length;
-        icon_y(index) => {
+        callback icon-y(int) -> length;
+        icon-y(index) => {
             return 100px // top padding
                 + index * 72px;
         }
 
         Image {
             source: @image-url("images/page_selection.svg");
-            y: sidebar.icon_y(root.active_page) - self.width / 2;
+            y: sidebar.icon-y(root.active-page) - self.width / 2;
             animate y {
                 duration: 125ms;
             }
-            width: main_view.x - sidebar.x + 1px;
+            width: main-view.x - sidebar.x + 1px;
             height: 1.77 * self.width;
-            colorize: DemoPalette.page_background_color;
+            colorize: DemoPalette.page-background-color;
         }
 
-        for page_icon[idx] in [
+        for page-icon[idx] in [
             @image-url("images/home.svg"),
             @image-url("images/settings.svg"),
             @image-url("images/ink.svg"),
         ] : SideBarIcon {
-            y: sidebar.icon_y(idx);
+            y: sidebar.icon-y(idx);
             x: 16px;
             height: 35px;
             width: 30px;
 
             icon := Image {
-                colorize: (root.active_page == idx) ? DemoPalette.active_page_icon_color : DemoPalette.inactive_page_icon_color;
+                colorize: (root.active-page == idx) ? DemoPalette.active-page-icon-color : DemoPalette.inactive-page-icon-color;
                 animate colorize {
                     duration: 125ms;
                 }
-                source: page_icon;
+                source: page-icon;
                 image-fit: contain;
                 width: 100%;
                 height: 100%;
             }
 
             activate => {
-                root.active_page = idx;
+                root.active-page = idx;
             }
         }
 
         Rectangle {
-            y: sidebar.icon_y(3) + 17px;
+            y: sidebar.icon-y(3) + 17px;
             x: 12px;
             background: #6284FF;
             height: 2px;
@@ -154,21 +154,21 @@ MainWindow := Window {
         }
 
         SideBarIcon {
-            y: sidebar.icon_y(4);
+            y: sidebar.icon-y(4);
             x: 16px;
             height: 35px;
             width: 30px;
 
             Image {
-                colorize: DemoPalette.night_mode ? #F1FF98 : DemoPalette.inactive_page_icon_color;
-                source: DemoPalette.night_mode ? @image-url("images/moon_full.svg") : @image-url("images/moon.svg");
+                colorize: DemoPalette.night-mode ? #F1FF98 : DemoPalette.inactive-page-icon-color;
+                source: DemoPalette.night-mode ? @image-url("images/moon_full.svg") : @image-url("images/moon.svg");
                 image-fit: contain;
                 width: 100%;
                 height: 100%;
             }
 
             activate => {
-                DemoPalette.night_mode = !DemoPalette.night_mode;
+                DemoPalette.night-mode = !DemoPalette.night-mode;
             }
         }
 

--- a/examples/printerdemo/ui/scan_page.60
+++ b/examples/printerdemo/ui/scan_page.60
@@ -12,8 +12,8 @@ import { DemoPalette, Page, SpinBox, Label, ComboBox, PushButton } from "./commo
 
 
 export ScanPage := Page {
-    callback start_job(string);
-    has_back_button: true;
+    callback start-job(string);
+    has-back-button: true;
     header: "Scan";
 
     GridLayout {
@@ -23,8 +23,8 @@ export ScanPage := Page {
         Row {
             Text {
                 text: "Choose Settings";
-                color: DemoPalette.secondary_foreground_color;
-                font-size: DemoPalette.base_font_size * 1.125;
+                color: DemoPalette.secondary-foreground-color;
+                font-size: DemoPalette.base-font-size * 1.125;
                 font-weight: 800;
             }
         }
@@ -89,7 +89,7 @@ export ScanPage := Page {
                     icon: @image-url("images/scan.svg");
                     text: "Start scanning";
                     clicked => {
-                        root.start_job("Scan");
+                        root.start-job("Scan");
                     }
                 }
                 Rectangle {

--- a/examples/printerdemo/ui/settings_page.60
+++ b/examples/printerdemo/ui/settings_page.60
@@ -20,8 +20,8 @@ export SettingsPage := Page {
         Row {
             Text {
                 text: "General";
-                color: DemoPalette.secondary_foreground_color;
-                font-size: DemoPalette.base_font_size * 1.125;
+                color: DemoPalette.secondary-foreground-color;
+                font-size: DemoPalette.base-font-size * 1.125;
                 font-weight: 800;
             }
         }
@@ -41,8 +41,8 @@ export SettingsPage := Page {
         Row {
             Text {
                 text: "Defaults";
-                color: DemoPalette.secondary_foreground_color;
-                font-size: DemoPalette.base_font_size * 1.125;
+                color: DemoPalette.secondary-foreground-color;
+                font-size: DemoPalette.base-font-size * 1.125;
                 font-weight: 800;
             }
         }

--- a/examples/printerdemo/ui/usb_page.60
+++ b/examples/printerdemo/ui/usb_page.60
@@ -13,8 +13,8 @@ import { StandardListView } from "sixtyfps_widgets.60";
 
 
 export UsbPage := Page {
-    callback start_job(string);
-    has_back_button: true;
+    callback start-job(string);
+    has-back-button: true;
     header: "USB";
 
     GridLayout {
@@ -37,7 +37,7 @@ export UsbPage := Page {
             max-height: 32px;
         }
 
-        list_view := StandardListView {
+        list-view := StandardListView {
             col: 1;
             row: 1;
             colspan: 2;
@@ -80,14 +80,14 @@ export UsbPage := Page {
                 text: "Start printing";
                 clicked => {
                     //FIXME!
-                    if (list_view.current_item == 2) {
-                        root.start_job("dog.png");
-                    } else if (list_view.current_item == 3) {
-                        root.start_job("elephant.png");
-                    } else if (list_view.current_item == 4) {
-                        root.start_job("snake.png");
+                    if (list-view.current-item == 2) {
+                        root.start-job("dog.png");
+                    } else if (list-view.current-item == 3) {
+                        root.start-job("elephant.png");
+                    } else if (list-view.current-item == 4) {
+                        root.start-job("snake.png");
                     } else {
-                        root.start_job("cat.png");
+                        root.start-job("cat.png");
                     }
                 }
             }

--- a/examples/printerdemo_old/ui/common.60
+++ b/examples/printerdemo_old/ui/common.60
@@ -9,12 +9,12 @@
 LICENSE END */
 export Label := Text {
     font-size: 28px;
-    horizontal_stretch: 1;
+    horizontal-stretch: 1;
 }
 
 export Page := Rectangle {
     background: white;
-    animate y { duration: 300ms; easing: ease_out; }
+    animate y { duration: 300ms; easing: ease-out; }
 }
 
 export Preview := Image {

--- a/examples/printerdemo_old/ui/copy_page.60
+++ b/examples/printerdemo_old/ui/copy_page.60
@@ -14,15 +14,15 @@ import { Label, Page, Preview } from "common.60";
 
 export CopyPage := Page {
     layout := GridLayout {
-        padding_left: 40px;
-        padding_right: 40px;
+        padding-left: 40px;
+        padding-right: 40px;
         spacing: 20px;
-        padding_top: 20px;
-        padding_bottom: 20px;
+        padding-top: 20px;
+        padding-bottom: 20px;
 
         Row {
             preview := Preview {
-                height: root.height - layout.padding_top - layout.padding_bottom;
+                height: root.height - layout.padding-top - layout.padding-bottom;
             }
             GridBox {
                 Row {
@@ -33,13 +33,13 @@ export CopyPage := Page {
 
                 Row {
                     SpinBox {
-                        horizontal_stretch: 1;
+                        horizontal-stretch: 1;
                     }
                 }
                 Row {
                     Button {
                         text: "Print Page";
-                        horizontal_stretch: 1;
+                        horizontal-stretch: 1;
                     }
                 }
                 Row {

--- a/examples/printerdemo_old/ui/fax_page.60
+++ b/examples/printerdemo_old/ui/fax_page.60
@@ -13,16 +13,16 @@ import { Label, Page, Preview } from "common.60";
 
 export FaxPage := Page {
 
-    property<string> fax_number <=> text.text;
-    callback fax_number_erase;
-    callback fax_send;
+    property<string> fax-number <=> text.text;
+    callback fax-number-erase;
+    callback fax-send;
 
     layout := GridLayout {
-        padding_left: 40px;
-        padding_right: 40px;
+        padding-left: 40px;
+        padding-right: 40px;
         spacing: 20px;
-        padding_top: 20px;
-        padding_bottom: 20px;
+        padding-top: 20px;
+        padding-bottom: 20px;
 
         preview := Preview {
             rowspan: 5;
@@ -33,10 +33,10 @@ export FaxPage := Page {
             colspan: 2;
             horizontal-alignment: center;
             font-size: 40px;
-            horizontal_stretch: 1;
+            horizontal-stretch: 1;
             overflow: elide;
-            min_width: 0;
-            preferred_width: 0;
+            min-width: 0;
+            preferred-width: 0;
         }
 
         Rectangle {
@@ -45,9 +45,9 @@ export FaxPage := Page {
             colspan: 2;
             background: #333;
             height: 50%;
-            border_radius: 4px;
+            border-radius: 4px;
 
-            for row_model[r] in [
+            for row-model[r] in [
                 [ 7, 8, 9 ],
                 [ 4, 5, 6 ],
                 [ 1, 2, 3 ],
@@ -57,12 +57,12 @@ export FaxPage := Page {
                 height: 25% * (parent.height - 5*10px);
                 y: r * (self.height + 10px) + 10px;
 
-                for num[c] in row_model : Rectangle {
+                for num[c] in row-model : Rectangle {
                     height: parent.height;
                     width: (parent.width - 4*10px) / 3;
                     x: c * (self.width + 10px) + 10px;
-                    border_radius: 4px;
-                    background: key_area.pressed ? #566 : #555 ;
+                    border-radius: 4px;
+                    background: key-area.pressed ? #566 : #555 ;
                     Text {
                         width: 100%;
                         height: 100%;
@@ -71,14 +71,14 @@ export FaxPage := Page {
                         color: white;
                         text: num >= 0 ? num : "⌫";
                     }
-                    key_area := TouchArea {
+                    key-area := TouchArea {
                         width: 100%;
                         height: 100%;
                         clicked => {
                             if (num >= 0) {
-                                fax_number += num;
+                                fax-number += num;
                             } else {
-                                fax_number_erase();
+                                fax-number-erase();
                             }
                         }
                     }
@@ -91,7 +91,7 @@ export FaxPage := Page {
             col: 2;
             text: "Send";
             font-size: 28px;
-            clicked => { root.fax_send(); }
+            clicked => { root.fax-send(); }
         }
     }
 }

--- a/examples/printerdemo_old/ui/print_page.60
+++ b/examples/printerdemo_old/ui/print_page.60
@@ -14,11 +14,11 @@ import { Label, Page, Preview } from "common.60";
 PrintPage := Page {
 
      layout := GridLayout {
-        padding_left: 40px;
-        padding_right: 40px;
+        padding-left: 40px;
+        padding-right: 40px;
         spacing: 20px;
-        padding_top: 20px;
-        padding_bottom: 20px;
+        padding-top: 20px;
+        padding-bottom: 20px;
 
         Row {
             preview := Preview { }
@@ -49,13 +49,13 @@ PrintPage := Page {
 
                 Row {
                     SpinBox {
-                        horizontal_stretch: 1;
+                        horizontal-stretch: 1;
                     }
                 }
                 Row {
                     Button {
                         text: "Print Page";
-                        horizontal_stretch: 1;
+                        horizontal-stretch: 1;
                     }
                 }
             }

--- a/examples/printerdemo_old/ui/printerdemo.60
+++ b/examples/printerdemo_old/ui/printerdemo.60
@@ -16,7 +16,7 @@ import { PrintPage } from "print_page.60";
 import { SettingsPage } from "settings_page.60";
 
 TopPanel := Rectangle {
-   property<int> active_page: 0;
+   property<int> active-page: 0;
    callback quit();
 
    background: white;
@@ -25,7 +25,7 @@ TopPanel := Rectangle {
         alignment: center;
         Text {
             text: "PrintMachine";
-            color: active_page == 0 ? black : #0000;
+            color: active-page == 0 ? black : #0000;
             animate color { duration: 200ms; }
             font-size: root.width * 5%;
             horizontal-alignment: center;
@@ -33,7 +33,7 @@ TopPanel := Rectangle {
         }
         Text {
             text: "2000";
-            color: active_page == 0 ? #918e8c : #0000;
+            color: active-page == 0 ? #918e8c : #0000;
             animate color { duration: 200ms; }
             font-size: root.width * 5%;
             horizontal-alignment: center;
@@ -41,7 +41,7 @@ TopPanel := Rectangle {
 
         }
     }
-    power_button := Image {
+    power-button := Image {
         x: parent.width - self.width - 20px;
         y: (parent.height - height) / 2;
         source: @image-url("images/power.svg");
@@ -71,51 +71,51 @@ MainWindow := Window {
 
     /// Note that this property is overwriten in the .cpp and .rs code.
     /// The data is only in this file so it looks good in the viewer
-    property <[InkLevel]> ink_levels: [
+    property <[InkLevel]> ink-levels: [
                 {color: #0ff, level: 60%},
                 {color: #ff0, level: 80%},
                 {color: #f0f, level: 70%},
                 {color: #000, level: 30%},
             ];
     /// Aliased to the fax number in the fax page
-    property <string> fax_number;
-    callback fax_number_erase;
+    property <string> fax-number;
+    callback fax-number-erase;
     /// That's just a default implementation for the viewer, but the .cpp and .rs code
     /// overwrite that to erase only the last character
-    fax_number_erase => { fax_number = ""; }
-    callback fax_send;
+    fax-number-erase => { fax-number = ""; }
+    callback fax-send;
 
-    property<int> active_page: 0;
+    property<int> active-page: 0;
 
     panel := TopPanel {
-        active_page: root.active_page;
+        active-page: root.active-page;
         width: 100%;
         height: 12.5%;
         quit => { root.quit(); }
     }
 
-    for page_info[idx] in [
-        { color: #1ac80a, text: "Copy", img_small: @image-url("images/replicate.svg") },
-        { color: #00c889, text: "Fax", img_small: @image-url("images/laptop.svg") },
-        { color: #00bbc8, text: "Print", img_small: @image-url("images/printer.svg") },
-        { color: #009dc8, text: "Settings", img_small: @image-url("images/list.svg") },
+    for page-info[idx] in [
+        { color: #1ac80a, text: "Copy", img-small: @image-url("images/replicate.svg") },
+        { color: #00c889, text: "Fax", img-small: @image-url("images/laptop.svg") },
+        { color: #00bbc8, text: "Print", img-small: @image-url("images/printer.svg") },
+        { color: #009dc8, text: "Settings", img-small: @image-url("images/list.svg") },
     ] : Rectangle {
         property <length> w: root.width / 5;
         width: w;
         height: root.height / 3;
         y: root.height / 4;
         x: idx * (w + (root.width - w*4) / 5) + (root.width - w*4)/5;
-        border_radius: 25px;
-        background: page_info.color;
+        border-radius: 25px;
+        background: page-info.color;
         img := Image {
             y: 5px;
             x: (w - (root.width / 6.25)) / 2;
             width: root.width / 6.25;
             height: root.height / 4.68;
-            source: page_info.img_small;
+            source: page-info.img-small;
             animate width, height, x, y {
                 duration: 300ms;
-                easing: ease_in_out;
+                easing: ease-in-out;
             }
         }
         text := Text {
@@ -125,44 +125,44 @@ MainWindow := Window {
             height: 100%;
             horizontal-alignment: center;
             vertical-alignment: center;
-            text: page_info.text;
+            text: page-info.text;
             font-size: 28px;
             animate x, y {
                 duration: 300ms;
-                easing: ease_in_out;
+                easing: ease-in-out;
             }
         }
         touch := TouchArea {
             clicked => {
-                if (root.active_page == 0) {
-                    root.active_page = idx + 1;
+                if (root.active-page == 0) {
+                    root.active-page = idx + 1;
                 }
             }
         }
 
-        animate x, y, height, width, background, border_radius {
+        animate x, y, height, width, background, border-radius {
             duration: 300ms;
-            easing: ease_in_out;
+            easing: ease-in-out;
         }
 
         states [
-            active when root.active_page == idx + 1: {
+            active when root.active-page == idx + 1: {
                 x: 0phx;
                 y: 0phx;
                 height: root.height * 12.5%;
                 width: root.width;
-                border_radius: 0px;
+                border-radius: 0px;
                 img.x: root.height * 12.5%;
                 img.width: root.height * 10%;
                 img.height: root.height * 10%;
                 text.y: 0phx;
             }
-            pressed when root.active_page == 0 && touch.pressed : {
+            pressed when root.active-page == 0 && touch.pressed : {
                 w: root.width / 5 + 6px;
                 height: root.height / 3 + 6px ;
                 y: root.height / 4 - 3px;
             }
-            invisible when root.active_page > 0 && root.active_page != idx + 1 : {
+            invisible when root.active-page > 0 && root.active-page != idx + 1 : {
                 color: transparent;
                 // FIXME: should probaby hide the entire item under with z-ordering
                 img.y: 1000000000px;
@@ -171,7 +171,7 @@ MainWindow := Window {
         ]
     }
 
-    if (root.active_page != 0) : Rectangle {
+    if (root.active-page != 0) : Rectangle {
         width: height;
         height: 12.5%;
         Text {
@@ -184,7 +184,7 @@ MainWindow := Window {
             vertical-alignment: center;
         }
         TouchArea {
-            clicked => { root.active_page = 0; }
+            clicked => { root.active-page = 0; }
         }
     }
 
@@ -199,30 +199,30 @@ MainWindow := Window {
         HorizontalLayout {
             spacing: 10px;
             padding: 10px;
-            for color_info[idx] in ink_levels : Rectangle {
+            for color-info[idx] in ink-levels : Rectangle {
                 background: white;
                 Rectangle {
                     width: parent.width;
-                    height: parent.height * color_info.level;
+                    height: parent.height * color-info.level;
                     y: parent.height - self.height;
-                    background: color_info.color;
+                    background: color-info.color;
                     states [
-                        innactive when root.active_page != 0 : {
+                        innactive when root.active-page != 0 : {
                             height: 0phx;
                         }
                     ]
                     transitions [
                         out innactive : {
-                            animate height { duration: 750ms; easing: ease_in_out; }
+                            animate height { duration: 750ms; easing: ease-in-out; }
                         }
                     ]
                 }
             }
         }
 
-        property <bool> full_screen;
+        property <bool> full-screen;
         states [
-            full_screen when full_screen : {
+            full-screen when full-screen : {
                 width: root.width - 35px;
                 height: 7/8 * root.height - 40px ;
             }
@@ -230,8 +230,8 @@ MainWindow := Window {
         animate width, height { duration: 200ms; easing: ease;  }
         TouchArea {
             clicked => {
-                if (active_page == 0) {
-                    parent.full_screen = !parent.full_screen;
+                if (active-page == 0) {
+                    parent.full-screen = !parent.full-screen;
                 }
             }
         }
@@ -242,7 +242,7 @@ MainWindow := Window {
         width: 100%;
         y: root.height;
         states [
-            active when root.active_page == 1: {
+            active when root.active-page == 1: {
                 y: root.height / 8;
             }
         ]
@@ -253,13 +253,13 @@ MainWindow := Window {
         width: 100%;
         y: root.height;
         states [
-            active when root.active_page == 2: {
+            active when root.active-page == 2: {
                 y: root.height / 8;
             }
         ]
-        fax_number <=> root.fax_number;
-        fax_number_erase => { root.fax_number_erase(); }
-        fax_send => { root.fax_send(); }
+        fax-number <=> root.fax-number;
+        fax-number-erase => { root.fax-number-erase(); }
+        fax-send => { root.fax-send(); }
     }
 
     PrintPage {
@@ -267,7 +267,7 @@ MainWindow := Window {
         width: 100%;
         y: root.height;
         states [
-            active when root.active_page == 3: {
+            active when root.active-page == 3: {
                 y: root.height / 8;
             }
         ]
@@ -278,7 +278,7 @@ MainWindow := Window {
         width: 100%;
         y: root.height;
         states [
-            active when root.active_page == 4: {
+            active when root.active-page == 4: {
                 y: root.height / 8;
             }
         ]

--- a/examples/slide_puzzle/slide_puzzle.60
+++ b/examples/slide_puzzle/slide_puzzle.60
@@ -10,11 +10,11 @@ LICENSE END */
 
 struct Piece := {
     // col/row position of the tile in the puzzle
-    pos_x: int,
-    pos_y: int,
+    pos-x: int,
+    pos-y: int,
     // offset in pixel from the base position for the kicking animation
-    offset_x: length,
-    offset_y: length,
+    offset-x: length,
+    offset-y: length,
 }
 
 struct Theme := {
@@ -46,21 +46,21 @@ struct Theme := {
 Checkbox := Rectangle {
     property <bool> checked;
     callback toggled(bool);
-    property<color> checked_color;
-    property<color> unchecked_color;
+    property<color> checked-color;
+    property<color> unchecked-color;
 
-    hover_rect := Rectangle {
+    hover-rect := Rectangle {
         background: #f5f5f5;
         x: - parent.width / 4;
         y: - parent.height / 4;
-        width: ta.has_hover ? root.width * 1.5 : 0px;
+        width: ta.has-hover ? root.width * 1.5 : 0px;
         height: self.width;
         border-radius: width;
     }
 
-    checkbox_rect := Rectangle {
+    checkbox-rect := Rectangle {
         border-width: height * 10%;
-        border-color: unchecked_color;
+        border-color: unchecked-color;
         border-radius: 2px;
 
         clip := Rectangle {
@@ -96,19 +96,19 @@ Checkbox := Rectangle {
         }*/
         checked when root.checked : {
             clip.width: root.width;
-            checkbox_rect.border-color: checked_color;
-            checkbox_rect.border-width: root.width;
+            checkbox-rect.border-color: checked-color;
+            checkbox-rect.border-width: root.width;
         }
     ]
     transitions [
         in checked : {
             animate clip.width { duration: 200ms; easing: ease-in; }
-            animate checkbox_rect.border-width { duration: 100ms; easing: ease-out; }
+            animate checkbox-rect.border-width { duration: 100ms; easing: ease-out; }
         }
         out checked : {
             animate clip.width { duration: 100ms; easing: ease; }
-            animate checkbox_rect.border-width { duration: 200ms; easing: ease-in-out; }
-            animate checkbox_rect.border-color { duration: 200ms; easing: cubic-bezier(1,1,1,0); }
+            animate checkbox-rect.border-width { duration: 200ms; easing: ease-in-out; }
+            animate checkbox-rect.border-color { duration: 200ms; easing: cubic-bezier(1,1,1,0); }
         }
 
     ]
@@ -119,28 +119,28 @@ import "./plaster-font/Plaster-Regular.ttf";
 export MainWindow := Window {
     title: "Slide Puzzle - SixtyFPS Demo";
 
-    callback piece_clicked(int);
+    callback piece-clicked(int);
     callback reset();
-    callback enable_auto_mode(bool);
-    property <bool> auto_play;
+    callback enable-auto-mode(bool);
+    property <bool> auto-play;
     property <int> moves;
     property <int> tiles-left;
     property <[Piece]> pieces: [
-        { pos_x: 0, pos_y: 0 },
-        { pos_x: 0, pos_y: 1 },
-        { pos_x: 0, pos_y: 2 },
-        { pos_x: 0, pos_y: 3 },
-        { pos_x: 1, pos_y: 0 },
-        { pos_x: 1, pos_y: 1 },
-        { pos_x: 1, pos_y: 2 },
-        { pos_x: 1, pos_y: 3 },
-        { pos_x: 2, pos_y: 0 },
-        { pos_x: 2, pos_y: 1 },
-        { pos_x: 2, pos_y: 2 },
-        { pos_x: 2, pos_y: 3 },
-        { pos_x: 3, pos_y: 0 },
-        { pos_x: 3, pos_y: 1 },
-        { pos_x: 3, pos_y: 2 },
+        { pos-x: 0, pos-y: 0 },
+        { pos-x: 0, pos-y: 1 },
+        { pos-x: 0, pos-y: 2 },
+        { pos-x: 0, pos-y: 3 },
+        { pos-x: 1, pos-y: 0 },
+        { pos-x: 1, pos-y: 1 },
+        { pos-x: 1, pos-y: 2 },
+        { pos-x: 1, pos-y: 3 },
+        { pos-x: 2, pos-y: 0 },
+        { pos-x: 2, pos-y: 1 },
+        { pos-x: 2, pos-y: 2 },
+        { pos-x: 2, pos-y: 3 },
+        { pos-x: 3, pos-y: 0 },
+        { pos-x: 3, pos-y: 1 },
+        { pos-x: 3, pos-y: 2 },
     ];
 
     property <[Theme]> themes: [
@@ -238,11 +238,11 @@ export MainWindow := Window {
             piece-spacing: 10%,
     };
 
-    property<length> pieces_size: min(width, height) / 6;
-    property<length> pieces_spacing: current-theme.game-use-background-image && tiles-left == 0 ?
-        2px : (pieces_size * current-theme.piece-spacing);
+    property<length> pieces-size: min(width, height) / 6;
+    property<length> pieces-spacing: current-theme.game-use-background-image && tiles-left == 0 ?
+        2px : (pieces-size * current-theme.piece-spacing);
 
-    animate pieces_spacing { duration: 500ms; easing: ease-out; }
+    animate pieces-spacing { duration: 500ms; easing: ease-out; }
 
     Image {
         height: 100%; width: 100%;
@@ -261,15 +261,15 @@ export MainWindow := Window {
         border-color: current-theme.game-text-color;
         border-width: current-theme.game-border;
         border-radius: current-theme.game-radius;
-        width: pieces_size * 4.6;
-        height: pieces_size * 5.4;
+        width: pieces-size * 4.6;
+        height: pieces-size * 5.4;
         x: (parent.width - width)/2;
         y: (parent.height - height)/2;
         animate background, border-color, border-width, border-radius { duration: 500ms; easing: ease-out; }
 
         Rectangle {
             width: parent.width * 90%;
-            height: pieces_size/2;
+            height: pieces-size/2;
             x: (parent.width - width) / 2;
             HorizontalLayout {
                 spacing: 0px;
@@ -296,13 +296,13 @@ export MainWindow := Window {
 
 
         for p[i] in pieces : Rectangle {
-            x: py * (pieces_size + pieces_spacing) + p.offset_x
-                + (parent.width - (4*pieces_size + 3*pieces_spacing))/2;
-            y: px * (pieces_size + pieces_spacing) + p.offset_y
-                + (parent.height - (4*pieces_size + 3*pieces_spacing))/2;
-            width: pieces_size;
-            height: pieces_size;
-            property <bool> is_correct: i == p.pos_x * 4 + p.pos_y;
+            x: py * (pieces-size + pieces-spacing) + p.offset-x
+                + (parent.width - (4*pieces-size + 3*pieces-spacing))/2;
+            y: px * (pieces-size + pieces-spacing) + p.offset-y
+                + (parent.height - (4*pieces-size + 3*pieces-spacing))/2;
+            width: pieces-size;
+            height: pieces-size;
+            property <bool> is-correct: i == p.pos-x * 4 + p.pos-y;
 
             drop-shadow-offset-x: 1px;
             drop-shadow-offset-y: 1px;
@@ -311,8 +311,8 @@ export MainWindow := Window {
             border-radius: current-theme.piece-radius;
             clip: true;
 
-            property<float> px: p.pos_x;
-            property<float> py: p.pos_y;
+            property<float> px: p.pos-x;
+            property<float> py: p.pos-y;
             animate px , py { duration: 170ms; easing: cubic-bezier(0.17,0.76,0.4,1.75); }
 
             if (current-theme.game-use-background-image) : Image {
@@ -330,7 +330,7 @@ export MainWindow := Window {
                     x: (parent.width - width) / 2;
                     y: (parent.height - height) / 2;
                     border-radius: width;
-                    background: is_correct ? #0008 : #fff8;
+                    background: is-correct ? #0008 : #fff8;
                 }
             }
 
@@ -344,9 +344,9 @@ export MainWindow := Window {
 
             if (!current-theme.game-use-background-image || tiles-left > 0) : Text {
                 text: i+1;
-                color: ((!current-theme.game-use-background-image && i >= 8) || (current-theme.game-use-background-image && is_correct)) ? current-theme.piece-text-color-2 : current-theme.piece-text-color-1;
-                font-size: pieces_size / 3;
-                font-weight: is_correct ? current-theme.piece-text-weight-correct-pos : current-theme.piece-text-weight-incorrect-pos;
+                color: ((!current-theme.game-use-background-image && i >= 8) || (current-theme.game-use-background-image && is-correct)) ? current-theme.piece-text-color-2 : current-theme.piece-text-color-1;
+                font-size: pieces-size / 3;
+                font-weight: is-correct ? current-theme.piece-text-weight-correct-pos : current-theme.piece-text-weight-incorrect-pos;
                 font-family: current-theme.piece-text-font-family;
                 vertical-alignment: center;
                 horizontal-alignment: center;
@@ -355,7 +355,7 @@ export MainWindow := Window {
             }
 
             touch := TouchArea {
-                clicked => { root.piece_clicked(i); }
+                clicked => { root.piece-clicked(i); }
             }
 
             shadow := Rectangle {
@@ -363,8 +363,8 @@ export MainWindow := Window {
                     height: width;
                     border-radius: width/2;
                     background: #0002;
-                    x: touch.pressed_x - width/2;
-                    y: touch.pressed_y - width/2;
+                    x: touch.pressed-x - width/2;
+                    y: touch.pressed-y - width/2;
                 }
             }
 
@@ -373,7 +373,7 @@ export MainWindow := Window {
                     shadow.color: #0002;
                     circle.width: shadow.width * 2 * 1.4142;
                 }
-                hover when touch.has_hover: {
+                hover when touch.has-hover: {
                     shadow.color: #0000000d;
                 }
 
@@ -390,15 +390,15 @@ export MainWindow := Window {
         }
 
         if (root.tiles-left == 0) : Text {
-            width: pieces_size;
-            height: pieces_size;
-            x: 3 * (pieces_size + pieces_spacing)
-                + (parent.width - (4*pieces_size + 3*pieces_spacing))/2;
-            y: 3 * (pieces_size + pieces_spacing)
-                + (parent.height - (4*pieces_size + 3*pieces_spacing))/2;
+            width: pieces-size;
+            height: pieces-size;
+            x: 3 * (pieces-size + pieces-spacing)
+                + (parent.width - (4*pieces-size + 3*pieces-spacing))/2;
+            y: 3 * (pieces-size + pieces-spacing)
+                + (parent.height - (4*pieces-size + 3*pieces-spacing))/2;
 
             color: current-theme.game-highlight-color;
-            font-size: pieces_size / 2;
+            font-size: pieces-size / 2;
             vertical-alignment: center;
             horizontal-alignment: center;
             text: "🖒";
@@ -418,12 +418,12 @@ export MainWindow := Window {
             width: parent.width;
             height: 1px;
             background: current-theme.game-text-color;
-            y: parent.height - pieces_size / 2;
+            y: parent.height - pieces-size / 2;
         }
 
         HorizontalLayout {
-            height: pieces_size / 2;
-            y: parent.height - pieces_size / 2;
+            height: pieces-size / 2;
+            y: parent.height - pieces-size / 2;
             width: parent.width;
             padding: height * 25%;
             Text {
@@ -437,10 +437,10 @@ export MainWindow := Window {
             }
             Checkbox {
                 width: parent.height - 2 * parent.padding;
-                checked <=> auto_play;
-                toggled(checked) => { root.enable_auto_mode(checked) }
-                checked_color: current-theme.game-highlight-color;
-                unchecked_color: current-theme.game-text-color;
+                checked <=> auto-play;
+                toggled(checked) => { root.enable-auto-mode(checked) }
+                checked-color: current-theme.game-highlight-color;
+                unchecked-color: current-theme.game-text-color;
             }
             Rectangle {} // stretch
             Text {

--- a/examples/todo/ui/todo.60
+++ b/examples/todo/ui/todo.60
@@ -18,10 +18,10 @@ export struct TodoItem := {
 MainWindow := Window {
     preferred-width: 400px;
     preferred-height: 600px;
-    callback todo_added(string);
-    callback remove_done();
+    callback todo-added(string);
+    callback remove-done();
 
-    property <[TodoItem]> todo_model: [
+    property <[TodoItem]> todo-model: [
         { title: "Implement the .60 file", checked: true },
         { title: "Do the Rust part", checked: false },
         { title: "Make the C++ code", checked: false },
@@ -34,23 +34,23 @@ MainWindow := Window {
 
     VerticalBox {
         HorizontalBox {
-            text_edit := LineEdit {
+            text-edit := LineEdit {
                 placeholder-text: "What needs to be done?";
                 accepted(text) => {
-                    todo_added(text);
+                    todo-added(text);
                 }
             }
             btn := Button {
                 text: "Add New Entry";
-                enabled: text_edit.text != "";
+                enabled: text-edit.text != "";
                 clicked => {
-                    todo_added(text_edit.text);
+                    todo-added(text-edit.text);
                 }
             }
         }
 
-        list_view := ListView {
-            for todo in todo_model:  HorizontalLayout {
+        list-view := ListView {
+            for todo in todo-model:  HorizontalLayout {
                 CheckBox {
                     text: todo.title;
                     checked: todo.checked;
@@ -64,7 +64,7 @@ MainWindow := Window {
             alignment: end;
             Button {
                 text: "Remove Done Items";
-                clicked => { root.remove_done(); }
+                clicked => { root.remove-done(); }
             }
         }
     }

--- a/sixtyfps_compiler/builtins.60
+++ b/sixtyfps_compiler/builtins.60
@@ -38,9 +38,9 @@ Rectangle := _ {
 }
 
 BorderRectangle := Rectangle {
-    property <length> border_width;
-    property <length> border_radius;
-    property <brush> border_color;
+    property <length> border-width;
+    property <length> border-radius;
+    property <brush> border-color;
     //-default_size_binding:expands_to_parent_geometry
 }
 
@@ -52,7 +52,7 @@ ImageItem := _ {
     property <length> y;
     property <length> width;
     property <length> height;
-    property <ImageFit> image_fit;
+    property <ImageFit> image-fit;
 }
 
 export ClippedImage := ImageItem {
@@ -78,12 +78,12 @@ export Rotate := _ {
 
 export Text := _ {
     property <string> text;
-    property <string> font_family;
-    property <length> font_size;
-    property <int> font_weight;
+    property <string> font-family;
+    property <length> font-size;
+    property <int> font-weight;
     property <brush> color: #000;
-    property <TextHorizontalAlignment> horizontal_alignment;
-    property <TextVerticalAlignment> vertical_alignment;
+    property <TextHorizontalAlignment> horizontal-alignment;
+    property <TextVerticalAlignment> vertical-alignment;
     property <TextOverflow> overflow;
     property <TextWrap> wrap;
     property <length> letter_spacing;
@@ -129,7 +129,7 @@ export FocusScope := _ {
     property <length> y;
     property <length> width;
     property <length> height;
-    property <bool> has_focus: native_output;
+    property <bool> has-focus: native_output;
     callback key_pressed(KeyEvent) -> EventResult;
     callback key_released(KeyEvent) -> EventResult;
     //-default_size_binding:expands_to_parent_geometry
@@ -143,10 +143,10 @@ export Flickable := _ {
     property <length> height;
                 // These properties are actually going to be forwarded to the viewport by the
                 // code generator
-    property <length> viewport_height;
-    property <length> viewport_width;
-    property <length> viewport_x: native_output;
-    property <length> viewport_y: native_output;
+    property <length> viewport-height;
+    property <length> viewport-width;
+    property <length> viewport-x: native_output;
+    property <length> viewport-y: native_output;
     property <bool> interactive: true;
     //-default_size_binding:expands_to_parent_geometry
 }
@@ -157,9 +157,9 @@ export WindowItem := _ {
     property <color> background; // StyleMetrics.window_background  set in apply_default_properties_from_style
     property <color> color <=> background;
     property <string> title: "SixtyFPS Window";
-    property <string> default_font_family;
-    property <length> default_font_size;
-    property <int> default_font_weight;
+    property <string> default-font-family;
+    property <length> default-font-size;
+    property <int> default-font-weight;
     property <image> icon;
 }
 
@@ -181,23 +181,23 @@ export BoxShadow := _ {
 
 export TextInput := _ {
     property <string> text: native_output;
-    property <string> font_family;
-    property <length> font_size;
-    property <int> font_weight;
+    property <string> font-family;
+    property <length> font-size;
+    property <int> font-weight;
     property <brush> color: #000;
-    property <color> selection_foreground_color: #000;
-    property <color> selection_background_color: #808080;
-    property <TextHorizontalAlignment> horizontal_alignment;
-    property <TextVerticalAlignment> vertical_alignment;
-    property <length> letter_spacing;
+    property <color> selection-foreground-color: #000;
+    property <color> selection-background-color: #808080;
+    property <TextHorizontalAlignment> horizontal-alignment;
+    property <TextVerticalAlignment> vertical-alignment;
+    property <length> letter-spacing;
     property <length> x;
     property <length> y;
     property <length> width;
     property <length> height;
-    property <length> text_cursor_width; // StyleMetrics.text_cursor_width  set in apply_default_properties_from_style
-    property <int> cursor_position: native_output;
-    property <int> anchor_position: native_output;
-    property <bool> has_focus: native_output;
+    property <length> text-cursor-width; // StyleMetrics.text-cursor-width  set in apply_default_properties_from_style
+    property <int> cursor-position: native_output;
+    property <int> anchor-position: native_output;
+    property <bool> has-focus: native_output;
     callback accepted;
     callback edited;
     property <bool> enabled: true;
@@ -210,8 +210,8 @@ export Clip := _ {
     property <length> y;
     property <length> width;
     property <length> height;
-    property <length> border_radius;
-    property <length> border_width;
+    property <length> border-radius;
+    property <length> border-width;
     property <bool> clip;
     //-default_size_binding:expands_to_parent_geometry
     // Note, this should be 'is_internal'  but isn't because it is in fact deprecated
@@ -270,9 +270,9 @@ LineTo := _ {
 ArcTo := _ {
     property <float> x;
     property <float> y;
-    property <float> radius_x;
-    property <float> radius_y;
-    property <float> x_rotation;
+    property <float> radius-x;
+    property <float> radius-y;
+    property <float> x-rotation;
     property <bool> large_arc;
     property <bool> sweep;
 
@@ -282,10 +282,10 @@ ArcTo := _ {
 }
 
 CubicTo := _ {
-    property <float> control_1_x;
-    property <float> control_1_y;
-    property <float> control_2_x;
-    property <float> control_2_y;
+    property <float> control-1-x;
+    property <float> control-1-y;
+    property <float> control-2-x;
+    property <float> control-2-y;
     property <float> x;
     property <float> y;
 
@@ -295,8 +295,8 @@ CubicTo := _ {
 }
 
 QuadraticTo := _ {
-    property <float> control_x;
-    property <float> control_y;
+    property <float> control-x;
+    property <float> control-y;
     property <float> x;
     property <float> y;
 
@@ -317,16 +317,16 @@ export Path := _ {
     property <length> width;
     property <length> height;
     property <brush> fill;
-    property <brush> fill_color <=> fill;
-    property <FillRule> fill_rule;
+    property <brush> fill-color <=> fill;
+    property <FillRule> fill-rule;
     property <brush> stroke;
-    property <color> stroke_color <=> stroke;
-    property <length> stroke_width;
+    property <color> stroke-color <=> stroke;
+    property <length> stroke-width;
     property <string> commands;
-    property <float> viewbox_x;
-    property <float> viewbox_y;
-    property <float> viewbox_width;
-    property <float> viewbox_height;
+    property <float> viewbox-x;
+    property <float> viewbox-y;
+    property <float> viewbox-width;
+    property <float> viewbox-height;
     property <bool> clip;
 
     //-disallow_global_types_as_child_elements
@@ -391,7 +391,7 @@ export PopupWindow := _ {
 PropertyAnimation := _ {
     property <duration> duration;
     property <easing> easing;
-    property <int> loop_count;
+    property <int> loop-count;
     //-is_non_item_type
 }
 
@@ -465,10 +465,10 @@ export NativeGroupBox := _ {
     property <length> height;
     property <bool> enabled: true;
     property <string> title;
-    property <length> native_padding_left: native_output;
-    property <length> native_padding_right: native_output;
-    property <length> native_padding_top: native_output;
-    property <length> native_padding_bottom: native_output;
+    property <length> native-padding-left: native_output;
+    property <length> native-padding-right: native_output;
+    property <length> native-padding-top: native_output;
+    property <length> native-padding-bottom: native_output;
     //-default_size_binding:expands_to_parent_geometry
     //-is_internal
 }
@@ -478,10 +478,10 @@ export NativeLineEdit := _ {
     property <length> y;
     property <length> width;
     property <length> height;
-    property <length> native_padding_left: native_output;
-    property <length> native_padding_right: native_output;
-    property <length> native_padding_top: native_output;
-    property <length> native_padding_bottom: native_output;
+    property <length> native-padding-left: native_output;
+    property <length> native-padding-right: native_output;
+    property <length> native-padding-top: native_output;
+    property <length> native-padding-bottom: native_output;
     property <bool> focused: native_output;
     property <bool> enabled: true;
     //-is_internal
@@ -492,16 +492,16 @@ export NativeScrollView := _ {
     property <length> y;
     property <length> width;
     property <length> height;
-    property <length> horizontal_max;
-    property <length> horizontal_page_size;
-    property <length> horizontal_value;
-    property <length> vertical_max;
-    property <length> vertical_page_size;
-    property <length> vertical_value: native_output;
-    property <length> native_padding_left: native_output;
-    property <length> native_padding_right: native_output;
-    property <length> native_padding_top: native_output;
-    property <length> native_padding_bottom: native_output;
+    property <length> horizontal-max;
+    property <length> horizontal-page-size;
+    property <length> horizontal-value;
+    property <length> vertical-max;
+    property <length> vertical-page-size;
+    property <length> vertical-value: native_output;
+    property <length> native-padding-left: native_output;
+    property <length> native-padding-right: native_output;
+    property <length> native-padding-top: native_output;
+    property <length> native-padding-bottom: native_output;
     //-default_size_binding:expands_to_parent_geometry
     //-is_internal
 }
@@ -535,18 +535,18 @@ export NativeTabWidget := _ {
     property <length> width;
     property <length> height;
 
-    property <length> content_x: native_output;
-    property <length> content_y: native_output;
-    property <length> content_height: native_output;
-    property <length> content_width: native_output;
-    property <length> tabbar_x: native_output;
-    property <length> tabbar_y: native_output;
-    property <length> tabbar_height: native_output;
-    property <length> tabbar_width: native_output;
-    property <length> tabbar_preferred_height;
-    property <length> tabbar_preferred_width;
-    property <length> content_min_height;
-    property <length> content_min_width;
+    property <length> content-x: native_output;
+    property <length> content-y: native_output;
+    property <length> content-height: native_output;
+    property <length> content-width: native_output;
+    property <length> tabbar-x: native_output;
+    property <length> tabbar-y: native_output;
+    property <length> tabbar-height: native_output;
+    property <length> tabbar-width: native_output;
+    property <length> tabbar-preferred-height;
+    property <length> tabbar-preferred-width;
+    property <length> content-min-height;
+    property <length> content-min-width;
     //-default_size_binding:expands_to_parent_geometry
     //-is_internal
 }
@@ -568,9 +568,9 @@ export NativeTab := _ {
 }
 
 export global NativeStyleMetrics := {
-    property <length> layout_spacing;
-    property <length> layout_padding;
-    property <length> text_cursor_width;
+    property <length> layout-spacing;
+    property <length> layout-padding;
+    property <length> text-cursor-width;
     //-is_non_item_type
     //-is_internal
 }

--- a/sixtyfps_compiler/langtype.rs
+++ b/sixtyfps_compiler/langtype.rs
@@ -163,7 +163,7 @@ impl Display for Type {
             Type::String => write!(f, "string"),
             Type::Duration => write!(f, "duration"),
             Type::Angle => write!(f, "angle"),
-            Type::PhysicalLength => write!(f, "physical_length"),
+            Type::PhysicalLength => write!(f, "physical-length"),
             Type::LogicalLength => write!(f, "length"),
             Type::Percent => write!(f, "percent"),
             Type::Color => write!(f, "color"),

--- a/sixtyfps_compiler/layout.rs
+++ b/sixtyfps_compiler/layout.rs
@@ -143,14 +143,14 @@ pub struct LayoutConstraints {
 impl LayoutConstraints {
     pub fn new(element: &ElementRc, diag: &mut BuildDiagnostics) -> Self {
         let mut constraints = Self {
-            min_width: binding_reference(element, "min_width"),
-            max_width: binding_reference(element, "max_width"),
-            min_height: binding_reference(element, "min_height"),
-            max_height: binding_reference(element, "max_height"),
-            preferred_width: binding_reference(element, "preferred_width"),
-            preferred_height: binding_reference(element, "preferred_height"),
-            horizontal_stretch: binding_reference(element, "horizontal_stretch"),
-            vertical_stretch: binding_reference(element, "vertical_stretch"),
+            min_width: binding_reference(element, "min-width"),
+            max_width: binding_reference(element, "max-width"),
+            min_height: binding_reference(element, "min-height"),
+            max_height: binding_reference(element, "max-height"),
+            preferred_width: binding_reference(element, "preferred-width"),
+            preferred_height: binding_reference(element, "preferred-height"),
+            horizontal_stretch: binding_reference(element, "horizontal-stretch"),
+            vertical_stretch: binding_reference(element, "vertical-stretch"),
             fixed_width: false,
             fixed_height: false,
         };
@@ -368,16 +368,16 @@ impl LayoutGeometry {
         let alignment = binding_reference(layout_element, "alignment");
 
         let padding = || binding_reference(layout_element, "padding");
-        init_fake_property(layout_element, "padding_left", padding);
-        init_fake_property(layout_element, "padding_right", padding);
-        init_fake_property(layout_element, "padding_top", padding);
-        init_fake_property(layout_element, "padding_bottom", padding);
+        init_fake_property(layout_element, "padding-left", padding);
+        init_fake_property(layout_element, "padding-right", padding);
+        init_fake_property(layout_element, "padding-top", padding);
+        init_fake_property(layout_element, "padding-bottom", padding);
 
         let padding = Padding {
-            left: binding_reference(layout_element, "padding_left").or_else(padding),
-            right: binding_reference(layout_element, "padding_right").or_else(padding),
-            top: binding_reference(layout_element, "padding_top").or_else(padding),
-            bottom: binding_reference(layout_element, "padding_bottom").or_else(padding),
+            left: binding_reference(layout_element, "padding-left").or_else(padding),
+            right: binding_reference(layout_element, "padding-right").or_else(padding),
+            top: binding_reference(layout_element, "padding-top").or_else(padding),
+            bottom: binding_reference(layout_element, "padding-bottom").or_else(padding),
         };
 
         let rect = LayoutRect::install_on_element(layout_element);

--- a/sixtyfps_compiler/load_builtins.rs
+++ b/sixtyfps_compiler/load_builtins.rs
@@ -132,7 +132,7 @@ pub fn load_builtins(register: &mut TypeRegister) {
         n.rust_type_constructor = parse_annotation("rust_type_constructor", &e).map(|x| x.unwrap());
         let global = if let Some(base) = e.QualifiedName() {
             let base = QualifiedTypeName::from_node(base).to_string();
-            if base != "_" {
+            if base != "-" {
                 n.parent = Some(natives.get(&base).unwrap().native_class.clone())
             };
             false

--- a/sixtyfps_compiler/lookup.rs
+++ b/sixtyfps_compiler/lookup.rs
@@ -409,14 +409,14 @@ impl LookupObject for EasingSpecific {
         use EasingCurve::CubicBezier;
         None.or_else(|| f("linear", Expression::EasingCurve(EasingCurve::Linear)))
             .or_else(|| f("ease", Expression::EasingCurve(CubicBezier(0.25, 0.1, 0.25, 1.0))))
-            .or_else(|| f("ease_in", Expression::EasingCurve(CubicBezier(0.42, 0.0, 1.0, 1.0))))
+            .or_else(|| f("ease-in", Expression::EasingCurve(CubicBezier(0.42, 0.0, 1.0, 1.0))))
             .or_else(|| {
-                f("ease_in_out", Expression::EasingCurve(CubicBezier(0.42, 0.0, 0.58, 1.0)))
+                f("ease-in-out", Expression::EasingCurve(CubicBezier(0.42, 0.0, 0.58, 1.0)))
             })
-            .or_else(|| f("ease_out", Expression::EasingCurve(CubicBezier(0.0, 0.0, 0.58, 1.0))))
+            .or_else(|| f("ease-out", Expression::EasingCurve(CubicBezier(0.0, 0.0, 0.58, 1.0))))
             .or_else(|| {
                 f(
-                    "cubic_bezier",
+                    "cubic-bezier",
                     Expression::BuiltinMacroReference(
                         BuiltinMacroFunction::CubicBezier,
                         ctx.current_token.clone(),
@@ -568,8 +568,8 @@ impl<'a> LookupObject for StringExpression<'a> {
                 ctx.current_token.as_ref().map(|t| t.to_source_location()),
             )),
         };
-        None.or_else(|| f("is_float", member_function(BuiltinFunction::StringIsFloat)))
-            .or_else(|| f("to_float", member_function(BuiltinFunction::StringToFloat)))
+        None.or_else(|| f("is-float", member_function(BuiltinFunction::StringIsFloat)))
+            .or_else(|| f("to-float", member_function(BuiltinFunction::StringToFloat)))
     }
 }
 struct ColorExpression<'a>(&'a Expression);

--- a/sixtyfps_compiler/object_tree.rs
+++ b/sixtyfps_compiler/object_tree.rs
@@ -305,7 +305,7 @@ impl TransitionPropertyAnimation {
         Expression::BinaryExpression {
             lhs: Box::new(Expression::StructFieldAccess {
                 base: Box::new(state),
-                name: (if self.is_out { "previous_state" } else { "current_state" }).into(),
+                name: (if self.is_out { "previous-state" } else { "current-state" }).into(),
             }),
             rhs: Box::new(Expression::NumberLiteral(self.state_id as _, Unit::None)),
             op: '=',
@@ -972,11 +972,11 @@ impl Element {
     ) -> ElementRc {
         let is_listview = if parent.borrow().base_type.to_string() == "ListView" {
             Some(ListViewInfo {
-                viewport_y: NamedReference::new(parent, "viewport_y"),
-                viewport_height: NamedReference::new(parent, "viewport_height"),
-                viewport_width: NamedReference::new(parent, "viewport_width"),
-                listview_height: NamedReference::new(parent, "visible_height"),
-                listview_width: NamedReference::new(parent, "visible_width"),
+                viewport_y: NamedReference::new(parent, "viewport-y"),
+                viewport_height: NamedReference::new(parent, "viewport-height"),
+                viewport_width: NamedReference::new(parent, "viewport-width"),
+                listview_height: NamedReference::new(parent, "visible-height"),
+                listview_width: NamedReference::new(parent, "visible-width"),
             })
         } else {
             None

--- a/sixtyfps_compiler/parser.rs
+++ b/sixtyfps_compiler/parser.rs
@@ -846,7 +846,7 @@ pub fn identifier_text(node: &SyntaxNode) -> Option<String> {
 }
 
 pub fn normalize_identifier(ident: &str) -> String {
-    ident.replace('-', "_")
+    ident.replace('_', "-")
 }
 
 // Actual parser

--- a/sixtyfps_compiler/passes/apply_default_properties_from_style.rs
+++ b/sixtyfps_compiler/passes/apply_default_properties_from_style.rs
@@ -37,10 +37,10 @@ pub async fn apply_default_properties_from_style(
             let mut elem = elem.borrow_mut();
             match elem.base_type.to_string().as_str() {
                 "TextInput" => {
-                    elem.bindings.set_binding_if_not_set("text_cursor_width".into(), || {
+                    elem.bindings.set_binding_if_not_set("text-cursor-width".into(), || {
                         Expression::PropertyReference(NamedReference::new(
                             &style_metrics.root_element,
-                            "text_cursor_width",
+                            "text-cursor-width",
                         ))
                         .into()
                     });
@@ -49,7 +49,7 @@ pub async fn apply_default_properties_from_style(
                     elem.bindings.set_binding_if_not_set("background".into(), || {
                         Expression::PropertyReference(NamedReference::new(
                             &style_metrics.root_element,
-                            "window_background",
+                            "window-background",
                         ))
                         .into()
                     });

--- a/sixtyfps_compiler/passes/binding_analysis.rs
+++ b/sixtyfps_compiler/passes/binding_analysis.rs
@@ -210,10 +210,10 @@ fn visit_implicit_layout_info_dependencies(
         }
         "Text" => {
             vis(&NamedReference::new(item, "text"));
-            vis(&NamedReference::new(item, "font_family"));
-            vis(&NamedReference::new(item, "font_size"));
-            vis(&NamedReference::new(item, "font_weight"));
-            vis(&NamedReference::new(item, "letter_spacing"));
+            vis(&NamedReference::new(item, "font-family"));
+            vis(&NamedReference::new(item, "font-size"));
+            vis(&NamedReference::new(item, "font-weight"));
+            vis(&NamedReference::new(item, "letter-spacing"));
             vis(&NamedReference::new(item, "wrap"));
             vis(&NamedReference::new(item, "overflow"));
             if orientation == Orientation::Vertical {

--- a/sixtyfps_compiler/passes/clip.rs
+++ b/sixtyfps_compiler/passes/clip.rs
@@ -60,7 +60,7 @@ pub fn handle_clip(
 fn create_clip_element(parent_elem: &ElementRc, native_clip: &Rc<NativeClass>) {
     let mut parent = parent_elem.borrow_mut();
     let clip = Rc::new(RefCell::new(Element {
-        id: format!("{}_clip", parent.id),
+        id: format!("{}-clip", parent.id),
         base_type: Type::Native(native_clip.clone()),
         children: std::mem::take(&mut parent.children),
         enclosing_component: parent.enclosing_component.clone(),
@@ -78,7 +78,7 @@ fn create_clip_element(parent_elem: &ElementRc, native_clip: &Rc<NativeClass>) {
             )
         })
         .collect();
-    for optional_binding in ["border_radius", "border_width"].iter() {
+    for optional_binding in ["border-radius", "border-width"].iter() {
         if parent_elem.borrow().bindings.contains_key(*optional_binding) {
             clip.borrow_mut().bindings.insert(
                 optional_binding.to_string(),

--- a/sixtyfps_compiler/passes/default_geometry.rs
+++ b/sixtyfps_compiler/passes/default_geometry.rs
@@ -90,7 +90,7 @@ pub fn default_geometry(root_component: &Rc<Component>, diag: &mut BuildDiagnost
                                 let PropertyLookupResult {
                                     resolved_name: image_fit_prop_name,
                                     property_type: image_fit_prop_type,
-                                } = elem.borrow().lookup_property("image_fit");
+                                } = elem.borrow().lookup_property("image-fit");
 
                                 elem.borrow_mut().bindings.set_binding_if_not_set(
                                     image_fit_prop_name.into(),
@@ -137,12 +137,12 @@ fn gen_layout_info_prop(elem: &ElementRc) {
 
     let li_v = super::lower_layout::create_new_prop(
         elem,
-        "layoutinfo_v",
+        "layoutinfo-v",
         crate::layout::layout_info_type(),
     );
     let li_h = super::lower_layout::create_new_prop(
         elem,
-        "layoutinfo_h",
+        "layoutinfo-h",
         crate::layout::layout_info_type(),
     );
     elem.borrow_mut().layout_info_prop = Some((li_h.clone(), li_v.clone()));

--- a/sixtyfps_compiler/passes/flickable.rs
+++ b/sixtyfps_compiler/passes/flickable.rs
@@ -51,7 +51,7 @@ fn create_viewport_element(flickable_elem: &ElementRc, native_rect: &Rc<NativeCl
     let mut flickable = flickable_elem.borrow_mut();
     let flickable = &mut *flickable;
     let viewport = Rc::new(RefCell::new(Element {
-        id: format!("{}_viewport", flickable.id),
+        id: format!("{}-viewport", flickable.id),
         base_type: Type::Native(native_rect.clone()),
         children: std::mem::take(&mut flickable.children),
         enclosing_component: flickable.enclosing_component.clone(),
@@ -59,7 +59,7 @@ fn create_viewport_element(flickable_elem: &ElementRc, native_rect: &Rc<NativeCl
         ..Element::default()
     }));
     for (prop, info) in &flickable.base_type.as_builtin().properties {
-        if let Some(vp_prop) = prop.strip_prefix("viewport_") {
+        if let Some(vp_prop) = prop.strip_prefix("viewport-") {
             let nr = NamedReference::new(&viewport, vp_prop);
             flickable.property_declarations.insert(prop.to_owned(), info.ty.clone().into());
             match flickable.bindings.entry(prop.to_owned()) {
@@ -93,35 +93,35 @@ fn fixup_geometry(flickable_elem: &ElementRc) {
     };
 
     if !flickable_elem.borrow().bindings.contains_key("height") {
-        forward_minmax_of("max_height", '<');
-        forward_minmax_of("preferred_height", '<');
+        forward_minmax_of("max-height", '<');
+        forward_minmax_of("preferred-height", '<');
     }
     if !flickable_elem.borrow().bindings.contains_key("width") {
-        forward_minmax_of("max_width", '<');
-        forward_minmax_of("preferred_width", '<');
+        forward_minmax_of("max-width", '<');
+        forward_minmax_of("preferred-width", '<');
     }
-    set_binding_if_not_explicit(flickable_elem, "viewport_width", || {
+    set_binding_if_not_explicit(flickable_elem, "viewport-width", || {
         Some(
             flickable_elem
                 .borrow()
                 .children
                 .iter()
                 .filter(|x| is_layout(&x.borrow().base_type))
-                .map(|x| Expression::PropertyReference(NamedReference::new(x, "min_width")))
+                .map(|x| Expression::PropertyReference(NamedReference::new(x, "min-width")))
                 .fold(
                     Expression::PropertyReference(NamedReference::new(flickable_elem, "width")),
                     |lhs, rhs| crate::builtin_macros::min_max_expression(lhs, rhs, '>'),
                 ),
         )
     });
-    set_binding_if_not_explicit(flickable_elem, "viewport_height", || {
+    set_binding_if_not_explicit(flickable_elem, "viewport-height", || {
         Some(
             flickable_elem
                 .borrow()
                 .children
                 .iter()
                 .filter(|x| is_layout(&x.borrow().base_type))
-                .map(|x| Expression::PropertyReference(NamedReference::new(x, "min_height")))
+                .map(|x| Expression::PropertyReference(NamedReference::new(x, "min-height")))
                 .fold(
                     Expression::PropertyReference(NamedReference::new(flickable_elem, "height")),
                     |lhs, rhs| crate::builtin_macros::min_max_expression(lhs, rhs, '>'),

--- a/sixtyfps_compiler/passes/focus_item.rs
+++ b/sixtyfps_compiler/passes/focus_item.rs
@@ -24,14 +24,14 @@ enum FocusCheckResult {
 }
 
 fn element_focus_check(element: &ElementRc) -> FocusCheckResult {
-    if let Some(forwarded_focus_binding) = element.borrow().bindings.get("forward_focus") {
+    if let Some(forwarded_focus_binding) = element.borrow().bindings.get("forward-focus") {
         if let Expression::ElementReference(target) = &forwarded_focus_binding.expression {
             return FocusCheckResult::FocusForwarded(
                 target.upgrade().unwrap(),
                 forwarded_focus_binding.to_source_location(),
             );
         } else {
-            panic!("internal error: forward_focus property is of type ElementReference but received non-element-reference binding");
+            panic!("internal error: forward-focus property is of type ElementReference but received non-element-reference binding");
         }
     }
 
@@ -117,10 +117,10 @@ pub fn determine_initial_focus_item(component: &Rc<Component>, diag: &mut BuildD
     }
 }
 
-/// The `forward_focus` property is not a real property that can be generated, so remove any bindings to it
+/// The `forward-focus` property is not a real property that can be generated, so remove any bindings to it
 /// to avoid them being materialized.
 pub fn erase_forward_focus_properties(component: &Rc<Component>) {
     recurse_elem_no_borrow(&component.root_element, &(), &mut |elem, _| {
-        elem.borrow_mut().bindings.remove("forward_focus");
+        elem.borrow_mut().bindings.remove("forward-focus");
     })
 }

--- a/sixtyfps_compiler/passes/lower_layout.rs
+++ b/sixtyfps_compiler/passes/lower_layout.rs
@@ -84,13 +84,13 @@ fn lower_grid_layout(
     };
 
     let layout_cache_prop_h =
-        create_new_prop(grid_layout_element, "layout_cache_h", Type::LayoutCache);
+        create_new_prop(grid_layout_element, "layout-cache-h", Type::LayoutCache);
     let layout_cache_prop_v =
-        create_new_prop(grid_layout_element, "layout_cache_v", Type::LayoutCache);
+        create_new_prop(grid_layout_element, "layout-cache-v", Type::LayoutCache);
     let layout_info_prop_h =
-        create_new_prop(grid_layout_element, "layoutinfo_h", layout_info_type());
+        create_new_prop(grid_layout_element, "layoutinfo-h", layout_info_type());
     let layout_info_prop_v =
-        create_new_prop(grid_layout_element, "layoutinfo_v", layout_info_type());
+        create_new_prop(grid_layout_element, "layoutinfo-v", layout_info_type());
 
     let mut row = 0;
     let mut col = 0;
@@ -244,9 +244,9 @@ fn lower_box_layout(
         geometry: LayoutGeometry::new(layout_element),
     };
 
-    let layout_cache_prop = create_new_prop(layout_element, "layout_cache", Type::LayoutCache);
-    let layout_info_prop_v = create_new_prop(layout_element, "layoutinfo_v", layout_info_type());
-    let layout_info_prop_h = create_new_prop(layout_element, "layoutinfo_h", layout_info_type());
+    let layout_cache_prop = create_new_prop(layout_element, "layout-cache", Type::LayoutCache);
+    let layout_info_prop_v = create_new_prop(layout_element, "layoutinfo-v", layout_info_type());
+    let layout_info_prop_h = create_new_prop(layout_element, "layoutinfo-h", layout_info_type());
 
     let layout_children = std::mem::take(&mut layout_element.borrow_mut().children);
 
@@ -342,7 +342,7 @@ fn lower_path_layout(
     layout_element: &ElementRc,
     diag: &mut BuildDiagnostics,
 ) {
-    let layout_cache_prop = create_new_prop(layout_element, "layout_cache", Type::LayoutCache);
+    let layout_cache_prop = create_new_prop(layout_element, "layout-cache", Type::LayoutCache);
 
     let path_elements_expr = match layout_element.borrow_mut().bindings.remove("elements") {
         Some(BindingExpression { expression: Expression::PathElements { elements }, .. }) => {
@@ -426,14 +426,14 @@ fn create_layout_item(
         }
         let mut item = item.borrow_mut();
         let b = item.bindings.remove(prop).unwrap();
-        item.bindings.insert(format!("min_{}", prop), b.clone());
-        item.bindings.insert(format!("max_{}", prop), b);
+        item.bindings.insert(format!("min-{}", prop), b.clone());
+        item.bindings.insert(format!("max-{}", prop), b);
         item.property_declarations.insert(
-            format!("min_{}", prop),
+            format!("min-{}", prop),
             PropertyDeclaration { property_type: Type::Percent, ..PropertyDeclaration::default() },
         );
         item.property_declarations.insert(
-            format!("max_{}", prop),
+            format!("max-{}", prop),
             PropertyDeclaration { property_type: Type::Percent, ..PropertyDeclaration::default() },
         );
     };

--- a/sixtyfps_compiler/passes/lower_popups.rs
+++ b/sixtyfps_compiler/passes/lower_popups.rs
@@ -123,7 +123,7 @@ fn create_coordinate(
         };
     }
     let parent_element = parent_stack.last().unwrap();
-    let property_name = format!("{}_popup_{}", popup_comp.root_element.borrow().id, coord);
+    let property_name = format!("{}-popup-{}", popup_comp.root_element.borrow().id, coord);
     parent_element
         .borrow_mut()
         .property_declarations

--- a/sixtyfps_compiler/passes/lower_shadows.rs
+++ b/sixtyfps_compiler/passes/lower_shadows.rs
@@ -43,23 +43,23 @@ fn create_box_shadow_element(
     }
 
     let mut element = Element {
-        id: format!("{}_shadow", sibling_element.borrow().id),
+        id: format!("{}-shadow", sibling_element.borrow().id),
         base_type: type_register.lookup_element("BoxShadow").unwrap(),
         enclosing_component: sibling_element.borrow().enclosing_component.clone(),
         bindings: shadow_property_bindings
             .into_iter()
             .map(|(shadow_prop_name, expr)| {
-                (shadow_prop_name.strip_prefix("drop_shadow_").unwrap().to_string(), expr)
+                (shadow_prop_name.strip_prefix("drop-shadow-").unwrap().to_string(), expr)
             })
             .collect(),
         ..Default::default()
     };
 
-    // FIXME: remove the border_radius manual mapping.
-    if sibling_element.borrow().bindings.contains_key("border_radius") {
+    // FIXME: remove the border-radius manual mapping.
+    if sibling_element.borrow().bindings.contains_key("border-radius") {
         element.bindings.insert(
-            "border_radius".to_string(),
-            Expression::PropertyReference(NamedReference::new(sibling_element, "border_radius"))
+            "border-radius".to_string(),
+            Expression::PropertyReference(NamedReference::new(sibling_element, "border-radius"))
                 .into(),
         );
     }

--- a/sixtyfps_compiler/passes/lower_states.rs
+++ b/sixtyfps_compiler/passes/lower_states.rs
@@ -44,7 +44,7 @@ fn lower_state_in_element(
     let state_property_ref = if has_transitions {
         Expression::StructFieldAccess {
             base: Box::new(state_property.clone()),
-            name: "current_state".into(),
+            name: "current-state".into(),
         }
     } else {
         state_property.clone()
@@ -172,7 +172,7 @@ fn compute_state_property_name(root_element: &ElementRc) -> String {
     while root_element.borrow().lookup_property(property_name.as_ref()).property_type
         != Type::Invalid
     {
-        property_name += "_";
+        property_name += "-";
     }
     property_name
 }

--- a/sixtyfps_compiler/passes/lower_tabwidget.rs
+++ b/sixtyfps_compiler/passes/lower_tabwidget.rs
@@ -88,7 +88,7 @@ fn process_tabwidget(
         set_geometry_prop(elem, child, "width", diag);
         set_geometry_prop(elem, child, "height", diag);
         let condition = Expression::BinaryExpression {
-            lhs: Expression::PropertyReference(NamedReference::new(elem, "current_index")).into(),
+            lhs: Expression::PropertyReference(NamedReference::new(elem, "current-index")).into(),
             rhs: Expression::NumberLiteral(index as _, Unit::None).into(),
             op: '=',
         };
@@ -101,7 +101,7 @@ fn process_tabwidget(
         }
 
         let mut tab = Element {
-            id: format!("{}_tab{}", elem.borrow().id, index),
+            id: format!("{}-tab{}", elem.borrow().id, index),
             base_type: tab_impl.clone(),
             enclosing_component: elem.borrow().enclosing_component.clone(),
             ..Default::default()
@@ -112,21 +112,21 @@ fn process_tabwidget(
         );
         tab.bindings.insert(
             "current".to_owned(),
-            Expression::TwoWayBinding(NamedReference::new(elem, "current_index"), None).into(),
+            Expression::TwoWayBinding(NamedReference::new(elem, "current-index"), None).into(),
         );
         tab.bindings.insert(
-            "tab_index".to_owned(),
+            "tab-index".to_owned(),
             Expression::NumberLiteral(index as _, Unit::None).into(),
         );
         tab.bindings.insert(
-            "num_tabs".to_owned(),
+            "num-tabs".to_owned(),
             Expression::NumberLiteral(num_tabs as _, Unit::None).into(),
         );
         tabs.push(Rc::new(RefCell::new(tab)));
     }
 
     let tabbar = Element {
-        id: format!("{}_tabbar", elem.borrow().id),
+        id: format!("{}-tabbar", elem.borrow().id),
         base_type: tabbar_impl.clone(),
         enclosing_component: elem.borrow().enclosing_component.clone(),
         children: tabs,
@@ -138,27 +138,27 @@ fn process_tabwidget(
     set_tabbar_geometry_prop(elem, &tabbar, "width");
     set_tabbar_geometry_prop(elem, &tabbar, "height");
     elem.borrow_mut().bindings.insert(
-        "tabbar_preferred_width".to_owned(),
-        Expression::TwoWayBinding(NamedReference::new(&tabbar, "preferred_width"), None).into(),
+        "tabbar-preferred-width".to_owned(),
+        Expression::TwoWayBinding(NamedReference::new(&tabbar, "preferred-width"), None).into(),
     );
     elem.borrow_mut().bindings.insert(
-        "tabbar_preferred_height".to_owned(),
-        Expression::TwoWayBinding(NamedReference::new(&tabbar, "preferred_height"), None).into(),
+        "tabbar-preferred-height".to_owned(),
+        Expression::TwoWayBinding(NamedReference::new(&tabbar, "preferred-height"), None).into(),
     );
 
     if let Some(expr) = children
         .iter()
-        .map(|x| Expression::PropertyReference(NamedReference::new(x, "min_width")))
+        .map(|x| Expression::PropertyReference(NamedReference::new(x, "min-width")))
         .fold1(|lhs, rhs| crate::builtin_macros::min_max_expression(lhs, rhs, '>'))
     {
-        elem.borrow_mut().bindings.insert("content_min_width".into(), expr.into());
+        elem.borrow_mut().bindings.insert("content-min-width".into(), expr.into());
     };
     if let Some(expr) = children
         .iter()
-        .map(|x| Expression::PropertyReference(NamedReference::new(x, "min_height")))
+        .map(|x| Expression::PropertyReference(NamedReference::new(x, "min-height")))
         .fold1(|lhs, rhs| crate::builtin_macros::min_max_expression(lhs, rhs, '>'))
     {
-        elem.borrow_mut().bindings.insert("content_min_height".into(), expr.into());
+        elem.borrow_mut().bindings.insert("content-min-height".into(), expr.into());
     };
 
     children.push(tabbar);
@@ -175,7 +175,7 @@ fn set_geometry_prop(
         prop.into(),
         Expression::PropertyReference(NamedReference::new(
             tab_widget,
-            &format!("content_{}", prop),
+            &format!("content-{}", prop),
         ))
         .into(),
     );
@@ -190,7 +190,7 @@ fn set_geometry_prop(
 fn set_tabbar_geometry_prop(tab_widget: &ElementRc, tabbar: &ElementRc, prop: &str) {
     tabbar.borrow_mut().bindings.insert(
         prop.into(),
-        Expression::PropertyReference(NamedReference::new(tab_widget, &format!("tabbar_{}", prop)))
+        Expression::PropertyReference(NamedReference::new(tab_widget, &format!("tabbar-{}", prop)))
             .into(),
     );
 }

--- a/sixtyfps_compiler/passes/materialize_fake_properties.rs
+++ b/sixtyfps_compiler/passes/materialize_fake_properties.rs
@@ -132,14 +132,14 @@ fn has_declared_property(elem: &Element, prop: &str) -> bool {
 /// Initialize a sensible default binding for the now materialized property
 fn initialize(elem: &ElementRc, name: &str) -> Option<Expression> {
     let expr = match name {
-        "min_height" => layout_constraint_prop(elem, "min", Orientation::Vertical),
-        "min_width" => layout_constraint_prop(elem, "min", Orientation::Horizontal),
-        "max_height" => layout_constraint_prop(elem, "max", Orientation::Vertical),
-        "max_width" => layout_constraint_prop(elem, "max", Orientation::Horizontal),
-        "preferred_height" => layout_constraint_prop(elem, "preferred", Orientation::Vertical),
-        "preferred_width" => layout_constraint_prop(elem, "preferred", Orientation::Horizontal),
-        "horizontal_stretch" => layout_constraint_prop(elem, "stretch", Orientation::Horizontal),
-        "vertical_stretch" => layout_constraint_prop(elem, "stretch", Orientation::Vertical),
+        "min-height" => layout_constraint_prop(elem, "min", Orientation::Vertical),
+        "min-width" => layout_constraint_prop(elem, "min", Orientation::Horizontal),
+        "max-height" => layout_constraint_prop(elem, "max", Orientation::Vertical),
+        "max-width" => layout_constraint_prop(elem, "max", Orientation::Horizontal),
+        "preferred-height" => layout_constraint_prop(elem, "preferred", Orientation::Vertical),
+        "preferred-width" => layout_constraint_prop(elem, "preferred", Orientation::Horizontal),
+        "horizontal-stretch" => layout_constraint_prop(elem, "stretch", Orientation::Horizontal),
+        "vertical-stretch" => layout_constraint_prop(elem, "stretch", Orientation::Vertical),
         "opacity" => Expression::NumberLiteral(1., Unit::None),
         "visible" => Expression::BoolLiteral(true),
         _ => return None,

--- a/sixtyfps_compiler/passes/move_declarations.rs
+++ b/sixtyfps_compiler/passes/move_declarations.rs
@@ -124,7 +124,7 @@ fn fixup_reference(nr: &mut NamedReference) {
 }
 
 fn map_name(e: &ElementRc, s: &str) -> String {
-    format!("{}_{}", e.borrow().id, s)
+    format!("{}-{}", e.borrow().id, s)
 }
 
 /// Optimized item are not used for the fact that they are items, but their properties

--- a/sixtyfps_compiler/passes/repeater_component.rs
+++ b/sixtyfps_compiler/passes/repeater_component.rs
@@ -57,7 +57,7 @@ fn create_repeater_components(component: &Rc<Component>) {
         if is_listview && !comp.root_element.borrow().bindings.contains_key("height") {
             let preferred = Expression::PropertyReference(NamedReference::new(
                 &comp.root_element,
-                "preferred_height",
+                "preferred-height",
             ));
             comp.root_element.borrow_mut().bindings.insert("height".into(), preferred.into());
         }

--- a/sixtyfps_compiler/passes/resolve_native_classes.rs
+++ b/sixtyfps_compiler/passes/resolve_native_classes.rs
@@ -142,7 +142,7 @@ fn select_minimal_class() {
     assert_eq!(
         select_minimal_class_based_on_property_usage(
             &rect.native_class,
-            ["border_width".to_owned()].iter()
+            ["border-width".to_owned()].iter()
         )
         .class_name,
         "BorderRectangle",
@@ -150,7 +150,7 @@ fn select_minimal_class() {
     assert_eq!(
         select_minimal_class_based_on_property_usage(
             &rect.native_class,
-            ["border_width".to_owned(), "x".to_owned()].iter()
+            ["border-width".to_owned(), "x".to_owned()].iter()
         )
         .class_name,
         "BorderRectangle",

--- a/sixtyfps_compiler/passes/resolving.rs
+++ b/sixtyfps_compiler/passes/resolving.rs
@@ -502,9 +502,12 @@ impl Expression {
         let result = match global_lookup.lookup(ctx, &first_str) {
             None => {
                 if let Some(minus_pos) = first.text().find('-') {
-                    // Attempt to recover if the user wanted to write "-"
+                    // Attempt to recover if the user wanted to write "-" for minus
                     let first_str = &first.text()[0..minus_pos];
-                    if global_lookup.lookup(ctx, first_str).is_some() {
+                    if global_lookup
+                        .lookup(ctx, &crate::parser::normalize_identifier(first_str))
+                        .is_some()
+                    {
                         ctx.diag.push_error(format!("Unknown unqualified identifier '{}'. Use space before the '-' if you meant a subtraction", first.text()), &node);
                         return Expression::Invalid;
                     }
@@ -993,7 +996,10 @@ fn continue_lookup_within_element(
         };
         if let Some(minus_pos) = second.text().find('-') {
             // Attempt to recover if the user wanted to write "-"
-            if elem.borrow().lookup_property(&second.text()[0..minus_pos]).property_type
+            if elem
+                .borrow()
+                .lookup_property(&crate::parser::normalize_identifier(&second.text()[0..minus_pos]))
+                .property_type
                 != Type::Invalid
             {
                 err(". Use space before the '-' if you meant a subtraction");

--- a/sixtyfps_compiler/passes/transform_and_opacity.rs
+++ b/sixtyfps_compiler/passes/transform_and_opacity.rs
@@ -75,7 +75,7 @@ pub(crate) fn handle_transform_and_opacity(
 
 fn create_opacity_element(child: &ElementRc, type_register: &TypeRegister) -> ElementRc {
     let element = Element {
-        id: format!("{}_opacity", child.borrow().id),
+        id: format!("{}-opacity", child.borrow().id),
         base_type: type_register.lookup_element("Opacity").unwrap(),
         enclosing_component: child.borrow().enclosing_component.clone(),
         bindings: std::iter::once((

--- a/sixtyfps_compiler/passes/unique_id.rs
+++ b/sixtyfps_compiler/passes/unique_id.rs
@@ -27,7 +27,7 @@ pub fn assign_unique_id(component: &Rc<Component>) {
         } else {
             elem_mut.base_type.to_string().to_ascii_lowercase()
         };
-        elem_mut.id = format!("{}_{}", old_id, count);
+        elem_mut.id = format!("{}-{}", old_id, count);
     });
 
     rename_globals(component, count);
@@ -42,7 +42,7 @@ fn rename_globals(component: &Rc<Component>, mut count: u32) {
             // builtin global keeps its name
             root.id = g.id.clone();
         } else {
-            root.id = format!("{}_{}", g.id, count);
+            root.id = format!("{}-{}", g.id, count);
         }
     }
 }

--- a/sixtyfps_compiler/passes/visible.rs
+++ b/sixtyfps_compiler/passes/visible.rs
@@ -26,7 +26,7 @@ pub fn handle_visible(component: &Rc<Component>, type_register: &TypeRegister) {
         &mut |elem: &ElementRc, _| {
             let is_lowered_from_visible_property =
                 elem.borrow().native_class().map_or(false, |n| {
-                    Rc::ptr_eq(&n, &native_clip) && elem.borrow().id.ends_with("_visibility")
+                    Rc::ptr_eq(&n, &native_clip) && elem.borrow().id.ends_with("-visibility")
                 });
             if is_lowered_from_visible_property {
                 // This is the element we just created. Skip it.
@@ -72,7 +72,7 @@ pub fn handle_visible(component: &Rc<Component>, type_register: &TypeRegister) {
 
 fn create_visibility_element(child: &ElementRc, native_clip: &Rc<NativeClass>) -> ElementRc {
     let element = Element {
-        id: format!("{}_visibility", child.borrow().id),
+        id: format!("{}-visibility", child.borrow().id),
         base_type: Type::Native(native_clip.clone()),
         enclosing_component: child.borrow().enclosing_component.clone(),
         bindings: std::iter::once((

--- a/sixtyfps_compiler/tests/syntax/analysis/binding_loop1.60
+++ b/sixtyfps_compiler/tests/syntax/analysis/binding_loop1.60
@@ -47,7 +47,7 @@ Test := Rectangle {
 
     WithStates {
         extra_background: background;
-//                       ^error{The binding for the property 'extra_background' is part of a binding loop}
+//                       ^error{The binding for the property 'extra-background' is part of a binding loop}
     }
 }
 

--- a/sixtyfps_compiler/tests/syntax/analysis/binding_loop_layout.60
+++ b/sixtyfps_compiler/tests/syntax/analysis/binding_loop_layout.60
@@ -11,10 +11,10 @@ LICENSE END */
 TC := Rectangle {
     outer := VerticalLayout {
 //          ^error{The binding for the property 'width' is part of a binding loop}
-//          ^^error{The binding for the property 'layoutinfo_h' is part of a binding loop}
+//          ^^error{The binding for the property 'layoutinfo-h' is part of a binding loop}
         inner := HorizontalLayout {
 //              ^error{The binding for the property 'width' is part of a binding loop}
-//              ^^error{The binding for the property 'layoutinfo_h' is part of a binding loop}
+//              ^^error{The binding for the property 'layoutinfo-h' is part of a binding loop}
             inner_inner := VerticalLayout {
                 width: parent.width;
 //                    ^error{The binding for the property 'width' is part of a binding loop}
@@ -27,8 +27,8 @@ TC := Rectangle {
 
 Test := Rectangle {
     VerticalLayout {
-//  ^error{The binding for the property 'layoutinfo_h' is part of a binding loop}  // FIXME: That's an internal property, but people might understand
-//  ^^error{The binding for the property 'min_width' is part of a binding loop}
+//  ^error{The binding for the property 'layoutinfo-h' is part of a binding loop}  // FIXME: That's an internal property, but people might understand
+//  ^^error{The binding for the property 'min-width' is part of a binding loop}
         Rectangle {
             width: parent.min_width;
             //    ^error{The binding for the property 'width' is part of a binding loop}
@@ -37,8 +37,8 @@ Test := Rectangle {
 
 
     l := HorizontalLayout {
-//      ^error{The binding for the property 'layoutinfo_h' is part of a binding loop}  // FIXME: That's an internal property, but people might understand
-//      ^^error{The binding for the property 'preferred_width' is part of a binding loop}
+//      ^error{The binding for the property 'layoutinfo-h' is part of a binding loop}  // FIXME: That's an internal property, but people might understand
+//      ^^error{The binding for the property 'preferred-width' is part of a binding loop}
         Text {
             text: "hello \{l.preferred-width/1px}x\{l.preferred-height/1px}";
 //               ^error{The binding for the property 'text' is part of a binding loop}
@@ -46,8 +46,8 @@ Test := Rectangle {
     }
 
     tc := TC {
-//       ^error{The binding for the property 'preferred_width' is part of a binding loop}
-//       ^^error{The binding for the property 'layoutinfo_h' is part of a binding loop}
+//       ^error{The binding for the property 'preferred-width' is part of a binding loop}
+//       ^^error{The binding for the property 'layoutinfo-h' is part of a binding loop}
         width: preferred-width;
 //            ^error{The binding for the property 'width' is part of a binding loop}
     }

--- a/sixtyfps_compiler/tests/syntax/analysis/binding_loop_layout2.60
+++ b/sixtyfps_compiler/tests/syntax/analysis/binding_loop_layout2.60
@@ -12,9 +12,9 @@ LICENSE END */
 Test := Rectangle {
     property <image> source;
     GridLayout {
-//  ^error{The binding for the property 'layout_cache_h' is part of a binding loop}
+//  ^error{The binding for the property 'layout-cache-h' is part of a binding loop}
 //  ^^error{The binding for the property 'width' is part of a binding loop}
-//  ^^^error{The binding for the property 'layout_cache_v' is part of a binding loop}
+//  ^^^error{The binding for the property 'layout-cache-v' is part of a binding loop}
 //  ^^^^error{The binding for the property 'height' is part of a binding loop}
         Image {
             source: root.source;

--- a/sixtyfps_compiler/tests/syntax/basic/box_shadow.60
+++ b/sixtyfps_compiler/tests/syntax/basic/box_shadow.60
@@ -9,11 +9,11 @@
 LICENSE END */
 SuperSimple := Rectangle {
     drop-shadow-color: #00000080;
-//                    ^warning{The drop_shadow_color property cannot be used on the root element, the shadow will not be visible}
+//                    ^warning{The drop-shadow-color property cannot be used on the root element, the shadow will not be visible}
 
     Text {
         drop-shadow-color: black;
-//                        ^error{The drop_shadow_color property is only supported on Rectangle and Clip elements right now}
+//                        ^error{The drop-shadow-color property is only supported on Rectangle and Clip elements right now}
     }
 }
 

--- a/sixtyfps_compiler/tests/syntax/basic/double_binding.60
+++ b/sixtyfps_compiler/tests/syntax/basic/double_binding.60
@@ -18,7 +18,7 @@ X := Rectangle {
 //  ^error{Duplicated property binding}
 
     not_exist <=> 12phx;
-//  ^error{Unknown property not_exist in Rectangle}
+//  ^error{Unknown property not-exist in Rectangle}
 
     property <int> foo: 12;
     foo: 13;

--- a/sixtyfps_compiler/tests/syntax/basic/return.60
+++ b/sixtyfps_compiler/tests/syntax/basic/return.60
@@ -17,6 +17,6 @@ X := Rectangle {
     callback xxx() -> string;
     xxx => {
         return 42phx;
-//      ^error{Cannot convert physical_length to string. Divide by 1phx to convert to a plain number}
+//      ^error{Cannot convert physical-length to string. Divide by 1phx to convert to a plain number}
     }
 }

--- a/sixtyfps_compiler/tests/syntax/basic/signal.60
+++ b/sixtyfps_compiler/tests/syntax/basic/signal.60
@@ -34,13 +34,13 @@ SubElements := Rectangle {
     }
 
     does_not_exist => {
-//  ^error{'does_not_exist' is not a callback in Rectangle}
+//  ^error{'does-not-exist' is not a callback in Rectangle}
         root.does_not_exist();
     }
 
     foobar() => { foobar() }
     callback_with_arg(a, b, c, d) => { }
-//  ^error{'callback_with_arg' only has 2 arguments, but 4 were provided}
+//  ^error{'callback-with-arg' only has 2 arguments, but 4 were provided}
 
 }
 

--- a/sixtyfps_compiler/tests/syntax/basic/states_transitions2.60
+++ b/sixtyfps_compiler/tests/syntax/basic/states_transitions2.60
@@ -20,7 +20,7 @@ TestCase := Rectangle {
 
     transitions [
         in does_not_exist: {
-//        ^error{State 'does_not_exist' does not exist}
+//        ^error{State 'does-not-exist' does not exist}
             animate * { }
         }
         in checked: {

--- a/sixtyfps_compiler/tests/syntax/basic/states_two_way.60
+++ b/sixtyfps_compiler/tests/syntax/basic/states_two_way.60
@@ -26,7 +26,7 @@ export Demo := Window {
             t.y: 100px;
 //          ^error{Cannot change the property 'y' in a state because it is initialized with a two-way binding}
             some_prop: "plop";
-//          ^error{Cannot change the property 'some_prop' in a state because it is initialized with a two-way binding}
+//          ^error{Cannot change the property 'some-prop' in a state because it is initialized with a two-way binding}
         }
     ]
 }

--- a/sixtyfps_compiler/tests/syntax/basic/unknown_item.60
+++ b/sixtyfps_compiler/tests/syntax/basic/unknown_item.60
@@ -23,7 +23,7 @@ SuperSimple := Rectangle {
         Rectangle {
             background: blue;
             foo_bar: blue;
-//          ^error{Unknown property foo_bar in Rectangle}
+//          ^error{Unknown property foo-bar in Rectangle}
         }
     }
 
@@ -45,7 +45,7 @@ SuperSimple := Rectangle {
 
     Rectangle {
         foo_bar: blue;
-//      ^error{Unknown property foo_bar in Rectangle}
+//      ^error{Unknown property foo-bar in Rectangle}
     }
 
     NativeLineEdit { }

--- a/sixtyfps_compiler/tests/syntax/layout/min_max_conflict.60
+++ b/sixtyfps_compiler/tests/syntax/layout/min_max_conflict.60
@@ -12,13 +12,13 @@ Test := Rectangle {
     GridLayout {
         Rectangle {
             height: 42px;
-//                 ^error{Cannot specify both 'height' and 'min_height'}
+//                 ^error{Cannot specify both 'height' and 'min-height'}
             min-height: 42px;
             max-width: 42px;
         }
         Rectangle {
             width: 42px;
-//                ^error{Cannot specify both 'width' and 'max_width'}
+//                ^error{Cannot specify both 'width' and 'max-width'}
             min-height: 42px;
             max-width: 42px;
         }

--- a/sixtyfps_compiler/tests/syntax/lookup/deprecated_property.60
+++ b/sixtyfps_compiler/tests/syntax/lookup/deprecated_property.60
@@ -22,8 +22,8 @@ Xxx := Rectangle {
     }
 
     minimum-height: root.maximum-width;
-//  ^warning{The property 'minimum_height' has been deprecated. Please use 'min_height' instead}
-//                       ^^warning{The property 'maximum_width' has been deprecated. Please use 'max_width' instead}
+//  ^warning{The property 'minimum-height' has been deprecated. Please use 'min-height' instead}
+//                       ^^warning{The property 'maximum-width' has been deprecated. Please use 'max-width' instead}
 
     callback not_called;
     not_called() => {

--- a/sixtyfps_compiler/tests/syntax/lookup/for_lookup.60
+++ b/sixtyfps_compiler/tests/syntax/lookup/for_lookup.60
@@ -65,7 +65,7 @@ Hello := Rectangle {
         y: pp.b;
 //        ^error{Cannot convert string to length}
         property<int> ggg: pp;
-//                        ^error{Cannot convert \{ a: physical_length,b: string,\} to int}
+//                        ^error{Cannot convert \{ a: physical-length,b: string,\} to int}
     }
 
 

--- a/sixtyfps_compiler/tests/syntax/lookup/two_way_binding.60
+++ b/sixtyfps_compiler/tests/syntax/lookup/two_way_binding.60
@@ -37,6 +37,6 @@ X := Rectangle {
         x <=> self.loop_on_x;
 //      ^error{The binding for the property 'x' is part of a binding loop}
         property <length> loop_on_x <=> x;
-//                                  ^error{The binding for the property 'loop_on_x' is part of a binding loop}
+//                                  ^error{The binding for the property 'loop-on-x' is part of a binding loop}
     }
 }

--- a/sixtyfps_compiler/tests/syntax/lookup/two_way_binding_infer.60
+++ b/sixtyfps_compiler/tests/syntax/lookup/two_way_binding_infer.60
@@ -11,20 +11,20 @@ LICENSE END */
 X := Rectangle {
 
     property infer_loop <=> infer_loop2;
-//  ^error{Could not infer type of property 'infer_loop'}
+//  ^error{Could not infer type of property 'infer-loop'}
     property infer_loop2 <=> infer_loop3;
-//  ^error{Could not infer type of property 'infer_loop2'}
+//  ^error{Could not infer type of property 'infer-loop2'}
     property infer_loop3 <=> infer_loop;
-//  ^error{Could not infer type of property 'infer_loop3'}
+//  ^error{Could not infer type of property 'infer-loop3'}
 //                           ^^error{Unknown unqualified identifier 'infer_loop'}
 //                       ^^^error{The expression in a two way binding must be a property reference}
 
     property infer_error <=> r.infer_error;
-//  ^error{Could not infer type of property 'infer_error'}
+//  ^error{Could not infer type of property 'infer-error'}
     r := Rectangle {
         property infer_error <=> 0;
 //                           ^error{The expression in a two way binding must be a property reference}
-//      ^^error{Could not infer type of property 'infer_error'}
+//      ^^error{Could not infer type of property 'infer-error'}
     }
 
     property auto_background <=> background;

--- a/sixtyfps_compiler/typeregister.rs
+++ b/sixtyfps_compiler/typeregister.rs
@@ -24,19 +24,19 @@ pub(crate) const RESERVED_GEOMETRY_PROPERTIES: &[(&str, Type)] = &[
 ];
 
 const RESERVED_LAYOUT_PROPERTIES: &[(&str, Type)] = &[
-    ("min_width", Type::LogicalLength),
-    ("min_height", Type::LogicalLength),
-    ("max_width", Type::LogicalLength),
-    ("max_height", Type::LogicalLength),
+    ("min-width", Type::LogicalLength),
+    ("min-height", Type::LogicalLength),
+    ("max-width", Type::LogicalLength),
+    ("max-height", Type::LogicalLength),
     ("padding", Type::LogicalLength),
-    ("padding_left", Type::LogicalLength),
-    ("padding_right", Type::LogicalLength),
-    ("padding_top", Type::LogicalLength),
-    ("padding_bottom", Type::LogicalLength),
-    ("preferred_width", Type::LogicalLength),
-    ("preferred_height", Type::LogicalLength),
-    ("horizontal_stretch", Type::Float32),
-    ("vertical_stretch", Type::Float32),
+    ("padding-left", Type::LogicalLength),
+    ("padding-right", Type::LogicalLength),
+    ("padding-top", Type::LogicalLength),
+    ("padding-bottom", Type::LogicalLength),
+    ("preferred-width", Type::LogicalLength),
+    ("preferred-height", Type::LogicalLength),
+    ("horizontal-stretch", Type::Float32),
+    ("vertical-stretch", Type::Float32),
     ("col", Type::Int32),
     ("row", Type::Int32),
     ("colspan", Type::Int32),
@@ -50,10 +50,10 @@ const RESERVED_OTHER_PROPERTIES: &[(&str, Type)] = &[
 ];
 
 pub(crate) const RESERVED_DROP_SHADOW_PROPERTIES: &[(&str, Type)] = &[
-    ("drop_shadow_offset_x", Type::LogicalLength),
-    ("drop_shadow_offset_y", Type::LogicalLength),
-    ("drop_shadow_blur", Type::LogicalLength),
-    ("drop_shadow_color", Type::Color),
+    ("drop-shadow-offset-x", Type::LogicalLength),
+    ("drop-shadow-offset-y", Type::LogicalLength),
+    ("drop-shadow-blur", Type::LogicalLength),
+    ("drop-shadow-color", Type::Color),
 ];
 
 /// list of reserved property injected in every item
@@ -65,7 +65,7 @@ pub fn reserved_properties() -> impl Iterator<Item = (&'static str, Type)> {
         .chain(RESERVED_DROP_SHADOW_PROPERTIES.iter())
         .map(|(k, v)| (*k, v.clone()))
         .chain(std::array::IntoIter::new([
-            ("forward_focus", Type::ElementReference),
+            ("forward-focus", Type::ElementReference),
             ("focus", BuiltinFunction::SetFocusItem.ty()),
         ]))
 }
@@ -83,10 +83,10 @@ pub fn reserved_property(name: &str) -> PropertyLookupResult {
         if let Some(a) = name.strip_prefix(pre) {
             for suf in &["width", "height"] {
                 if let Some(b) = a.strip_suffix(suf) {
-                    if b == "imum_" {
+                    if b == "imum-" {
                         return PropertyLookupResult {
                             property_type: Type::LogicalLength,
-                            resolved_name: format!("{}_{}", pre, suf).into(),
+                            resolved_name: format!("{}-{}", pre, suf).into(),
                         };
                     }
                 }
@@ -164,11 +164,11 @@ impl TypeRegister {
 
         declare_enum("TextHorizontalAlignment", &["left", "center", "right"]);
         declare_enum("TextVerticalAlignment", &["top", "center", "bottom"]);
-        declare_enum("TextWrap", &["no_wrap", "word_wrap"]);
+        declare_enum("TextWrap", &["no-wrap", "word-wrap"]);
         declare_enum("TextOverflow", &["clip", "elide"]);
         declare_enum(
             "LayoutAlignment",
-            &["stretch", "center", "start", "end", "space_between", "space_around"],
+            &["stretch", "center", "start", "end", "space-between", "space-around"],
         );
         declare_enum("ImageFit", &["fill", "contain", "cover"]);
         declare_enum("EventResult", &["reject", "accept"]);

--- a/sixtyfps_compiler/widgets/fluent/sixtyfps_widgets.60
+++ b/sixtyfps_compiler/widgets/fluent/sixtyfps_widgets.60
@@ -62,10 +62,10 @@ global Palette := {
 }
 
 export global StyleMetrics := {
-    property<length> layout_spacing: 8px;
-    property<length> layout_padding: 8px;
-    property<length> text_cursor_width: 2px;
-    property<color> window_background: white; //FIXME: Palette.white  does not compile (cannot access globals from other globals #175)
+    property<length> layout-spacing: 8px;
+    property<length> layout-padding: 8px;
+    property<length> text-cursor-width: 2px;
+    property<color> window-background: white; //FIXME: Palette.white  does not compile (cannot access globals from other globals #175)
 }
 
 export Button := Rectangle {
@@ -81,7 +81,7 @@ export Button := Rectangle {
     border-color: !enabled ? Palette.neutralLighter : Palette.neutralSecondaryAlt;
     background: !enabled ? Palette.neutralLighter
         : touch.pressed ? Palette.neutralLight
-        : touch.has_hover ? Palette.neutralLighter
+        : touch.has-hover ? Palette.neutralLighter
         : Palette.white;
     horizontal-stretch: 0;
     vertical-stretch: 0;
@@ -98,9 +98,9 @@ export Button := Rectangle {
 
         text := Text {
             color: !enabled ? Palette.neutralTertiary : Palette.neutralDark;
-            horizontal_alignment: center;
-            vertical_alignment: center;
-            font_weight: 600;
+            horizontal-alignment: center;
+            vertical-alignment: center;
+            font-weight: 600;
         }
     }
 
@@ -128,22 +128,22 @@ export CheckBox := Rectangle {
                /* border-color: !enabled ? Palette.neutralLighter : Palette.neutralSecondaryAlt;
                 background: !enabled ? Palette.white
                     : touch.pressed ? Palette.neutralLight
-                    : touch.has_hover ? Palette.neutralLighter
+                    : touch.has-hover ? Palette.neutralLighter
                     : Palette.themePrimary;*/
 
                 border-color: checked ? background : !enabled ? Palette.neutralTertiaryAlt : Palette.neutralSecondaryAlt;
                 background: !checked ? Palette.white
                             : !enabled ? Palette.neutralTertiaryAlt
-                            : touch.has_hover || touch.pressed ? Palette.themeDark
+                            : touch.has-hover || touch.pressed ? Palette.themeDark
                             : Palette.themePrimary;
                 animate background { duration: 250ms; easing: ease; }
 
                 //width: height;
-                vertical_stretch: 0;
+                vertical-stretch: 0;
                 width: 20px;
                 height: 20px;
 
-                if (checked || touch.has_hover || touch.pressed) : Path {
+                if (checked || touch.has-hover || touch.pressed) : Path {
                     width: 66%;
                     height: 66%;
                     x: (parent.width - width) / 2;
@@ -156,9 +156,9 @@ export CheckBox := Rectangle {
 
         text := Text {
             color: !enabled ? Palette.neutralTertiary : Palette.neutralDark;
-            horizontal_alignment: left;
-            vertical_alignment: center;
-            vertical_stretch: 1;
+            horizontal-alignment: left;
+            vertical-alignment: center;
+            vertical-stretch: 1;
         }
 
     }
@@ -181,11 +181,11 @@ SpinBoxButton := Rectangle {
     property<bool> enabled <=> touch.enabled;
     background: !enabled ? transparent
         : touch.pressed ? Palette.neutralLight
-        : touch.has_hover ? Palette.neutralLighter
+        : touch.has-hover ? Palette.neutralLighter
         : Palette.white;
 
-    property <color> symbol_color: !enabled ? Palette.neutralTertiary
-        : touch.pressed || touch.has_hover ? Palette.neutralPrimary
+    property <color> symbol-color: !enabled ? Palette.neutralTertiary
+        : touch.pressed || touch.has-hover ? Palette.neutralPrimary
         : Palette.neutralSecondary;
     touch := TouchArea { }
 }
@@ -213,8 +213,8 @@ export SpinBox := FocusScope {
             rowspan: 2;
             text: value;
             color: !enabled ? Palette.neutralTertiary : Palette.neutralDark;
-            horizontal_alignment: left;
-            vertical_alignment: center;
+            horizontal-alignment: left;
+            vertical-alignment: center;
         }
         Rectangle { width: 8px; }
         button := SpinBoxButton {
@@ -222,7 +222,7 @@ export SpinBox := FocusScope {
             enabled: root.enabled;
             Path {
                 commands: "M978.2,688.9l-84.2,82.1c-15.7,15.3-41.1,15.3-56.7,0l-341-304.2L162.6,764.5c-15.5,15.1-41,15.1-56.6,0l-84.3-82.1c-15.6-15.2-15.6-39.9,0-55.2l446.6-398.2c15.7-15.3,41-15.3,56.7,0l6.9,6.7l446.3,398.1C993.9,649,993.9,673.7,978.2,688.9z";
-                fill: parent.symbol_color;
+                fill: parent.symbol-color;
                 height: 33%;
                 x: (parent.width - width) / 2;
                 y: (parent.height - height) / 2;
@@ -238,7 +238,7 @@ export SpinBox := FocusScope {
             enabled: root.enabled;
             Path {
                 commands: "M21.8,311.1l84.2-82.1c15.7-15.2,41-15.2,56.7,0l341.1,304.1l333.7-297.5c15.5-15.2,41-15.2,56.6,0l84.3,82.1c15.6,15.2,15.6,40,0,55.2L531.7,771c-15.7,15.3-41,15.3-56.7,0l-6.9-6.7L21.8,366.3C6.1,351,6.1,326.3,21.8,311.1z";
-                fill: parent.symbol_color;
+                fill: parent.symbol-color;
                 height: 33%;
                 x: (parent.width - width) / 2;
                 y: (parent.height - height) / 2;
@@ -253,14 +253,14 @@ export SpinBox := FocusScope {
     }
 
     Rectangle {
-        x: enabled && has_focus ? -2px : 0px;
+        x: enabled && has-focus ? -2px : 0px;
         y: x;
         width: parent.width - 2*x;
         height: parent.height - 2*y;
         border-radius: 2px;
-        border-width: !enabled ? 0px : has_focus ? 3px : 1px;
+        border-width: !enabled ? 0px : has-focus ? 3px : 1px;
         border-color: !enabled ? Palette.neutralLighter
-            : has_focus ? Palette.themeSecondary
+            : has-focus ? Palette.themeSecondary
             : Palette.neutralDark;
     }
 
@@ -283,45 +283,45 @@ export Slider := Rectangle {
         x: parent.height / 2;
         height: parent.min-height / 4;
         y: (parent.height - height) / 2;
-        border_radius: height/2;
+        border-radius: height/2;
         background: !root.enabled ? Palette.neutralLighter
-            : touch.has_hover ? Palette.themeLight
+            : touch.has-hover ? Palette.themeLight
             : Palette.neutralTertiaryAlt;
     }
 
     Rectangle {
-        width: (parent.width - parent.min-height) * (handle.new_value / maximum);
+        width: (parent.width - parent.min-height) * (handle.new-value / maximum);
         x: parent.height / 2;
         height: parent.min-height / 4;
         y: (parent.height - height) / 2;
-        border_radius: height/2;
+        border-radius: height/2;
         background: !root.enabled ? Palette.neutralTertiary
-            : touch.has_hover ? Palette.themeSecondary
+            : touch.has-hover ? Palette.themeSecondary
             : Palette.neutralSecondary;
     }
 
     handle := Rectangle {
         width: height;
         height: parent.height;
-        border_width: 3px;
-        border_radius: height / 2;
-        border_color: !root.enabled ? Palette.neutralTertiaryAlt
-            : touch.has_hover ? Palette.themePrimary
+        border-width: 3px;
+        border-radius: height / 2;
+        border-color: !root.enabled ? Palette.neutralTertiaryAlt
+            : touch.has-hover ? Palette.themePrimary
             : Palette.neutralSecondary;
         background: Palette.white;
-        x: (root.width - handle.width) * (new_value - minimum)/(maximum - minimum);
-        property<float> new_value_tmp : (touch.pressed && enabled)
-            ? root.value + (touch.mouse_x - touch.pressed_x) * (maximum - minimum) / (root.width - handle.width)
+        x: (root.width - handle.width) * (new-value - minimum)/(maximum - minimum);
+        property<float> new-value-tmp : (touch.pressed && enabled)
+            ? root.value + (touch.mouse-x - touch.pressed-x) * (maximum - minimum) / (root.width - handle.width)
             : root.value;
-        property<float> new_value : new_value_tmp < root.minimum ? root.minimum
-            : new_value_tmp > root.maximum ? root.maximum : new_value_tmp;
+        property<float> new-value : new-value-tmp < root.minimum ? root.minimum
+            : new-value-tmp > root.maximum ? root.maximum : new-value-tmp;
     }
     touch := TouchArea {
         width: parent.width;
         height: parent.height;
         clicked => {
             if (enabled) {
-                root.value = handle.new_value;
+                root.value = handle.new-value;
                 root.changed(root.value);
             }
         }
@@ -340,7 +340,7 @@ export GroupBox := VerticalLayout {
         text: root.title;
         vertical-stretch: 0;
         color: !enabled ? Palette.neutralTertiary : Palette.neutralDark;
-        font_weight: 600;
+        font-weight: 600;
     }
     @children
 }
@@ -348,25 +348,25 @@ export GroupBox := VerticalLayout {
 
 
 export TabWidgetImpl := Rectangle {
-    property <length> content_x: 0;
-    property <length> content_y: tabbar_preferred_height;
-    property <length> content_height: height - tabbar_preferred_height;
-    property <length> content_width: width;
-    property <length> tabbar_x: 0;
-    property <length> tabbar_y: 0;
-    property <length> tabbar_height: tabbar_preferred_height;
-    property <length> tabbar_width: width;
+    property <length> content-x: 0;
+    property <length> content-y: tabbar-preferred-height;
+    property <length> content-height: height - tabbar-preferred-height;
+    property <length> content-width: width;
+    property <length> tabbar-x: 0;
+    property <length> tabbar-y: 0;
+    property <length> tabbar-height: tabbar-preferred-height;
+    property <length> tabbar-width: width;
 
-    property <length> tabbar_preferred_height;
-    property <length> tabbar_preferred_width;
-    property <length> content_min_height;
-    property <length> content_min_width;
-    property <int> current_index;
+    property <length> tabbar-preferred-height;
+    property <length> tabbar-preferred-width;
+    property <length> content-min-height;
+    property <length> content-min-width;
+    property <int> current-index;
 
-    preferred_width: content_min_width;
-    min_width: content_min_width;
-    preferred_height: content_min_height + tabbar_preferred_height;
-    min_height: content_min_height + tabbar_preferred_height;
+    preferred-width: content-min-width;
+    min-width: content-min-width;
+    preferred-height: content-min-height + tabbar-preferred-height;
+    min-height: content-min-height + tabbar-preferred-height;
 
 }
 export TabImpl := Rectangle {
@@ -375,23 +375,23 @@ export TabImpl := Rectangle {
     property<bool> enabled : true;
     property<bool> pressed;
     property<int> current;
-    property<int> tab_index;
-    property<int> num_tabs;
+    property<int> tab-index;
+    property<int> num-tabs;
 
-    min-height: t.preferred_height + 16px;
-    preferred_width: t.preferred_width + 16px;
+    min-height: t.preferred-height + 16px;
+    preferred-width: t.preferred-width + 16px;
 
 
     background: !enabled ? Palette.neutralLighter
         : touch.pressed ? Palette.neutralLight
-        : touch.has_hover ? Palette.neutralLighter
+        : touch.has-hover ? Palette.neutralLighter
         : Palette.white;
     horizontal-stretch: 0;
     vertical-stretch: 0;
 
     touch := TouchArea {
         clicked => {
-            current = tab_index;
+            current = tab-index;
         }
     }
     t:= Text {
@@ -400,14 +400,14 @@ export TabImpl := Rectangle {
         vertical-alignment: center;
         horizontal-alignment: center;
         color: !enabled ? Palette.neutralTertiary : Palette.neutralPrimary;
-        font_weight: root.current == root.tab_index ? 600 : 500;
+        font-weight: root.current == root.tab-index ? 600 : 500;
     }
 
     Rectangle {
         height: 3px;
-        width: touch.has_hover && root.current == root.tab_index ? parent.width : parent.width - 16px;
+        width: touch.has-hover && root.current == root.tab-index ? parent.width : parent.width - 16px;
         animate width { duration: 250ms; easing: ease-out; }
-        background: root.current == root.tab_index ? Palette.themeSecondary : transparent;
+        background: root.current == root.tab-index ? Palette.themeSecondary : transparent;
         y: parent.height - height;
         x: (parent.width - width) / 2;
     }
@@ -422,13 +422,13 @@ export TabWidget := TabWidget {}
 
 export LineEdit := Rectangle {
     property <string> text <=> input.text;
-    property <string> placeholder_text;
-    property <bool> has_focus: input.has_focus;
+    property <string> placeholder-text;
+    property <bool> has-focus: input.has-focus;
     property <bool> enabled <=> input.enabled;
     callback accepted(string);
     callback edited(string);
     forward-focus: input;
-  //  border_color: root.has_focus ? Palette.highlight_background : #ffffff;
+  //  border-color: root.has-focus ? Palette.highlight-background : #ffffff;
 
     horizontal-stretch: 1;
     vertical-stretch: 0;
@@ -437,24 +437,24 @@ export LineEdit := Rectangle {
 
     background: !enabled ? Palette.neutralLighter : Palette.white;
     border-radius: 2px;
-    border-width: !enabled ? 0px : has_focus ? 3px : 1px;
+    border-width: !enabled ? 0px : has-focus ? 3px : 1px;
     border-color: !enabled ? Palette.neutralLighter
-        : has_focus ? Palette.themeSecondary
+        : has-focus ? Palette.themeSecondary
         : Palette.neutralPrimary;
 
     HorizontalLayout {
         padding-left: 8px;
         padding-right: 8px;
         input := TextInput {
-            vertical_alignment: center;
+            vertical-alignment: center;
             accepted => { root.accepted(self.text); }
             edited => { root.edited(self.text); }
             color: !enabled ? Palette.neutralTertiary : Palette.neutralPrimary;
             Text {
                 height: 100%; width: 100%;
-                vertical_alignment: center;
+                vertical-alignment: center;
                 color: !enabled ? Palette.neutralTertiary : Palette.neutralSecondary;
-                text: root.text == "" ? root.placeholder_text : "";
+                text: root.text == "" ? root.placeholder-text : "";
             }
         }
     }
@@ -462,49 +462,49 @@ export LineEdit := Rectangle {
 
 ScrollBar := Rectangle {
     background: white;
-   // border_color: Palette.button_background;
-    border_width: 1px;
+   // border-color: Palette.button-background;
+    border-width: 1px;
     property <bool> horizontal;
     property<length> max;
-    property<length> page_size;
+    property<length> page-size;
     // this is always negative and migger than  -max
     property<length> value;
 
     handle := Rectangle {
-        width: !horizontal ? parent.width : max <= 0phx ? 0phx : parent.width * (page_size / (max + page_size));
-        height: horizontal ? parent.height : max <= 0phx ? 0phx : parent.height * (page_size / (max + page_size));
+        width: !horizontal ? parent.width : max <= 0phx ? 0phx : parent.width * (page-size / (max + page-size));
+        height: horizontal ? parent.height : max <= 0phx ? 0phx : parent.height * (page-size / (max + page-size));
 
-        border_radius: (horizontal ? self.height : self.width) / 2;
-        background: touch_area.pressed ? Palette.themePrimary :
-            touch_area.has_hover ? Palette.themeSecondary : Palette.neutralTertiary;
-        x: !horizontal ? 0phx : (root.width - handle.width) * (new_value / max);
-        y: horizontal ? 0phx : (root.height - handle.height) * (new_value / max);
-        property<length> new_value_tmp : -root.value + (
-            !touch_area.pressed ? 0phx
-            : horizontal ?  (touch_area.mouse_x - touch_area.pressed_x) * (max / (root.width - handle.width))
-            : (touch_area.mouse_y - touch_area.pressed_y) * (max / (root.height - handle.height)));
-        property<length> new_value : new_value_tmp < 0phx ? 0phx
+        border-radius: (horizontal ? self.height : self.width) / 2;
+        background: touch-area.pressed ? Palette.themePrimary :
+            touch-area.has-hover ? Palette.themeSecondary : Palette.neutralTertiary;
+        x: !horizontal ? 0phx : (root.width - handle.width) * (new-value / max);
+        y: horizontal ? 0phx : (root.height - handle.height) * (new-value / max);
+        property<length> new-value-tmp : -root.value + (
+            !touch-area.pressed ? 0phx
+            : horizontal ?  (touch-area.mouse-x - touch-area.pressed-x) * (max / (root.width - handle.width))
+            : (touch-area.mouse-y - touch-area.pressed-y) * (max / (root.height - handle.height)));
+        property<length> new-value : new-value-tmp < 0phx ? 0phx
             : root.max < 0phx ? 0phx
-            : new_value_tmp > root.max ? root.max : new_value_tmp;
+            : new-value-tmp > root.max ? root.max : new-value-tmp;
     }
-    touch_area := TouchArea {
+    touch-area := TouchArea {
         width: parent.width;
         height: parent.height;
         clicked => {
-            root.value = -handle.new_value;
+            root.value = -handle.new-value;
         }
     }
 }
 
 export ScrollView := Rectangle {
-    property <length> viewport_width <=> fli.viewport_width;
-    property <length> viewport_height <=> fli.viewport_height;
-    property <length> viewport_x <=> fli.viewport_x;
-    property <length> viewport_y <=> fli.viewport_y;
-    property <length> visible_width <=> fli.width;
-    property <length> visible_height <=> fli.height;
-    min_height: 50px;
-    min_width: 50px;
+    property <length> viewport-width <=> fli.viewport-width;
+    property <length> viewport-height <=> fli.viewport-height;
+    property <length> viewport-x <=> fli.viewport-x;
+    property <length> viewport-y <=> fli.viewport-y;
+    property <length> visible-width <=> fli.width;
+    property <length> visible-height <=> fli.height;
+    min-height: 50px;
+    min-width: 50px;
     horizontal-stretch: 1;
     vertical-stretch: 1;
 
@@ -513,10 +513,10 @@ export ScrollView := Rectangle {
         x: 1px;
         y: 1px;
         interactive: false;
-        viewport_y <=> vbar.value;
-        viewport_x <=> hbar.value;
-        viewport_height: 1000px;
-        viewport_width: 1000px;
+        viewport-y <=> vbar.value;
+        viewport-x <=> hbar.value;
+        viewport-height: 1000px;
+        viewport-width: 1000px;
         width: parent.width - vbar.width - 1px;
         height: parent.height - hbar.height -1px;
     }
@@ -525,16 +525,16 @@ export ScrollView := Rectangle {
         x: fli.width + fli.x;
         height: fli.height + fli.y;
         horizontal: false;
-        max: fli.viewport_height - fli.height;
-        page_size: fli.height;
+        max: fli.viewport-height - fli.height;
+        page-size: fli.height;
     }
     hbar := ScrollBar {
         height: 16px;
         y: fli.height + fli.y;
         width: fli.width + fli.x;
         horizontal: true;
-        max: fli.viewport_width - fli.width;
-        page_size: fli.width;
+        max: fli.viewport-width - fli.width;
+        page-size: fli.width;
     }
 }
 
@@ -544,7 +544,7 @@ export ListView := ScrollView {
 
 export StandardListView := ListView {
     property<[StandardListViewItem]> model;
-    property<int> current_item: -1;
+    property<int> current-item: -1;
     for item[idx] in model : Rectangle {
         l := HorizontalLayout {
             padding: 8px;
@@ -554,31 +554,31 @@ export StandardListView := ListView {
                 color: Palette.neutralPrimary;
             }
         }
-        width: parent.visible_width;
-        background: idx == root.current_item ? Palette.neutralLighter
-                    : touch.has_hover ? Palette.neutralLighterAlt : transparent;
+        width: parent.visible-width;
+        background: idx == root.current-item ? Palette.neutralLighter
+                    : touch.has-hover ? Palette.neutralLighterAlt : transparent;
         touch := TouchArea {
             width: parent.width;
             height: parent.height;
-            clicked => { current_item = idx; }
+            clicked => { current-item = idx; }
         }
     }
 }
 
 export ComboBox := FocusScope {
     property <[string]> model;
-    property <int> current_index : -1;
-    property <string> current_value;
-    //property <bool> is_open: false;
+    property <int> current-index : -1;
+    property <string> current-value;
+    //property <bool> is-open: false;
     property<bool> enabled <=> touch.enabled;
     callback selected(string);
 
     Rectangle {
         background: !enabled ? Palette.neutralLighter : Palette.white;
         border-radius: 2px;
-        border-width: !enabled ? 0px : has_focus ? 3px : 1px;
+        border-width: !enabled ? 0px : has-focus ? 3px : 1px;
         border-color: !enabled ? Palette.neutralLighter
-            : has_focus ? Palette.themeSecondary
+            : has-focus ? Palette.themeSecondary
             : Palette.neutralPrimary;
     }
 
@@ -593,12 +593,12 @@ export ComboBox := FocusScope {
         padding-right: 8px;
         spacing: 8px;
         t := Text {
-            text <=> root.current_value;
+            text <=> root.current-value;
             horizontal-alignment: left;
             vertical-alignment: center;
             horizontal-stretch: 1;
             color: !enabled ? Palette.neutralTertiary
-                : root.has_focus || touch.has_hover ? Palette.neutralPrimary
+                : root.has-focus || touch.has-hover ? Palette.neutralPrimary
                 : Palette.neutralSecondary;
             min-width: 0;
         }
@@ -629,26 +629,26 @@ export ComboBox := FocusScope {
         Rectangle {
             border-color: Palette.neutralLighter;
             border-width: 1px;
-            /*drop_shadow_color: Palette.neutralTertiary;
-            drop_shadow_blur: 5px;*/
+            /*drop-shadow-color: Palette.neutralTertiary;
+            drop-shadow-blur: 5px;*/
             background: Palette.white;
         }
         VerticalLayout {
             for value[idx] in root.model: Rectangle {
-                background: idx == root.current_index ? Palette.neutralLighter
-                    : item_area.has_hover ? Palette.neutralLighterAlt : transparent;
+                background: idx == root.current-index ? Palette.neutralLighter
+                    : item-area.has-hover ? Palette.neutralLighterAlt : transparent;
                 VerticalLayout {
                     padding: 10px;
                     Text {
                         text: value;
-                        item_area := TouchArea {
+                        item-area := TouchArea {
                             width: 100%;
                             height: 100%;
                             clicked => {
                                 if (root.enabled) {
-                                    root.current_index = idx;
-                                    root.current_value = value;
-                                    root.selected(root.current_value);
+                                    root.current-index = idx;
+                                    root.current-value = value;
+                                    root.selected(root.current-value);
                                 }
                             }
                         }
@@ -660,15 +660,15 @@ export ComboBox := FocusScope {
 }
 
 export VerticalBox := VerticalLayout {
-    spacing: StyleMetrics.layout_spacing;
-    padding: StyleMetrics.layout_padding;
+    spacing: StyleMetrics.layout-spacing;
+    padding: StyleMetrics.layout-padding;
 }
 export HorizontalBox := HorizontalLayout {
-    spacing: StyleMetrics.layout_spacing;
-    padding: StyleMetrics.layout_padding;
+    spacing: StyleMetrics.layout-spacing;
+    padding: StyleMetrics.layout-padding;
 }
 export GridBox := GridLayout {
-    spacing: StyleMetrics.layout_spacing;
-    padding: StyleMetrics.layout_padding;
+    spacing: StyleMetrics.layout-spacing;
+    padding: StyleMetrics.layout-padding;
 }
 

--- a/sixtyfps_compiler/widgets/native/sixtyfps_widgets.60
+++ b/sixtyfps_compiler/widgets/native/sixtyfps_widgets.60
@@ -10,7 +10,7 @@ LICENSE END */
 
 export { NativeStyleMetrics as StyleMetrics }
 
-// FIXME: the font-size should be removed but is required right now to compile the printer_demo
+// FIXME: the font-size should be removed but is required right now to compile the printer-demo
 export Button := NativeButton {
     property<length> font-size;
     enabled: true;
@@ -20,26 +20,26 @@ export SpinBox := NativeSpinBox { property<length> font-size; }
 export Slider := NativeSlider { }
 export GroupBox := NativeGroupBox {
     GridLayout {
-        padding_left: root.native_padding_left;
-        padding_right: root.native_padding_right;
-        padding_top: root.native_padding_top;
-        padding_bottom: root.native_padding_bottom;
+        padding-left: root.native-padding-left;
+        padding-right: root.native-padding-right;
+        padding-top: root.native-padding-top;
+        padding-bottom: root.native-padding-bottom;
         @children
     }
  }
 export LineEdit := NativeLineEdit {
     property <string> text;
-    property <string> placeholder_text;
+    property <string> placeholder-text;
     enabled: true;
-    focused: input.has_focus;
+    focused: input.has-focus;
     forward-focus: input;
     callback accepted(string);
     callback edited(string);
     GridLayout {
-        padding_left: root.native_padding_left;
-        padding_right: root.native_padding_right;
-        padding_top: root.native_padding_top;
-        padding_bottom: root.native_padding_bottom;
+        padding-left: root.native-padding-left;
+        padding-right: root.native-padding-right;
+        padding-top: root.native-padding-top;
+        padding-bottom: root.native-padding-bottom;
         input := TextInput {
             text <=> root.text;
             enabled: root.enabled;
@@ -54,37 +54,37 @@ export LineEdit := NativeLineEdit {
             color: #ecedeb; // FIXME: use the palette
             col: 0;
             row: 0;
-            text: root.text == "" ? root.placeholder_text : "";
+            text: root.text == "" ? root.placeholder-text : "";
         }
     }
 }
 
 export ScrollView := NativeScrollView {
-    property <length> viewport_width <=> fli.viewport_width;
-    property <length> viewport_height <=> fli.viewport_height;
-    property <length> viewport_x <=> fli.viewport_x;
-    property <length> viewport_y <=> fli.viewport_y;
-    property <length> visible_width <=> fli.width;
-    property <length> visible_height <=> fli.height;
+    property <length> viewport-width <=> fli.viewport-width;
+    property <length> viewport-height <=> fli.viewport-height;
+    property <length> viewport-x <=> fli.viewport-x;
+    property <length> viewport-y <=> fli.viewport-y;
+    property <length> visible-width <=> fli.width;
+    property <length> visible-height <=> fli.height;
 
-    vertical_max: fli.viewport_height > fli.height ? fli.viewport_height - fli.height : 0phx;
-    vertical_page_size: fli.height;
+    vertical-max: fli.viewport-height > fli.height ? fli.viewport-height - fli.height : 0phx;
+    vertical-page-size: fli.height;
 
-    horizontal_max: fli.viewport_width > fli.width ? fli.viewport_width - fli.width : 0phx;
-    horizontal_page_size: fli.width;
+    horizontal-max: fli.viewport-width > fli.width ? fli.viewport-width - fli.width : 0phx;
+    horizontal-page-size: fli.width;
 
     fli := Flickable {
-        x: root.native_padding_left;
-        width: root.width - root.native_padding_left - root.native_padding_right;
-        y: root.native_padding_top;
-        height: root.height - root.native_padding_top - root.native_padding_bottom;
+        x: root.native-padding-left;
+        width: root.width - root.native-padding-left - root.native-padding-right;
+        y: root.native-padding-top;
+        height: root.height - root.native-padding-top - root.native-padding-bottom;
 
         @children
         interactive: false;
-        viewport_y <=> root.vertical_value;
-        viewport_x <=> root.horizontal_value;
-        viewport_height: 1000px;
-        viewport_width: 1000px;
+        viewport-y <=> root.vertical-value;
+        viewport-x <=> root.horizontal-value;
+        viewport-height: 1000px;
+        viewport-width: 1000px;
     }
 }
 
@@ -94,16 +94,16 @@ export ListView := ScrollView {
 
 export StandardListView := ListView {
     property<[StandardListViewItem]> model;
-    property<int> current_item: -1;
+    property<int> current-item: -1;
     for item[i] in model : NativeStandardListViewItem {
         item: item;
         index: i;
-        width: parent.visible_width;
-        is_selected: current_item == i;
+        width: parent.visible-width;
+        is-selected: current-item == i;
         TouchArea {
             width: parent.width;
             height: parent.height;
-            clicked => { current_item = i; }
+            clicked => { current-item = i; }
         }
     }
 }
@@ -111,9 +111,9 @@ export StandardListView := ListView {
 
 export ComboBox := NativeComboBox {
     property <[string]> model;
-    property <int> current_index : -1;
+    property <int> current-index : -1;
     enabled: true;
-    open_popup => { popup.show(); }
+    open-popup => { popup.show(); }
     callback selected(string);
 
     popup := PopupWindow {
@@ -129,17 +129,17 @@ export ComboBox := NativeComboBox {
             spacing: 0px;
             for value[i] in root.model: NativeStandardListViewItem {
                 item: { text: value };
-                is_selected: current_index == i;
+                is-selected: current-index == i;
                 VerticalLayout {  // FIXME: ideally this layout shouldn't be required
                     TouchArea {
                         height: 25px;
                         clicked => {
                             if (root.enabled) {
-                                current_index = i;
-                                current_value = value;
-                                selected(current_value);
+                                current-index = i;
+                                current-value = value;
+                                selected(current-value);
                             }
-                            //is_open = false;
+                            //is-open = false;
                         }
                     }
                 }
@@ -149,7 +149,7 @@ export ComboBox := NativeComboBox {
 }
 
 export TabWidgetImpl := NativeTabWidget {
-    property <int> current_index;
+    property <int> current-index;
 }
 export TabImpl := NativeTab {}
 export TabBarImpl := HorizontalLayout {
@@ -158,15 +158,15 @@ export TabBarImpl := HorizontalLayout {
 export TabWidget := TabWidget {}
 
 export VerticalBox := VerticalLayout {
-    spacing: NativeStyleMetrics.layout_spacing;
-    padding: NativeStyleMetrics.layout_spacing;
+    spacing: NativeStyleMetrics.layout-spacing;
+    padding: NativeStyleMetrics.layout-spacing;
 }
 export HorizontalBox := HorizontalLayout {
-    spacing: NativeStyleMetrics.layout_spacing;
-    padding: NativeStyleMetrics.layout_spacing;
+    spacing: NativeStyleMetrics.layout-spacing;
+    padding: NativeStyleMetrics.layout-spacing;
 }
 export GridBox := GridLayout {
-    spacing: NativeStyleMetrics.layout_spacing;
-    padding: NativeStyleMetrics.layout_spacing;
+    spacing: NativeStyleMetrics.layout-spacing;
+    padding: NativeStyleMetrics.layout-spacing;
 }
 

--- a/sixtyfps_compiler/widgets/ugly/sixtyfps_widgets.60
+++ b/sixtyfps_compiler/widgets/ugly/sixtyfps_widgets.60
@@ -9,51 +9,51 @@
 LICENSE END */
 
 global Palette := {
-    property<color> window_background: #ecedeb;
-    property<color> text_color: #090909;
-    property<color> text_color_disabled: lightgray;
-    property<color> text_color_secondary: #111;
-    property<color> button_background: #aaa;
-    property<color> button_background_disabled: #aaa;
-    property<color> button_hover: #8c8c8c;
-    property<color> button_pressed: #575757;
-    property<color> highlight_background: #2b60ae;
-    property<color> placeholder_text: #ccc;
-    property<color> border_color: #d0d3cf;
-    property<color> base_background_color: white;
-    property<color> checkbox_unchecked_indicator: #aaa;
+    property<color> window-background: #ecedeb;
+    property<color> text-color: #090909;
+    property<color> text-color-disabled: lightgray;
+    property<color> text-color-secondary: #111;
+    property<color> button-background: #aaa;
+    property<color> button-background-disabled: #aaa;
+    property<color> button-hover: #8c8c8c;
+    property<color> button-pressed: #575757;
+    property<color> highlight-background: #2b60ae;
+    property<color> placeholder-text: #ccc;
+    property<color> border-color: #d0d3cf;
+    property<color> base-background-color: white;
+    property<color> checkbox-unchecked-indicator: #aaa;
 }
 
 export global StyleMetrics := {
-    property<length> layout_spacing: 5px;
-    property<length> layout_padding: 5px;
-    property<length> text_cursor_width: 2px;
-    property<color> window_background: #ecedeb; //FIXME: Palette.window_background  does not compile (cannot access globals from other globals #175)
+    property<length> layout-spacing: 5px;
+    property<length> layout-padding: 5px;
+    property<length> text-cursor-width: 2px;
+    property<color> window-background: #ecedeb; //FIXME: Palette.window-background  does not compile (cannot access globals from other globals #175)
 }
 
 export Button := Rectangle {
     callback clicked;
     property<string> text;
     property<length> font-size;
-    property<bool> pressed: self.enabled && touch_area.pressed;
-    property<bool> enabled <=> touch_area.enabled;
+    property<bool> pressed: self.enabled && touch-area.pressed;
+    property<bool> enabled <=> touch-area.enabled;
     property<image> icon;
 
-    border_width: 1px;
-    border_radius: 2px;
-    border_color: Palette.text_color;
-    background: !self.enabled ? Palette.button_background_disabled: self.pressed ? Palette.button_pressed : (touch_area.has_hover ? Palette.button_hover : Palette.button_background);
+    border-width: 1px;
+    border-radius: 2px;
+    border-color: Palette.text-color;
+    background: !self.enabled ? Palette.button-background-disabled: self.pressed ? Palette.button-pressed : (touch-area.has-hover ? Palette.button-hover : Palette.button-background);
     animate background { duration: 100ms; }
     horizontal-stretch: 0;
     vertical-stretch: 0;
 
 
     HorizontalLayout {
-        padding-top: root.border_radius + 8px;
-        padding-bottom: root.border_radius + 8px;
-        padding-left: root.border_radius + 16px;
-        padding-right: root.border_radius + 16px;
-        spacing: StyleMetrics.layout_spacing;
+        padding-top: root.border-radius + 8px;
+        padding-bottom: root.border-radius + 8px;
+        padding-left: root.border-radius + 16px;
+        padding-right: root.border-radius + 16px;
+        spacing: StyleMetrics.layout-spacing;
 
         if (icon.width > 0 && icon.height > 0): Image {
             source <=> icon;
@@ -68,11 +68,11 @@ export Button := Rectangle {
             font-size: root.font-size;
             horizontal-alignment: center;
             vertical-alignment: center;
-            color: root.enabled ? Palette.text_color : Palette.text_color_disabled;
+            color: root.enabled ? Palette.text-color : Palette.text-color-disabled;
         }
     }
 
-    touch_area := TouchArea {
+    touch-area := TouchArea {
         width: root.width;
         height: root.height;
         clicked => {
@@ -85,7 +85,7 @@ export CheckBox := Rectangle {
     callback toggled;
     property <string> text;
     property <bool> checked;
-    property<bool> enabled <=> touch_area.enabled;
+    property<bool> enabled <=> touch-area.enabled;
     height: 20px;
     horizontal-stretch: 0;
     vertical-stretch: 0;
@@ -95,34 +95,34 @@ export CheckBox := Rectangle {
         // the check box iteself
         indicator := Rectangle {
             width: 40px;
-            border_width: 1px;
-            border_radius: root.height / 2;
-            border_color: root.enabled ? (root.checked ? Palette.highlight_background : black) : Palette.text_color_disabled;
-            background: root.checked ? (root.enabled ? Palette.highlight_background : Palette.text_color_disabled) : white;
+            border-width: 1px;
+            border-radius: root.height / 2;
+            border-color: root.enabled ? (root.checked ? Palette.highlight-background : black) : Palette.text-color-disabled;
+            background: root.checked ? (root.enabled ? Palette.highlight-background : Palette.text-color-disabled) : white;
             animate background { duration: 100ms; }
 
             bubble := Rectangle {
                 width: root.height - 8px;
                 height: bubble.width;
-                border_radius: bubble.height / 2;
+                border-radius: bubble.height / 2;
                 y: 4px;
                 x: 4px + a * (indicator.width - bubble.width - 8px);
                 property <float> a: root.checked ? 1 : 0;
-                background: root.checked ? white : (root.enabled ? Palette.button_background : Palette.text_color_disabled);
+                background: root.checked ? white : (root.enabled ? Palette.button-background : Palette.text-color-disabled);
                 animate a, background { duration: 200ms; easing: ease;}
             }
         }
 
         Text {
-            min_width: max(100px, preferred_width);
+            min-width: max(100px, preferred-width);
             text: root.text;
             vertical-alignment: center;
-            color: root.enabled ? Palette.text_color : Palette.text_color_disabled;
+            color: root.enabled ? Palette.text-color : Palette.text-color-disabled;
         }
 
     }
 
-    touch_area := TouchArea {
+    touch-area := TouchArea {
         width: root.width;
         height: root.height;
         clicked => {
@@ -140,10 +140,10 @@ SpinBoxButton := Rectangle {
     property<string> text;
     property <length> font-size;
     property<bool> enabled <=> touch.enabled;
-    border_width: 1px;
-    border_radius: 2px;
-    border_color: black;
-    background: !enabled ? Palette.button_background_disabled : touch.pressed ? Palette.button_pressed : (touch.has_hover ? Palette.button_hover : Palette.button_background);
+    border-width: 1px;
+    border-radius: 2px;
+    border-color: black;
+    background: !enabled ? Palette.button-background-disabled : touch.pressed ? Palette.button-pressed : (touch.has-hover ? Palette.button-hover : Palette.button-background);
     animate background { duration: 100ms; }
     touch := TouchArea {
         clicked => {
@@ -159,7 +159,7 @@ SpinBoxButton := Rectangle {
         horizontal-alignment: center;
         text: root.text;
         font-size: root.font-size;
-        color: root.enabled ? Palette.text_color : Palette.text_color_disabled;
+        color: root.enabled ? Palette.text-color : Palette.text-color-disabled;
     }
 }
 
@@ -175,9 +175,9 @@ export SpinBox := Rectangle {
 
     background: white;
 
-    max_height: 32px;
-    min_height: 32px;
-    min_width: 120px;
+    max-height: 32px;
+    min-height: 32px;
+    min-width: 120px;
     horizontal-stretch: 1;
     vertical-stretch: 0;
 
@@ -194,7 +194,7 @@ export SpinBox := Rectangle {
         enabled <=> root.enabled;
     }
 
-    plus_button := SpinBoxButton {
+    plus-button := SpinBoxButton {
         width: parent.height;
         height: parent.height;
         enabled <=> root.enabled;
@@ -212,11 +212,11 @@ export SpinBox := Rectangle {
         text: root.value;
         font-size: root.font-size;
         x: parent.height + 15px;
-        width: plus_button.x - self.x - 15px;
+        width: plus-button.x - self.x - 15px;
         height: parent.height;
         horizontal-alignment: center;
         vertical-alignment: center;
-        color: root.enabled ? Palette.text_color : Palette.text_color_disabled;
+        color: root.enabled ? Palette.text-color : Palette.text-color-disabled;
     }
 }
 
@@ -224,57 +224,57 @@ export Slider := Rectangle {
     property<float> maximum: 100;
     property<float> minimum: 0;
     property<float> value;
-    property<bool> enabled <=> touch_area.enabled;
+    property<bool> enabled <=> touch-area.enabled;
     callback changed(float);
 
-    max_height: 32px;
-    min_height: 32px;
-    min_width: 120px;
+    max-height: 32px;
+    min-height: 32px;
+    min-width: 120px;
     horizontal-stretch: 1;
     vertical-stretch: 0;
 
-    slider_filled := Rectangle {
+    slider-filled := Rectangle {
         width: parent.width;
         y: parent.height / 3;
         height: parent.height / 3;
-        border_width: 1px;
-        border_radius: 2px;
-        border_color: black;
-        background: root.enabled ? Palette.highlight_background : Palette.text_color_disabled;
+        border-width: 1px;
+        border-radius: 2px;
+        border-color: black;
+        background: root.enabled ? Palette.highlight-background : Palette.text-color-disabled;
     }
 
-    slider_empty := Rectangle {
-        y: slider_filled.y;
+    slider-empty := Rectangle {
+        y: slider-filled.y;
         x: handle.x;
         width: parent.width - self.x;
-        height: slider_filled.height;
-        border_width: slider_filled.border_width;
-        border_radius: slider_filled.border_radius;
-        border_color: slider_filled.border_color;
-        background: root.enabled ? Palette.button_background : white;
+        height: slider-filled.height;
+        border-width: slider-filled.border-width;
+        border-radius: slider-filled.border-radius;
+        border-color: slider-filled.border-color;
+        background: root.enabled ? Palette.button-background : white;
     }
 
     handle := Rectangle {
         width: parent.height / 3;
         height: parent.height;
-        border_width: 1px;
-        border_radius: 3px;
-        border_color: black;
-        background: (touch_area.pressed && enabled) ? Palette.button_pressed : white;
+        border-width: 1px;
+        border-radius: 3px;
+        border-color: black;
+        background: (touch-area.pressed && enabled) ? Palette.button-pressed : white;
         animate background { duration: 100ms; }
-        x: (root.width - handle.width) * (new_value - minimum)/(maximum - minimum);
-        property<float> new_value_tmp : (touch_area.pressed && enabled)
-            ? root.value + (touch_area.mouse_x - touch_area.pressed_x) * (maximum - minimum) / (root.width - handle.width)
+        x: (root.width - handle.width) * (new-value - minimum)/(maximum - minimum);
+        property<float> new-value-tmp : (touch-area.pressed && enabled)
+            ? root.value + (touch-area.mouse-x - touch-area.pressed-x) * (maximum - minimum) / (root.width - handle.width)
             : root.value;
-        property<float> new_value : new_value_tmp < root.minimum ? root.minimum
-            : new_value_tmp > root.maximum ? root.maximum : new_value_tmp;
+        property<float> new-value : new-value-tmp < root.minimum ? root.minimum
+            : new-value-tmp > root.maximum ? root.maximum : new-value-tmp;
     }
-    touch_area := TouchArea {
+    touch-area := TouchArea {
         width: parent.width;
         height: parent.height;
         clicked => {
             if (enabled) {
-                root.value = handle.new_value;
+                root.value = handle.new-value;
                 root.changed(root.value);
             }
         }
@@ -290,14 +290,14 @@ export GroupBox := GridLayout {
         Text {
             text: root.title;
             vertical-stretch: 0;
-            color: root.enabled ? Palette.text_color : Palette.text_color_disabled;
+            color: root.enabled ? Palette.text-color : Palette.text-color-disabled;
         }
     }
     Row {
         Rectangle {
-            border_width: 1px;
-            border_color: Palette.border_color;
-            border_radius: 2px;
+            border-width: 1px;
+            border-color: Palette.border-color;
+            border-radius: 2px;
             background: white;
 
             GridLayout {
@@ -309,29 +309,29 @@ export GroupBox := GridLayout {
 }
 
 export TabWidgetImpl := Rectangle {
-    property <length> content_x: 0;
-    property <length> content_y: tabbar_preferred_height;
-    property <length> content_height: height - tabbar_preferred_height;
-    property <length> content_width: width;
-    property <length> tabbar_x: 0;
-    property <length> tabbar_y: 0;
-    property <length> tabbar_height: tabbar_preferred_height;
-    property <length> tabbar_width: width;
+    property <length> content-x: 0;
+    property <length> content-y: tabbar-preferred-height;
+    property <length> content-height: height - tabbar-preferred-height;
+    property <length> content-width: width;
+    property <length> tabbar-x: 0;
+    property <length> tabbar-y: 0;
+    property <length> tabbar-height: tabbar-preferred-height;
+    property <length> tabbar-width: width;
 
-    property <length> tabbar_preferred_height;
-    property <length> tabbar_preferred_width;
-    property <length> content_min_height;
-    property <length> content_min_width;
-    property <int> current_index;
+    property <length> tabbar-preferred-height;
+    property <length> tabbar-preferred-width;
+    property <length> content-min-height;
+    property <length> content-min-width;
+    property <int> current-index;
 
-    border_width: 1px;
-    border_color: Palette.border_color;
-    border_radius: 2px;
+    border-width: 1px;
+    border-color: Palette.border-color;
+    border-radius: 2px;
 
-    preferred_width: content_min_width;
-    min_width: content_min_width;
-    preferred_height: content_min_height + tabbar_preferred_height;
-    min_height: content_min_height + tabbar_preferred_height;
+    preferred-width: content-min-width;
+    min-width: content-min-width;
+    preferred-height: content-min-height + tabbar-preferred-height;
+    min-height: content-min-height + tabbar-preferred-height;
 
 }
 export TabImpl := Rectangle {
@@ -340,29 +340,29 @@ export TabImpl := Rectangle {
     property<bool> enabled : true;
     property<bool> pressed;
     property<int> current;
-    property<int> tab_index;
-    property<int> num_tabs;
-    preferred_height: t.preferred_height + 8px;
-    preferred_width: t.preferred_width + 12px;
+    property<int> tab-index;
+    property<int> num-tabs;
+    preferred-height: t.preferred-height + 8px;
+    preferred-width: t.preferred-width + 12px;
 
-    border_width: 1px;
-    border_radius: 2px;
-    border_color: black;
-    background: !enabled ? Palette.button_background_disabled : (touch.pressed || current == tab_index) ? Palette.button_pressed : (touch.has_hover ? Palette.button_hover : Palette.button_background);
+    border-width: 1px;
+    border-radius: 2px;
+    border-color: black;
+    background: !enabled ? Palette.button-background-disabled : (touch.pressed || current == tab-index) ? Palette.button-pressed : (touch.has-hover ? Palette.button-hover : Palette.button-background);
     animate background { duration: 100ms; }
     touch := TouchArea {
         clicked => {
-            current = tab_index;
+            current = tab-index;
         }
     }
     t:= Text {
-        x: enabled && (touch.pressed || current == tab_index) ? 1px : 0px;
-        y: enabled && (touch.pressed || current == tab_index) ? 1px : 0px;
+        x: enabled && (touch.pressed || current == tab-index) ? 1px : 0px;
+        y: enabled && (touch.pressed || current == tab-index) ? 1px : 0px;
         width: parent.width;
         height: parent.height;
         vertical-alignment: center;
         horizontal-alignment: center;
-        color: root.enabled ? Palette.text_color : Palette.text_color_disabled;
+        color: root.enabled ? Palette.text-color : Palette.text-color-disabled;
     }
 }
 
@@ -374,16 +374,16 @@ export TabBarImpl := HorizontalLayout {
 
 export LineEdit := Rectangle {
     property <string> text;
-    property <string> placeholder_text;
-    property <bool> has_focus: input.has_focus;
+    property <string> placeholder-text;
+    property <bool> has-focus: input.has-focus;
     property <bool> enabled <=> input.enabled;
     callback accepted(string);
     callback edited(string);
     forward-focus: input;
 
-    border_color: root.has_focus ? Palette.highlight_background : #ffffff;
-    border_radius: 1px;
-    border_width: 2px;
+    border-color: root.has-focus ? Palette.highlight-background : #ffffff;
+    border-radius: 1px;
+    border-width: 2px;
     horizontal-stretch: 1;
     vertical-stretch: 0;
 
@@ -391,9 +391,9 @@ export LineEdit := Rectangle {
         padding: 3px;
 
         Rectangle {
-            border_color: #ecedeb;
-            border_radius: 1px;
-            border_width: 1px;
+            border-color: #ecedeb;
+            border-radius: 1px;
+            border-width: 1px;
             background: white;
 
             GridLayout {
@@ -406,13 +406,13 @@ export LineEdit := Rectangle {
                     edited => {
                         root.edited(self.text);
                     }
-                    color: enabled ? Palette.text_color : Palette.text_color_disabled;
+                    color: enabled ? Palette.text-color : Palette.text-color-disabled;
                 }
                 Text {
-                    color: Palette.placeholder_text;
+                    color: Palette.placeholder-text;
                     col: 0;
                     row: 0;
-                    text: (root.text == "" && !input.has-focus) ? root.placeholder_text : "";
+                    text: (root.text == "" && !input.has-focus) ? root.placeholder-text : "";
                 }
             }
         }
@@ -422,53 +422,53 @@ export LineEdit := Rectangle {
 
 ScrollBar := Rectangle {
     background: white;
-    border_color: Palette.button_background;
-    border_width: 1px;
+    border-color: Palette.button-background;
+    border-width: 1px;
     property <bool> horizontal;
     property<length> max;
-    property<length> page_size;
+    property<length> page-size;
     // this is always negative and migger than  -max
     property<length> value;
 
     handle := Rectangle {
-        width: !horizontal ? parent.width : max <= 0phx ? 0phx : parent.width * (page_size / (max + page_size));
-        height: horizontal ? parent.height : max <= 0phx ? 0phx : parent.height * (page_size / (max + page_size));
+        width: !horizontal ? parent.width : max <= 0phx ? 0phx : parent.width * (page-size / (max + page-size));
+        height: horizontal ? parent.height : max <= 0phx ? 0phx : parent.height * (page-size / (max + page-size));
 
-        border_radius: (horizontal ? self.height : self.width) / 2;
-        background: touch_area.pressed ? Palette.button_pressed : (touch_area.has_hover ? Palette.button_hover : Palette.button_background);
+        border-radius: (horizontal ? self.height : self.width) / 2;
+        background: touch-area.pressed ? Palette.button-pressed : (touch-area.has-hover ? Palette.button-hover : Palette.button-background);
         animate background { duration: 100ms; }
-        x: !horizontal ? 0phx : (root.width - handle.width) * (new_value / max);
-        y: horizontal ? 0phx : (root.height - handle.height) * (new_value / max);
-        property<length> new_value_tmp : -root.value + (
-            !touch_area.pressed ? 0phx
-            : horizontal ?  (touch_area.mouse_x - touch_area.pressed_x) * (max / (root.width - handle.width))
-            : (touch_area.mouse_y - touch_area.pressed_y) * (max / (root.height - handle.height)));
-        property<length> new_value : new_value_tmp < 0phx ? 0phx
+        x: !horizontal ? 0phx : (root.width - handle.width) * (new-value / max);
+        y: horizontal ? 0phx : (root.height - handle.height) * (new-value / max);
+        property<length> new-value-tmp : -root.value + (
+            !touch-area.pressed ? 0phx
+            : horizontal ?  (touch-area.mouse-x - touch-area.pressed-x) * (max / (root.width - handle.width))
+            : (touch-area.mouse-y - touch-area.pressed-y) * (max / (root.height - handle.height)));
+        property<length> new-value : new-value-tmp < 0phx ? 0phx
             : root.max < 0phx ? 0phx
-            : new_value_tmp > root.max ? root.max : new_value_tmp;
+            : new-value-tmp > root.max ? root.max : new-value-tmp;
     }
-    touch_area := TouchArea {
+    touch-area := TouchArea {
         width: parent.width;
         height: parent.height;
         clicked => {
-            root.value = -handle.new_value;
+            root.value = -handle.new-value;
         }
     }
 
 }
 
 export ScrollView := Rectangle {
-    property <length> viewport_width <=> fli.viewport_width;
-    property <length> viewport_height <=> fli.viewport_height;
-    property <length> viewport_x <=> fli.viewport_x;
-    property <length> viewport_y <=> fli.viewport_y;
-    property <length> visible_width <=> fli.width;
-    property <length> visible_height <=> fli.height;
-    min_height: 50px;
-    min_width: 50px;
-    border_width: 1px;
-    border_color: Palette.border_color;
-    background: Palette.base_background_color;
+    property <length> viewport-width <=> fli.viewport-width;
+    property <length> viewport-height <=> fli.viewport-height;
+    property <length> viewport-x <=> fli.viewport-x;
+    property <length> viewport-y <=> fli.viewport-y;
+    property <length> visible-width <=> fli.width;
+    property <length> visible-height <=> fli.height;
+    min-height: 50px;
+    min-width: 50px;
+    border-width: 1px;
+    border-color: Palette.border-color;
+    background: Palette.base-background-color;
     horizontal-stretch: 1;
     vertical-stretch: 1;
 
@@ -477,10 +477,10 @@ export ScrollView := Rectangle {
         x: 1px;
         y: 1px;
         interactive: false;
-        viewport_y <=> vbar.value;
-        viewport_x <=> hbar.value;
-        viewport_height: 1000px;
-        viewport_width: 1000px;
+        viewport-y <=> vbar.value;
+        viewport-x <=> hbar.value;
+        viewport-height: 1000px;
+        viewport-width: 1000px;
         width: parent.width - vbar.width - 1px;
         height: parent.height - hbar.height -1px;
     }
@@ -489,16 +489,16 @@ export ScrollView := Rectangle {
         x: fli.width + fli.x;
         height: fli.height + fli.y;
         horizontal: false;
-        max: fli.viewport_height - fli.height;
-        page_size: fli.height;
+        max: fli.viewport-height - fli.height;
+        page-size: fli.height;
     }
     hbar := ScrollBar {
         height: 16px;
         y: fli.height + fli.y;
         width: fli.width + fli.x;
         horizontal: true;
-        max: fli.viewport_width - fli.width;
-        page_size: fli.width;
+        max: fli.viewport-width - fli.width;
+        page-size: fli.width;
     }
 }
 
@@ -508,69 +508,69 @@ export ListView := ScrollView {
 
 export StandardListView := ListView {
     property<[StandardListViewItem]> model;
-    property<int> current_item: -1;
+    property<int> current-item: -1;
     for item[idx] in model : Rectangle {
         l := HorizontalLayout {
             padding: 0px;
             spacing: 0px;
             t := Text {
                 text: item.text;
-                color: Palette.text_color;
+                color: Palette.text-color;
             }
         }
-        width: parent.visible_width;
-        background: current_item == idx ? Palette.highlight_background : transparent;
+        width: parent.visible-width;
+        background: current-item == idx ? Palette.highlight-background : transparent;
         TouchArea {
             width: parent.width;
             height: parent.height;
-            clicked => { current_item = idx; }
+            clicked => { current-item = idx; }
         }
     }
 }
 
 export ComboBox := Rectangle {
     property <[string]> model;
-    property <int> current_index : -1;
-    property <string> current_value;
-    //property <bool> is_open: false;
-    property<bool> enabled <=> touch_area.enabled;
+    property <int> current-index : -1;
+    property <string> current-value;
+    //property <bool> is-open: false;
+    property<bool> enabled <=> touch-area.enabled;
     callback selected(string);
 
-    border_width: 1px;
-    border_radius: 2px;
-    border_color: Palette.text_color;
-    background: !enabled ? Palette.button_background_disabled : touch_area.pressed ? Palette.button_pressed : (touch_area.has_hover ? Palette.button_hover : Palette.button_background);
+    border-width: 1px;
+    border-radius: 2px;
+    border-color: Palette.text-color;
+    background: !enabled ? Palette.button-background-disabled : touch-area.pressed ? Palette.button-pressed : (touch-area.has-hover ? Palette.button-hover : Palette.button-background);
     animate background { duration: 100ms; }
     horizontal-stretch: 0;
     vertical-stretch: 0;
-    min_width: 170px;
+    min-width: 170px;
 
     HorizontalLayout {
-        padding-top: root.border_radius + 8px;
-        padding-bottom: root.border_radius + 8px;
-        padding-left: root.border_radius + 8px;
-        padding-right: root.border_radius + 8px;
+        padding-top: root.border-radius + 8px;
+        padding-bottom: root.border-radius + 8px;
+        padding-left: root.border-radius + 8px;
+        padding-right: root.border-radius + 8px;
 
         t := Text {
-            text <=> root.current_value;
+            text <=> root.current-value;
             horizontal-alignment: left;
             vertical-alignment: center;
-            color: root.enabled ? Palette.text_color : Palette.text_color_disabled;
+            color: root.enabled ? Palette.text-color : Palette.text-color-disabled;
             horizontal-stretch: 1;
         }
         Text {
             text:"▼";
-            color: root.enabled ? Palette.text_color : Palette.text_color_disabled;
+            color: root.enabled ? Palette.text-color : Palette.text-color-disabled;
             horizontal-stretch: 0;
             vertical-alignment: center;
         }
     }
 
-    touch_area := TouchArea {
+    touch-area := TouchArea {
         width: 100%;
         height: 100%;
         clicked => {
-            //is_open = !is_open;
+            //is-open = !is-open;
             popup.show();
         }
     }
@@ -581,20 +581,20 @@ export ComboBox := Rectangle {
         VerticalLayout {
             spacing: 0px;
             for value[idx] in root.model: Rectangle {
-                background: item_area.has_hover ? Palette.highlight_background : Palette.base_background_color;
+                background: item-area.has-hover ? Palette.highlight-background : Palette.base-background-color;
                 VerticalLayout { // FIXME: ideally this layout shouldn't be required
                     Text {
                         text: value;
-                        item_area := TouchArea {
+                        item-area := TouchArea {
                             width: 100%;
                             height: 100%;
                             clicked => {
                                 if (root.enabled) {
-                                    root.current_index = idx;
-                                    root.current_value = value;
-                                    root.selected(root.current_value);
+                                    root.current-index = idx;
+                                    root.current-value = value;
+                                    root.selected(root.current-value);
                                 }
-                                //is_open = false;
+                                //is-open = false;
                             }
                         }
                     }
@@ -605,14 +605,14 @@ export ComboBox := Rectangle {
 }
 
 export VerticalBox := VerticalLayout {
-    spacing: StyleMetrics.layout_spacing;
-    padding: StyleMetrics.layout_spacing;
+    spacing: StyleMetrics.layout-spacing;
+    padding: StyleMetrics.layout-spacing;
 }
 export HorizontalBox := HorizontalLayout {
-    spacing: StyleMetrics.layout_spacing;
-    padding: StyleMetrics.layout_spacing;
+    spacing: StyleMetrics.layout-spacing;
+    padding: StyleMetrics.layout-spacing;
 }
 export GridBox := GridLayout {
-    spacing: StyleMetrics.layout_spacing;
-    padding: StyleMetrics.layout_spacing;
+    spacing: StyleMetrics.layout-spacing;
+    padding: StyleMetrics.layout-spacing;
 }

--- a/sixtyfps_runtime/interpreter/api.rs
+++ b/sixtyfps_runtime/interpreter/api.rs
@@ -978,7 +978,7 @@ fn component_definition_properties2() {
     let props = comp_def.properties().collect::<Vec<(_, _)>>();
 
     assert_eq!(props.len(), 1);
-    assert_eq!(props[0].0, "sub_text");
+    assert_eq!(props[0].0, "sub-text");
     assert_eq!(props[0].1, ValueType::String);
 
     let callbacks = comp_def.callbacks().collect::<Vec<_>>();

--- a/sixtyfps_runtime/interpreter/api.rs
+++ b/sixtyfps_runtime/interpreter/api.rs
@@ -356,7 +356,7 @@ impl TryInto<sixtyfps_corelib::Color> for Value {
 }
 
 /// Normalize the identifier to use dashes
-fn normalize_identifier(ident: &str) -> Cow<'_, str> {
+pub(crate) fn normalize_identifier(ident: &str) -> Cow<'_, str> {
     if ident.contains('_') {
         ident.replace('_', "-").into()
     } else {

--- a/sixtyfps_runtime/interpreter/ffi.rs
+++ b/sixtyfps_runtime/interpreter/ffi.rs
@@ -316,7 +316,10 @@ pub unsafe extern "C" fn sixtyfps_interpreter_component_instance_get_property(
 ) -> bool {
     generativity::make_guard!(guard);
     let comp = inst.unerase(guard);
-    match comp.description().get_property(comp.borrow(), std::str::from_utf8(&name).unwrap()) {
+    match comp
+        .description()
+        .get_property(comp.borrow(), &normalize_identifier(std::str::from_utf8(&name).unwrap()))
+    {
         Ok(val) => {
             std::ptr::write(out as *mut Value, val);
             true
@@ -334,7 +337,11 @@ pub extern "C" fn sixtyfps_interpreter_component_instance_set_property(
     generativity::make_guard!(guard);
     let comp = inst.unerase(guard);
     comp.description()
-        .set_property(comp.borrow(), std::str::from_utf8(&name).unwrap(), val.as_value().clone())
+        .set_property(
+            comp.borrow(),
+            &normalize_identifier(std::str::from_utf8(&name).unwrap()),
+            val.as_value().clone(),
+        )
         .is_ok()
 }
 
@@ -353,7 +360,7 @@ pub unsafe extern "C" fn sixtyfps_interpreter_component_instance_invoke_callback
     let comp = inst.unerase(guard);
     match comp.description().invoke_callback(
         comp.borrow(),
-        std::str::from_utf8(&name).unwrap(),
+        &normalize_identifier(std::str::from_utf8(&name).unwrap()),
         args.as_slice(),
     ) {
         Ok(val) => {
@@ -400,7 +407,7 @@ pub unsafe extern "C" fn sixtyfps_interpreter_component_instance_set_callback(
     comp.description()
         .set_callback_handler(
             comp.borrow(),
-            std::str::from_utf8(&name).unwrap(),
+            &normalize_identifier(std::str::from_utf8(&name).unwrap()),
             Box::new(callback),
         )
         .is_ok()

--- a/tests/cases/callbacks/handler_with_arg.60
+++ b/tests/cases/callbacks/handler_with_arg.60
@@ -85,7 +85,7 @@ try {
     instance.test_callback();
     assert(false);
 } catch(e) {
-    assert.equal(e.toString(), "Error: test_callback expect 1 arguments, but 0 where provided");
+    assert.equal(e.toString(), "Error: test-callback expect 1 arguments, but 0 where provided");
 }
 assert.equal(instance.callback_emission_count, 0);
 

--- a/tests/cases/types/structs.60
+++ b/tests/cases/types/structs.60
@@ -66,6 +66,7 @@ let super_player = { name: "Super Player", score: 99, energy_level: 0.4 };
 instance.player_2 = super_player;
 assert.equal(instance.player_2.name, "Super Player");
 assert.equal(instance.player_2_score, 99);
+assert.equal(instance.player_2.energy_level, 0.4);
 ```
 
 */

--- a/tools/syntax_updater/main.rs
+++ b/tools/syntax_updater/main.rs
@@ -242,5 +242,12 @@ fn fold_token(
             return write!(file, "{}ms", node.text());
         }
     }*/
+    /* Example: replace _ by - in identifiers
+    if node.kind() == SyntaxKind::Identifier
+        && node.text().contains('_')
+        && !node.text().starts_with("_")
+    {
+        return file.write_all(node.text().replace('_', "-").as_bytes())
+    }*/
     file.write_all(node.text().as_bytes())
 }


### PR DESCRIPTION
As a result
 - The error messages will now show the error with `-` instead of `_`
 - The LSP will auto-complete with -
 - The interpreter's list of properties will list the property with '-'
   (but we made the change so that set_property, get_property, and so on
   work also if passed a '-')