### PR TITLE
Internal cleanup: Remove canvas dependency from text layout code

### DIFF
--- a/sixtyfps_runtime/rendering_backends/gl/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/lib.rs
@@ -473,9 +473,8 @@ impl ItemRenderer for GLItemRenderer {
             text.wrap(),
             text.overflow(),
             false,
-            &mut canvas,
             paint,
-            |canvas, to_draw, pos, _, _| {
+            |to_draw, pos, _, _| {
                 canvas.fill_text(pos.x, pos.y, to_draw.trim_end(), paint).unwrap();
             },
         );
@@ -527,9 +526,8 @@ impl ItemRenderer for GLItemRenderer {
             text_input.wrap(),
             sixtyfps_corelib::items::TextOverflow::clip,
             text_input.single_line(),
-            &mut canvas,
             paint,
-            |canvas, to_draw, pos, start, metrics| {
+            |to_draw, pos, start, metrics| {
                 let range = start..(start + to_draw.len());
                 if min_select != max_select
                     && (range.contains(&min_select)


### PR DESCRIPTION
We can use the non-canvas bound TextContext and need the canvas only
in the closure when painting.