### PR TITLE
Fix links to rgb crate in the sixtyfps.io hosted online docs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -307,7 +307,7 @@ jobs:
       # allow deprecated warning because we are using nightly and some things might be deprecated in nightly
       # for which the stable alternative is not yet available
       RUSTFLAGS: -D warnings -W deprecated
-      RUSTDOCFLAGS: --html-in-header=/home/runner/work/sixtyfps/sixtyfps/docs/resources/sixtyfps-docs-preview.html --html-in-header=/home/runner/work/sixtyfps/sixtyfps/docs/resources/sixtyfps-docs-highlight.html -D warnings -W deprecated
+      RUSTDOCFLAGS: --html-in-header=/home/runner/work/sixtyfps/sixtyfps/docs/resources/sixtyfps-docs-preview.html --html-in-header=/home/runner/work/sixtyfps/sixtyfps/docs/resources/sixtyfps-docs-highlight.html -D warnings -W deprecated --extern-html-root-url rgb=https://docs.rs/rgb/0.8.27/ -Z unstable-options
       SIXTYFPS_NO_QT: 1
       CARGO_INCREMENTAL: false
       MDBOOK_VERSION: 0.4.10

--- a/sixtyfps_runtime/corelib/Cargo.toml
+++ b/sixtyfps_runtime/corelib/Cargo.toml
@@ -41,6 +41,7 @@ weak-table =  "0.3"
 scopeguard = "1.1.0"
 cfg-if = "1"
 unicode-segmentation = "1.8.0"
+# Note: When bumping this, make sure to adjust the rgb base url in ci.yaml for the nightly docs build
 rgb = "0.8.27"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
Use the external docs rustdoc feature to link to the rgb docs on docs.rs.