### PR TITLE
Fix missing compiler warning about duplicated ids when using id more …

### DIFF
--- a/sixtyfps_compiler/tests/syntax/basic/duplicated_id.60
+++ b/sixtyfps_compiler/tests/syntax/basic/duplicated_id.60
@@ -28,6 +28,9 @@ SubElement := Rectangle {
         world := Rectangle { }
 //              ^warning{duplicated element id 'world'}
     }
+
+    hello := Rectangle {}
+//          ^warning{duplicated element id 'hello'}
 }
 
 TestCase := Rectangle {


### PR DESCRIPTION
…than twice

Don't remove the id of a duplicate from the seen set, as it may appear
again.