### PR TITLE
Add a simple loading spinner animation for the plotter wasm demo

### DIFF
--- a/examples/plotter/index.html
+++ b/examples/plotter/index.html
@@ -8,10 +8,37 @@
 
 <head>
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type" />
+    <style>
+        .spinner:before {
+            content: '';
+            box-sizing: border-box;
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 100px;
+            height: 100px;
+            margin-top: -10px;
+            margin-left: -10px;
+            border-radius: 50%;
+            border: 2px solid transparent;
+            border-top-color: #07d;
+            border-bottom-color: #07d;
+            animation: spinner 1s ease infinite;
+        }
+
+        @keyframes spinner {
+            to {
+                transform: rotate(360deg);
+            }
+        }
+    </style>
 </head>
 
 <body>
     <p>This is the SixtyFPS Plotter example compiled to WebAssembly.</p>
+    <div id="spinner" style="position: relative;">
+        <div class="spinner">Loading...</div>
+    </div>
     <canvas id="canvas"></canvas>
     <p>
         <a href="https://github.com/sixtyfpsui/sixtyfps/blob/master/examples/plotter/main.rs">
@@ -19,7 +46,14 @@
     </p>
     <script type="module">
         import init from "./pkg/plotter.js";
-        init();
+        async function start() {
+            try {
+                await init();
+            } finally {
+                document.getElementById("spinner").remove();
+            }
+        };
+        start();
     </script>
 </body>
 


### PR DESCRIPTION
I'd like to apply this to all the wasm examples, but this one is here first for review.

The demos take a while to download, especially over slower mobile connections.


https://user-images.githubusercontent.com/1486/129153614-f9d49d0a-77cd-40af-9689-d0dbf7332693.mov

