### PR TITLE
Fix default text color when using Qt/native style in dark mode on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+ - Apply the default text color from the style for the `color` of `Text` and `TextInput` elements, to contrast
+   correctly with the application of `Window`'s `background` property.
+
 ### Added
 
 ### Fixed

--- a/docs/builtin_elements.md
+++ b/docs/builtin_elements.md
@@ -189,7 +189,7 @@ and the text itself.
 * **`font-family`** (*string*): The font name
 * **`font-size`** (*length*): The font size of the text
 * **`font-weight`** (*int*): The weight of the font. The values range from 100 (lightest) to 900 (thickest). 400 is the normal weight.
-* **`color`** (*brush*): The color of the text (default: black)
+* **`color`** (*brush*): The color of the text (default value: depends on the style)
 * **`horizontal-alignment`** (*enum [`TextHorizontalAlignment`](#texthorizontalalignment)*): The horizontal alignment of the text.
 * **`vertical-alignment`** (*enum [`TextVerticalAlignment`](#textverticalalignment)*): The vertical alignment of the text.
 * **`wrap`** (*enum [`TextWrap`](#textwrap)*): The way the text wraps (default: no-wrap).
@@ -582,7 +582,7 @@ When not part of a layout, its width or height defaults to 100% of the parent el
 * **`font-family`** (*string*): The font name
 * **`font-size`** (*length*): The font size of the text
 * **`font-weight`** (*int*): The weight of the font. The values range from 100 (lightest) to 900 (thickest). 400 is the normal weight.
-* **`color`** (*brush*): The color of the text (default: transparent)
+* **`color`** (*brush*): The color of the text (default value: depends on the style)
 * **`horizontal-alignment`** (enum *[`TextHorizontalAlignment`](#texthorizontalalignment)*): The horizontal alignment of the text.
 * **`vertical-alignment`** (enum *[`TextVerticalAlignment`](#textverticalalignment)*): The vertical alignment of the text.
 * **`has-focus`** (*bool*): Set to `true` when item is focused and receives keyboard events.

--- a/sixtyfps_compiler/builtins.60
+++ b/sixtyfps_compiler/builtins.60
@@ -81,7 +81,7 @@ export Text := _ {
     property <string> font-family;
     property <length> font-size;
     property <int> font-weight;
-    property <brush> color: #000;
+    property <brush> color;  // StyleMetrics.default-text-color  set in apply_default_properties_from_style
     property <TextHorizontalAlignment> horizontal-alignment;
     property <TextVerticalAlignment> vertical-alignment;
     property <TextOverflow> overflow;
@@ -184,7 +184,7 @@ export TextInput := _ {
     property <string> font-family;
     property <length> font-size;
     property <int> font-weight;
-    property <brush> color: #000;
+    property <brush> color; // StyleMetrics.default-text-color  set in apply_default_properties_from_style
     property <color> selection-foreground-color: #000;
     property <color> selection-background-color: #808080;
     property <TextHorizontalAlignment> horizontal-alignment;
@@ -571,6 +571,7 @@ export global NativeStyleMetrics := {
     property <length> layout-spacing;
     property <length> layout-padding;
     property <length> text-cursor-width;
+    property <color> default-text-color;
     //-is_non_item_type
     //-is_internal
 }

--- a/sixtyfps_compiler/passes/apply_default_properties_from_style.rs
+++ b/sixtyfps_compiler/passes/apply_default_properties_from_style.rs
@@ -44,6 +44,30 @@ pub async fn apply_default_properties_from_style(
                         ))
                         .into()
                     });
+                    elem.bindings.set_binding_if_not_set("color".into(), || {
+                        Expression::Cast {
+                            from: Expression::PropertyReference(NamedReference::new(
+                                &style_metrics.root_element,
+                                "default-text-color",
+                            ))
+                            .into(),
+                            to: Type::Brush,
+                        }
+                        .into()
+                    });
+                }
+                "Text" => {
+                    elem.bindings.set_binding_if_not_set("color".into(), || {
+                        Expression::Cast {
+                            from: Expression::PropertyReference(NamedReference::new(
+                                &style_metrics.root_element,
+                                "default-text-color",
+                            ))
+                            .into(),
+                            to: Type::Brush,
+                        }
+                        .into()
+                    });
                 }
                 "Window" => {
                     elem.bindings.set_binding_if_not_set("background".into(), || {

--- a/sixtyfps_compiler/widgets/fluent/sixtyfps_widgets.60
+++ b/sixtyfps_compiler/widgets/fluent/sixtyfps_widgets.60
@@ -66,6 +66,7 @@ export global StyleMetrics := {
     property<length> layout-padding: 8px;
     property<length> text-cursor-width: 2px;
     property<color> window-background: white; //FIXME: Palette.white  does not compile (cannot access globals from other globals #175)
+    property<color> default-text-color: black;
 }
 
 export Button := Rectangle {

--- a/sixtyfps_compiler/widgets/ugly/sixtyfps_widgets.60
+++ b/sixtyfps_compiler/widgets/ugly/sixtyfps_widgets.60
@@ -29,6 +29,7 @@ export global StyleMetrics := {
     property<length> layout-padding: 5px;
     property<length> text-cursor-width: 2px;
     property<color> window-background: #ecedeb; //FIXME: Palette.window-background  does not compile (cannot access globals from other globals #175)
+    property<color> default-text-color: #090909;
 }
 
 export Button := Rectangle {

--- a/sixtyfps_runtime/rendering_backends/qt/qt_widgets.rs
+++ b/sixtyfps_runtime/rendering_backends/qt/qt_widgets.rs
@@ -2269,6 +2269,7 @@ pub struct NativeStyleMetrics {
     pub layout_padding: Property<f32>,
     pub text_cursor_width: Property<f32>,
     pub window_background: Property<Color>,
+    pub default_text_color: Property<Color>,
 }
 
 impl Default for NativeStyleMetrics {
@@ -2278,6 +2279,7 @@ impl Default for NativeStyleMetrics {
             layout_padding: Default::default(),
             text_cursor_width: Default::default(),
             window_background: Default::default(),
+            default_text_color: Default::default(),
         };
         sixtyfps_init_native_style_metrics(&s);
         s
@@ -2305,5 +2307,9 @@ pub extern "C" fn sixtyfps_init_native_style_metrics(self_: &NativeStyleMetrics)
     let window_background = cpp!(unsafe[] -> u32 as "QRgb" {
         return qApp->palette().color(QPalette::Window).rgba();
     });
-    self_.window_background.set(Color::from_argb_encoded(window_background))
+    self_.window_background.set(Color::from_argb_encoded(window_background));
+    let default_text_color = cpp!(unsafe[] -> u32 as "QRgb" {
+        return qApp->palette().color(QPalette::Text).rgba();
+    });
+    self_.default_text_color.set(Color::from_argb_encoded(default_text_color));
 }


### PR DESCRIPTION
We apply a default window background from the palette to all `Window`
elements, and likewise we need to apply the default text color to Text
elements to ensure a readable contrast.