### PR TITLE
Add support for global aliases

### DIFF
--- a/sixtyfps_compiler/generator/cpp.rs
+++ b/sixtyfps_compiler/generator/cpp.rs
@@ -608,10 +608,10 @@ pub fn generate(doc: &Document, diag: &mut BuildDiagnostics) -> Option<impl std:
         generate_component(&mut file, glob, diag, None);
 
         if glob.visible_in_public_api() {
-            file.definitions.extend(glob.exported_global_names.borrow().iter().map(|name| {
+            file.definitions.extend(glob.global_aliases().into_iter().map(|name| {
                 Declaration::TypeAlias(TypeAlias {
                     old_name: ident(&glob.root_element.borrow().id).into_owned(),
-                    new_name: name.clone(),
+                    new_name: name,
                 })
             }))
         }

--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -145,7 +145,6 @@ pub fn generate(doc: &Document, diag: &mut BuildDiagnostics) -> Option<TokenStre
 
     Some(quote! {
         #[allow(non_snake_case)]
-        #[allow(non_camel_case_types)]
         #[allow(clippy::style)]
         #[allow(clippy::complexity)]
         mod #compo_module {
@@ -917,12 +916,8 @@ fn generate_component(
             }
         ))
     } else if component.is_global() && component.visible_in_public_api() {
-        let aliases = component
-            .exported_global_names
-            .borrow()
-            .iter()
-            .flat_map(|name| (name != &component.root_element.borrow().id).then(|| ident(&name)))
-            .collect::<Vec<_>>();
+        let aliases =
+            component.global_aliases().into_iter().map(|name| ident(&name)).collect::<Vec<_>>();
 
         Some(quote!(
             #visibility struct #public_component_id<'a>(&'a ::core::pin::Pin<::std::rc::Rc<#inner_component_id>>);

--- a/sixtyfps_compiler/object_tree.rs
+++ b/sixtyfps_compiler/object_tree.rs
@@ -23,7 +23,7 @@ use crate::parser;
 use crate::parser::{syntax_nodes, SyntaxKind, SyntaxNode};
 use crate::typeloader::ImportedTypes;
 use crate::typeregister::TypeRegister;
-use std::cell::{Cell, RefCell};
+use std::cell::RefCell;
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, HashMap};
 use std::iter::FromIterator;
@@ -224,7 +224,7 @@ pub struct Component {
 
     /// Set to true if the component is a global that's exported, thus requires
     /// visibility in publicly generated API.
-    pub exported_global: Cell<bool>,
+    pub exported_global_names: RefCell<Vec<String>>,
 }
 
 impl Component {
@@ -272,7 +272,7 @@ impl Component {
 
     pub fn visible_in_public_api(&self) -> bool {
         if self.is_global() {
-            self.exported_global.get()
+            !self.exported_global_names.borrow().is_empty()
         } else {
             self.parent_element.upgrade().is_none()
         }

--- a/sixtyfps_compiler/object_tree.rs
+++ b/sixtyfps_compiler/object_tree.rs
@@ -222,8 +222,8 @@ pub struct Component {
     pub used_types: RefCell<UsedSubTypes>,
     pub popup_windows: RefCell<Vec<PopupWindow>>,
 
-    /// Set to true if the component is a global that's exported, thus requires
-    /// visibility in publicly generated API.
+    /// The names under which this component should be accessible
+    /// if it is a global singleton and exported.
     pub exported_global_names: RefCell<Vec<String>>,
 }
 

--- a/sixtyfps_compiler/object_tree.rs
+++ b/sixtyfps_compiler/object_tree.rs
@@ -277,6 +277,15 @@ impl Component {
             self.parent_element.upgrade().is_none()
         }
     }
+
+    pub fn global_aliases(&self) -> Vec<String> {
+        self.exported_global_names
+            .borrow()
+            .iter()
+            .filter(|name| *name != &self.root_element.borrow().id)
+            .map(|name| name.to_string())
+            .collect()
+    }
 }
 
 #[derive(Clone, Debug, Default)]

--- a/sixtyfps_compiler/passes.rs
+++ b/sixtyfps_compiler/passes.rs
@@ -109,7 +109,7 @@ pub async fn run_passes(
     .await;
     ensure_window::ensure_window(root_component, &doc.local_registry);
     collect_globals::collect_globals(doc, diag);
-    unique_id::assign_unique_id(root_component, &doc.exports());
+    unique_id::assign_unique_id(root_component);
     binding_analysis::binding_analysis(root_component, diag);
     deduplicate_property_read::deduplicate_property_read(root_component);
     move_declarations::move_declarations(root_component, diag);

--- a/sixtyfps_compiler/passes/check_public_api.rs
+++ b/sixtyfps_compiler/passes/check_public_api.rs
@@ -18,11 +18,11 @@ use crate::object_tree::{Component, Document};
 
 pub fn check_public_api(doc: &Document, diag: &mut BuildDiagnostics) {
     check_public_api_component(&doc.root_component, diag);
-    for (_, ty) in doc.exports() {
+    for (export_name, ty) in doc.exports() {
         if let Type::Component(c) = ty {
             if c.is_global() {
                 // This global will become part of the public API.
-                c.exported_global.set(true);
+                c.exported_global_names.borrow_mut().push(export_name.clone());
                 check_public_api_component(c, diag)
             }
         }

--- a/sixtyfps_compiler/passes/unique_id.rs
+++ b/sixtyfps_compiler/passes/unique_id.rs
@@ -41,6 +41,8 @@ fn rename_globals(component: &Rc<Component>, mut count: u32) {
         if matches!(&root.base_type, Type::Builtin(_)) {
             // builtin global keeps its name
             root.id = g.id.clone();
+        } else if let Some(s) = g.exported_global_names.borrow().first() {
+            root.id = s.to_string();
         } else {
             root.id = format!("{}-{}", g.id, count);
         }

--- a/sixtyfps_runtime/interpreter/api.rs
+++ b/sixtyfps_runtime/interpreter/api.rs
@@ -1140,6 +1140,7 @@ fn globals() {
     export global My-Super_Global := {
         property <int> the-property : 21;
     }
+    export { My-Super_Global as AliasedGlobal }
     export Dummy := Rectangle {
     }"#
             .into(),
@@ -1152,12 +1153,20 @@ fn globals() {
         Ok(())
     );
     assert_eq!(
+        instance.set_global_property("AliasedGlobal", "the_property", Value::Number(44.)),
+        Ok(())
+    );
+    assert_eq!(
         instance.set_global_property("DontExist", "the-property", Value::Number(88.)),
         Err(SetPropertyError::NoSuchProperty)
     );
 
     assert_eq!(
         instance.set_global_property("My_Super-Global", "theproperty", Value::Number(88.)),
+        Err(SetPropertyError::NoSuchProperty)
+    );
+    assert_eq!(
+        instance.set_global_property("AliasedGlobal", "theproperty", Value::Number(88.)),
         Err(SetPropertyError::NoSuchProperty)
     );
     assert_eq!(

--- a/sixtyfps_runtime/interpreter/dynamic_component.rs
+++ b/sixtyfps_runtime/interpreter/dynamic_component.rs
@@ -1012,7 +1012,11 @@ pub fn instantiate(
         extra_data.globals = component_type
             .compiled_globals
             .iter()
-            .map(|g| crate::global_component::instantiate(g))
+            .map(|g| {
+                let (_, instance) = crate::global_component::instantiate(g);
+                g.names().iter().map(|name| (name.clone(), instance.clone())).collect::<Vec<_>>()
+            })
+            .flatten()
             .collect();
     }
     *component_type.window_offset.apply_mut(instance.as_mut()) =

--- a/sixtyfps_runtime/interpreter/global_component.rs
+++ b/sixtyfps_runtime/interpreter/global_component.rs
@@ -24,6 +24,22 @@ pub enum CompiledGlobal {
     Component(ErasedComponentDescription),
 }
 
+impl CompiledGlobal {
+    pub fn names(&self) -> Vec<String> {
+        match self {
+            CompiledGlobal::Builtin(name, _) => vec![name.clone()],
+            CompiledGlobal::Component(component) => {
+                generativity::make_guard!(guard);
+                let component = component.unerase(guard);
+                let mut names = component.original.exported_global_names.borrow().clone();
+                // eval.rs (generated code) accesses globals by their internal name
+                names.push(component.original.root_element.borrow().id.clone());
+                names
+            }
+        }
+    }
+}
+
 pub trait GlobalComponent {
     fn invoke_callback(self: Pin<&Self>, callback_name: &str, args: &[Value]) -> Result<Value, ()>;
 

--- a/sixtyfps_runtime/interpreter/global_component.rs
+++ b/sixtyfps_runtime/interpreter/global_component.rs
@@ -31,8 +31,7 @@ impl CompiledGlobal {
             CompiledGlobal::Component(component) => {
                 generativity::make_guard!(guard);
                 let component = component.unerase(guard);
-                let mut names = component.original.exported_global_names.borrow().clone();
-                // eval.rs (generated code) accesses globals by their internal name
+                let mut names = component.original.global_aliases();
                 names.push(component.original.root_element.borrow().id.clone());
                 names
             }

--- a/tests/cases/globals/global_alias.60
+++ b/tests/cases/globals/global_alias.60
@@ -1,0 +1,54 @@
+/* LICENSE BEGIN
+    This file is part of the SixtyFPS Project -- https://sixtyfps.io
+    Copyright (c) 2021 Olivier Goffart <olivier.goffart@sixtyfps.io>
+    Copyright (c) 2021 Simon Hausmann <simon.hausmann@sixtyfps.io>
+
+    SPDX-License-Identifier: GPL-3.0-only
+    This file is also available under commercial licensing terms.
+    Please contact info@sixtyfps.io for more information.
+LICENSE END */
+//include_path: ../../helper_components
+
+global MyGlobal := {
+    property <int> hello: 42;
+}
+
+export { MyGlobal }
+export { MyGlobal as GlobalAlias }
+
+TestCase := Rectangle {
+    property <bool> test_global_prop_value: MyGlobal.hello == 100;
+}
+
+/*
+```rust
+let instance = TestCase::new();
+assert!(!instance.get_test_global_prop_value());
+assert_eq!(MyGlobal::get(&instance).get_hello(), 42);
+assert_eq!(GlobalAlias::get(&instance).get_hello(), 42);
+instance.global::<MyGlobal>().set_hello(100);
+assert!(instance.get_test_global_prop_value());
+assert_eq!(MyGlobal::get(&instance).get_hello(), 100);
+assert_eq!(GlobalAlias::get(&instance).get_hello(), 100);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(!instance.get_test_global_prop_value());
+assert_eq(instance.global<MyGlobal>().get_hello(), 42);
+assert_eq(instance.global<GlobalAlias>().get_hello(), 42);
+instance.global<MyGlobal>().set_hello(100);
+assert(instance.get_test_global_prop_value());
+assert_eq(instance.global<MyGlobal>().get_hello(), 100);
+assert_eq(instance.global<GlobalAlias>().get_hello(), 100);
+
+```
+
+```js
+let instance = new sixtyfps.TestCase({});
+assert(!instance.test_global_prop_value);
+// TODO
+```
+
+*/


### PR DESCRIPTION
When exporting an global multiple times under different names, make sure
that they alias in the generated code.

As a consequence, the compiler maintains the original unique name and in
Rust and C++ makes only the exported names public. In the interpreter
the internal name is theoretically still accessible from the outside.