### PR TITLE
Refactor the way the two-ways biding are represented internaly

### DIFF
--- a/sixtyfps_compiler/generator.rs
+++ b/sixtyfps_compiler/generator.rs
@@ -183,9 +183,6 @@ pub fn handle_property_bindings_init(
                 }
             })
         }
-        if matches!(binding_expression.expression, Expression::Invalid) {
-            return;
-        }
         handle_property(elem, prop_name, binding_expression);
     }
 

--- a/sixtyfps_compiler/passes/clip.rs
+++ b/sixtyfps_compiler/passes/clip.rs
@@ -89,6 +89,6 @@ fn create_clip_element(parent_elem: &ElementRc, native_clip: &Rc<NativeClass>) {
     }
     clip.borrow_mut().bindings.insert(
         "clip".to_owned(),
-        Expression::TwoWayBinding(NamedReference::new(parent_elem, "clip"), None).into(),
+        BindingExpression::new_two_way(NamedReference::new(parent_elem, "clip")),
     );
 }

--- a/sixtyfps_compiler/passes/deduplicate_property_read.rs
+++ b/sixtyfps_compiler/passes/deduplicate_property_read.rs
@@ -88,13 +88,6 @@ impl<'a> DedupPropState<'a> {
 }
 
 fn process_expression(expr: &mut Expression, old_state: &DedupPropState) {
-    if let Expression::TwoWayBinding(_, expr) = expr {
-        if let Some(expr) = expr {
-            process_expression(&mut *expr, old_state)
-        }
-        return;
-    }
-
     let new_state = DedupPropState { parent_state: Some(old_state), ..DedupPropState::default() };
     collect_unconditional_read_count(expr, &new_state);
     process_conditional_expressions(expr, &new_state);

--- a/sixtyfps_compiler/passes/ensure_window.rs
+++ b/sixtyfps_compiler/passes/ensure_window.rs
@@ -9,7 +9,7 @@
 LICENSE END */
 //! Make sure that the top level element of the component is always a Window
 
-use crate::expression_tree::Expression;
+use crate::expression_tree::BindingExpression;
 use crate::langtype::Type;
 use crate::namedreference::NamedReference;
 use crate::object_tree::{Component, Element};
@@ -56,7 +56,7 @@ pub fn ensure_window(component: &Rc<Component>, type_register: &TypeRegister) {
     let make_two_way = |name: &str| {
         new_root.borrow_mut().bindings.insert(
             name.into(),
-            Expression::TwoWayBinding(NamedReference::new(&win_elem, name), None).into(),
+            BindingExpression::new_two_way(NamedReference::new(&win_elem, name)),
         );
     };
     make_two_way("width");

--- a/sixtyfps_compiler/passes/flickable.rs
+++ b/sixtyfps_compiler/passes/flickable.rs
@@ -22,7 +22,7 @@ use std::rc::Rc;
 
 use itertools::Itertools;
 
-use crate::expression_tree::{Expression, NamedReference};
+use crate::expression_tree::{BindingExpression, Expression, NamedReference};
 use crate::langtype::{NativeClass, Type};
 use crate::object_tree::{Component, Element, ElementRc};
 use crate::typeregister::TypeRegister;
@@ -64,14 +64,10 @@ fn create_viewport_element(flickable_elem: &ElementRc, native_rect: &Rc<NativeCl
             flickable.property_declarations.insert(prop.to_owned(), info.ty.clone().into());
             match flickable.bindings.entry(prop.to_owned()) {
                 std::collections::btree_map::Entry::Occupied(entry) => {
-                    let entry = entry.into_mut();
-                    entry.expression = Expression::TwoWayBinding(
-                        nr,
-                        Some(Box::new(std::mem::take(&mut entry.expression))),
-                    )
+                    entry.into_mut().two_way_bindings.push(nr);
                 }
                 std::collections::btree_map::Entry::Vacant(entry) => {
-                    entry.insert(Expression::TwoWayBinding(nr, None).into());
+                    entry.insert(BindingExpression::new_two_way(nr));
                 }
             }
         }

--- a/sixtyfps_compiler/passes/inlining.rs
+++ b/sixtyfps_compiler/passes/inlining.rs
@@ -188,6 +188,7 @@ fn duplicate_binding(
             .as_ref()
             .map(|pa| duplicate_property_animation(pa, mapping, root_component)),
         analysis: b.analysis.clone(),
+        two_way_bindings: b.two_way_bindings.clone(),
     };
     (k.clone(), b)
 }

--- a/sixtyfps_compiler/passes/lower_tabwidget.rs
+++ b/sixtyfps_compiler/passes/lower_tabwidget.rs
@@ -13,7 +13,7 @@ LICENSE END */
 //! be further inlined as it may expends to native widget that needs inlining
 
 use crate::diagnostics::BuildDiagnostics;
-use crate::expression_tree::{Expression, NamedReference, Unit};
+use crate::expression_tree::{BindingExpression, Expression, NamedReference, Unit};
 use crate::langtype::Type;
 use crate::object_tree::*;
 use itertools::Itertools;
@@ -108,11 +108,11 @@ fn process_tabwidget(
         };
         tab.bindings.insert(
             "title".to_owned(),
-            Expression::TwoWayBinding(NamedReference::new(child, "title"), None).into(),
+            BindingExpression::new_two_way(NamedReference::new(child, "title")),
         );
         tab.bindings.insert(
             "current".to_owned(),
-            Expression::TwoWayBinding(NamedReference::new(elem, "current-index"), None).into(),
+            BindingExpression::new_two_way(NamedReference::new(elem, "current-index")),
         );
         tab.bindings.insert(
             "tab-index".to_owned(),
@@ -139,11 +139,11 @@ fn process_tabwidget(
     set_tabbar_geometry_prop(elem, &tabbar, "height");
     elem.borrow_mut().bindings.insert(
         "tabbar-preferred-width".to_owned(),
-        Expression::TwoWayBinding(NamedReference::new(&tabbar, "preferred-width"), None).into(),
+        BindingExpression::new_two_way(NamedReference::new(&tabbar, "preferred-width")),
     );
     elem.borrow_mut().bindings.insert(
         "tabbar-preferred-height".to_owned(),
-        Expression::TwoWayBinding(NamedReference::new(&tabbar, "preferred-height"), None).into(),
+        BindingExpression::new_two_way(NamedReference::new(&tabbar, "preferred-height")),
     );
 
     if let Some(expr) = children

--- a/sixtyfps_compiler/passes/materialize_fake_properties.rs
+++ b/sixtyfps_compiler/passes/materialize_fake_properties.rs
@@ -50,15 +50,7 @@ pub fn materialize_fake_properties(component: &Rc<Component>) {
                     e.insert(BindingExpression::new_with_span(init_expr, span));
                 }
                 std::collections::btree_map::Entry::Occupied(mut e) => {
-                    let mut expr = &mut e.get_mut().expression;
-                    while let Expression::TwoWayBinding(_, next) = expr {
-                        if let Some(next) = next {
-                            expr = next;
-                        } else {
-                            *next = Some(Box::new(init_expr));
-                            break;
-                        }
-                    }
+                    e.get_mut().expression = init_expr;
                 }
             }
         }
@@ -70,18 +62,7 @@ pub fn materialize_fake_properties(component: &Rc<Component>) {
 fn must_initialize(elem: &Element, prop: &str) -> bool {
     match elem.bindings.get(prop) {
         None => true,
-        Some(b) => {
-            // Check if this is a TwoWay binding that need to be initialized anyway
-            let mut expr = &b.expression;
-            while let Expression::TwoWayBinding(_, next) = expr {
-                if let Some(next) = next {
-                    expr = next
-                } else {
-                    return true;
-                }
-            }
-            false
-        }
+        Some(b) => matches!(b.expression, Expression::Invalid),
     }
 }
 

--- a/sixtyfps_compiler/passes/transform_and_opacity.rs
+++ b/sixtyfps_compiler/passes/transform_and_opacity.rs
@@ -14,7 +14,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::diagnostics::BuildDiagnostics;
-use crate::expression_tree::{Expression, NamedReference};
+use crate::expression_tree::{BindingExpression, NamedReference};
 use crate::langtype::Type;
 use crate::object_tree::{self, Component, Element, ElementRc};
 use crate::typeregister::TypeRegister;
@@ -80,7 +80,7 @@ fn create_opacity_element(child: &ElementRc, type_register: &TypeRegister) -> El
         enclosing_component: child.borrow().enclosing_component.clone(),
         bindings: std::iter::once((
             "opacity".to_owned(),
-            Expression::TwoWayBinding(NamedReference::new(child, "opacity"), None).into(),
+            BindingExpression::new_two_way(NamedReference::new(child, "opacity")),
         ))
         .collect(),
         ..Default::default()

--- a/sixtyfps_runtime/interpreter/eval.rs
+++ b/sixtyfps_runtime/interpreter/eval.rs
@@ -134,7 +134,6 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
     match expression {
         Expression::Invalid => panic!("invalid expression while evaluating"),
         Expression::Uncompiled(_) => panic!("uncompiled expression while evaluating"),
-        Expression::TwoWayBinding(..) => panic!("invalid expression while evaluating"),
         Expression::StringLiteral(s) => Value::String(s.into()),
         Expression::NumberLiteral(n, unit) => Value::Number(unit.normalize(*n)),
         Expression::BoolLiteral(b) => Value::Bool(*b),


### PR DESCRIPTION
Don't put them in a fake expression.
This simplifies a bit the expression handling, and will make
possible to fix analysis that needs a vew into the aliases