### PR TITLE
add missing opening html tag in the rust tutorial

### DIFF
--- a/docs/tutorial/rust/src/running_in_a_browser.md
+++ b/docs/tutorial/rust/src/running_in_a_browser.md
@@ -54,6 +54,7 @@ file. The SixtyFPS runtime expects the `<canvas>` element to have the id `id = "
 (Replace `memory.js` by the correct file name).
 
 ```html
+<html>
   <body>
     <!-- canvas required by the SixtyFPS runtime -->
     <canvas id="canvas">>/canvas>


### PR DESCRIPTION
in the section to run the tutorial in the browser with wasm, the <html> opening tag is missing for the stub webpage