### PR TITLE
Fix key events the control modifier on Windows, X11 and Wayland

### DIFF
--- a/sixtyfps_runtime/rendering_backends/gl/graphics_window.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/graphics_window.rs
@@ -43,6 +43,7 @@ pub struct GraphicsWindow {
     map_state: RefCell<GraphicsWindowBackendState>,
     properties: Pin<Box<WindowProperties>>,
     keyboard_modifiers: std::cell::Cell<KeyboardModifiers>,
+    pub(crate) currently_pressed_key_code: std::cell::Cell<Option<winit::event::VirtualKeyCode>>,
 
     mouse_input_state: std::cell::Cell<corelib::input::MouseInputState>,
     /// Current popup's component and position
@@ -94,6 +95,7 @@ impl GraphicsWindow {
             map_state: RefCell::new(GraphicsWindowBackendState::Unmapped),
             properties: Box::pin(WindowProperties::default()),
             keyboard_modifiers: Default::default(),
+            currently_pressed_key_code: Default::default(),
             mouse_input_state: Default::default(),
             active_popup: Default::default(),
             default_font_properties: default_font_properties_prop,

--- a/sixtyfps_runtime/rendering_backends/qt/qt_window.rs
+++ b/sixtyfps_runtime/rendering_backends/qt/qt_window.rs
@@ -1457,7 +1457,10 @@ fn qt_key_to_string(key: key_generated::Qt_Key, event_text: String) -> SharedStr
         return special_key_code.encode_to_string();
     };
 
-    if !event_text.is_empty() {
+    // On Windows, X11 and Wayland, Ctrl+C for example sends a terminal control character,
+    // which we choose not to supply to the application. Instead we fall through to translating
+    // the supplied key code.
+    if !event_text.is_empty() && !event_text.chars().any(|ch| ch.is_control()) {
         return event_text.into();
     }
 


### PR DESCRIPTION
Under these windowing systems, we receive a QString text from Qt that
contains a terminal control character (like \u{3} for ctrl+c). We
decided to supply the character for the key (for example 'c' for Ctrl+C)
to the application, so activate the conversion from the key code when
control characters are present.

With winit, we receive first a key down input event with the virtual key
code (for example C for Ctrl+C), followed by a ReceivedCharacter event
with a terminal control character. We choose to ignore that and instead
take the previously received key code and try to use that instead.

Fixes #441