### PR TITLE
Fix panic when calling focus() on a repeated element

### DIFF
--- a/sixtyfps_compiler/expression_tree.rs
+++ b/sixtyfps_compiler/expression_tree.rs
@@ -776,6 +776,12 @@ impl Expression {
         self.visit(|e| e.visit_recursive(visitor));
     }
 
+    /// Visit itself and each sub expression recursively
+    pub fn visit_recursive_mut(&mut self, visitor: &mut dyn FnMut(&mut Self)) {
+        visitor(self);
+        self.visit_mut(|e| e.visit_recursive_mut(visitor));
+    }
+
     pub fn is_constant(&self) -> bool {
         match self {
             Expression::Invalid => true,

--- a/sixtyfps_compiler/passes/repeater_component.rs
+++ b/sixtyfps_compiler/passes/repeater_component.rs
@@ -93,4 +93,18 @@ fn adjust_references(comp: &Rc<Component>) {
             };
         }
     });
+    // Transform any references to the repeated element to refer to the root of each instance.
+    visit_all_expressions(comp, |expr, _| {
+        expr.visit_recursive_mut(&mut |expr| {
+            if let Expression::ElementReference(ref mut element_ref) = expr {
+                if let Some(repeater_element) =
+                    element_ref.upgrade().filter(|e| e.borrow().repeated.is_some())
+                {
+                    let inner_element =
+                        repeater_element.borrow().base_type.as_component().root_element.clone();
+                    *element_ref = Rc::downgrade(&inner_element);
+                }
+            }
+        })
+    });
 }

--- a/tests/cases/crashes/issue_422_enclosing_component.60
+++ b/tests/cases/crashes/issue_422_enclosing_component.60
@@ -1,0 +1,52 @@
+/* LICENSE BEGIN
+    This file is part of the SixtyFPS Project -- https://sixtyfps.io
+    Copyright (c) 2021 Olivier Goffart <olivier.goffart@sixtyfps.io>
+    Copyright (c) 2021 Simon Hausmann <simon.hausmann@sixtyfps.io>
+
+    SPDX-License-Identifier: GPL-3.0-only
+    This file is also available under commercial licensing terms.
+    Please contact info@sixtyfps.io for more information.
+LICENSE END */
+
+// issue #422
+
+export TestCase := Window {
+    width: 100phx;
+    height: 100phx;
+
+    property<bool> combo_has_focus;
+
+    if (true): combo := FocusScope {
+        if (true): TouchArea {
+            clicked => {
+                combo.focus();
+                root.combo_has_focus = combo.has-focus;
+            }
+        }
+    }
+}
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(!instance.get_combo_has_focus());
+sixtyfps::testing::send_mouse_click(&instance, 5., 5.);
+assert(instance.get_combo_has_focus());
+```
+
+```rust
+let instance = TestCase::new();
+assert!(!instance.get_combo_has_focus());
+sixtyfps::testing::send_mouse_click(&instance, 5., 5.);
+assert!(instance.get_combo_has_focus());
+```
+
+```js
+var instance = new sixtyfps.TestCase();
+assert(!instance.combo_has_focus);
+instance.send_mouse_click(5., 5.);
+assert(instance.combo_has_focus);
+```
+*/


### PR DESCRIPTION
When trying to reference an instance of a repeated item, for use with
ItemRc or VRef<Item>, the item_index (or id) of the ElementRc is not
directly what we want.

For the Rust and C++ code generators, the self/_self already refers
correctly to the repeated instance, but item_index must be zero to refer
to the root.

For the interpreter the self equivalent is the
local_context.component_instance is already the repeated instance that
we can use, and we're just looking for the root element of that, in
order to create the ItemRc/VRef.

Fixes #422