### PR TITLE
Add image-scaling property to Images to control how they are scaled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
  - TextInput can support multiple line by setting single-line to false
  - The CMake integration now allows enabling/disabling SixtyFPS library features, such as Wayland support
    or the dynamic run-time interpreter.
+ - Added `image-rendering` property to Image to control how the image is scaled
 
 ### Fixed
  - The interpreter API correctly return an error instead of panicking when setting properties or calling callbacks

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ members = [
     'examples/memory',
     'examples/plotter',
     'examples/imagefilter',
-    'examples/imagescaling',
     'helper_crates/const-field-offset',
     'helper_crates/vtable',
     'helper_crates/vtable/macro',

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     'examples/memory',
     'examples/plotter',
     'examples/imagefilter',
+    'examples/imagescaling',
     'helper_crates/const-field-offset',
     'helper_crates/vtable',
     'helper_crates/vtable/macro',

--- a/docs/builtin_elements.md
+++ b/docs/builtin_elements.md
@@ -138,6 +138,12 @@ An Image can be used to represent an image loaded from an image file.
 
   When the `Image` element is part of a layout, the default value for **`image-fit`** is `contain`. Otherwise it is `fill`.
 
+* **`image-rendering`** (*enum*): Specifies how the source image will be scaled. Possible values are:
+  * `smooth`: The image is scaled with a linear interpolation algorithm.
+  * `pixelated`: The image is scaled with the nearest neighbor algorithm.
+  
+  The default value is `smooth`.
+
 * **`colorize`** (*brush*): When set, the image is used as an alpha mask and is drown in the given color (or with the gradient)
 * **`width`**, **`height`** (*length*): The width and height of the image as it appears on the screen.The default values are
   the sizes provided by the **`source`** image. If the `Image` is **not** in a layout and only **one** of the two sizes are

--- a/sixtyfps_compiler/builtins.60
+++ b/sixtyfps_compiler/builtins.60
@@ -53,7 +53,7 @@ ImageItem := _ {
     property <length> width;
     property <length> height;
     property <ImageFit> image-fit;
-    property <ImageScaling> image-scaling;
+    property <ImageRendering> image-rendering;
 }
 
 export ClippedImage := ImageItem {
@@ -62,7 +62,7 @@ export ClippedImage := ImageItem {
     property <int> source-clip-width;
     property <int> source-clip-height;
     property <brush> colorize;
-    property <ImageScaling> image-scaling;
+    property <ImageRendering> image-rendering;
     //-default_size_binding:implicit_size
 }
 

--- a/sixtyfps_compiler/builtins.60
+++ b/sixtyfps_compiler/builtins.60
@@ -53,6 +53,7 @@ ImageItem := _ {
     property <length> width;
     property <length> height;
     property <ImageFit> image-fit;
+    property <ImageScaling> image-scaling;
 }
 
 export ClippedImage := ImageItem {
@@ -61,6 +62,7 @@ export ClippedImage := ImageItem {
     property <int> source-clip-width;
     property <int> source-clip-height;
     property <brush> colorize;
+    property <ImageScaling> image-scaling;
     //-default_size_binding:implicit_size
 }
 

--- a/sixtyfps_compiler/typeregister.rs
+++ b/sixtyfps_compiler/typeregister.rs
@@ -171,6 +171,7 @@ impl TypeRegister {
             &["stretch", "center", "start", "end", "space-between", "space-around"],
         );
         declare_enum("ImageFit", &["fill", "contain", "cover"]);
+        declare_enum("ImageScaling", &["smooth", "pixelated"]);
         declare_enum("EventResult", &["reject", "accept"]);
         declare_enum("FillRule", &["nonzero", "evenodd"]);
 

--- a/sixtyfps_compiler/typeregister.rs
+++ b/sixtyfps_compiler/typeregister.rs
@@ -171,7 +171,7 @@ impl TypeRegister {
             &["stretch", "center", "start", "end", "space-between", "space-around"],
         );
         declare_enum("ImageFit", &["fill", "contain", "cover"]);
-        declare_enum("ImageScaling", &["smooth", "pixelated"]);
+        declare_enum("ImageRendering", &["smooth", "pixelated"]);
         declare_enum("EventResult", &["reject", "accept"]);
         declare_enum("FillRule", &["nonzero", "evenodd"]);
 

--- a/sixtyfps_runtime/corelib/items/image.rs
+++ b/sixtyfps_runtime/corelib/items/image.rs
@@ -47,14 +47,14 @@ impl Default for ImageFit {
 #[derive(Copy, Clone, Debug, PartialEq, strum_macros::EnumString, strum_macros::Display)]
 #[repr(C)]
 #[allow(non_camel_case_types)]
-pub enum ImageScaling {
+pub enum ImageRendering {
     smooth,
     pixelated,
 }
 
-impl Default for ImageScaling {
+impl Default for ImageRendering {
     fn default() -> Self {
-        ImageScaling::smooth
+        ImageRendering::smooth
     }
 }
 
@@ -69,7 +69,7 @@ pub struct ImageItem {
     pub width: Property<f32>,
     pub height: Property<f32>,
     pub image_fit: Property<ImageFit>,
-    pub image_scaling: Property<ImageScaling>,
+    pub image_rendering: Property<ImageRendering>,
     pub cached_rendering_data: CachedRenderingData,
 }
 
@@ -143,7 +143,7 @@ pub struct ClippedImage {
     pub width: Property<f32>,
     pub height: Property<f32>,
     pub image_fit: Property<ImageFit>,
-    pub image_scaling: Property<ImageScaling>,
+    pub image_rendering: Property<ImageRendering>,
     pub colorize: Property<Brush>,
     pub source_clip_x: Property<i32>,
     pub source_clip_y: Property<i32>,

--- a/sixtyfps_runtime/corelib/items/image.rs
+++ b/sixtyfps_runtime/corelib/items/image.rs
@@ -44,6 +44,20 @@ impl Default for ImageFit {
     }
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, strum_macros::EnumString, strum_macros::Display)]
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub enum ImageScaling {
+    smooth,
+    pixelated,
+}
+
+impl Default for ImageScaling {
+    fn default() -> Self {
+        ImageScaling::smooth
+    }
+}
+
 #[repr(C)]
 #[derive(FieldOffsets, Default, SixtyFPSElement)]
 #[pin]
@@ -55,6 +69,7 @@ pub struct ImageItem {
     pub width: Property<f32>,
     pub height: Property<f32>,
     pub image_fit: Property<ImageFit>,
+    pub image_scaling: Property<ImageScaling>,
     pub cached_rendering_data: CachedRenderingData,
 }
 
@@ -128,6 +143,7 @@ pub struct ClippedImage {
     pub width: Property<f32>,
     pub height: Property<f32>,
     pub image_fit: Property<ImageFit>,
+    pub image_scaling: Property<ImageScaling>,
     pub colorize: Property<Brush>,
     pub source_clip_x: Property<i32>,
     pub source_clip_y: Property<i32>,

--- a/sixtyfps_runtime/corelib/rtti.rs
+++ b/sixtyfps_runtime/corelib/rtti.rs
@@ -42,7 +42,7 @@ declare_ValueType![
     crate::items::TextWrap,
     crate::model::StandardListViewItem,
     crate::items::ImageFit,
-    crate::items::ImageScaling,
+    crate::items::ImageRendering,
     crate::input::KeyEvent,
     crate::items::EventResult,
     crate::Brush,

--- a/sixtyfps_runtime/corelib/rtti.rs
+++ b/sixtyfps_runtime/corelib/rtti.rs
@@ -42,6 +42,7 @@ declare_ValueType![
     crate::items::TextWrap,
     crate::model::StandardListViewItem,
     crate::items::ImageFit,
+    crate::items::ImageScaling,
     crate::input::KeyEvent,
     crate::items::EventResult,
     crate::Brush,

--- a/sixtyfps_runtime/interpreter/api.rs
+++ b/sixtyfps_runtime/interpreter/api.rs
@@ -307,7 +307,7 @@ declare_value_enum_conversion!(sixtyfps_corelib::items::TextOverflow, TextOverfl
 declare_value_enum_conversion!(sixtyfps_corelib::items::TextWrap, TextWrap);
 declare_value_enum_conversion!(sixtyfps_corelib::layout::LayoutAlignment, LayoutAlignment);
 declare_value_enum_conversion!(sixtyfps_corelib::items::ImageFit, ImageFit);
-declare_value_enum_conversion!(sixtyfps_corelib::items::ImageScaling, ImageScaling);
+declare_value_enum_conversion!(sixtyfps_corelib::items::ImageRendering, ImageRendering);
 declare_value_enum_conversion!(sixtyfps_corelib::input::KeyEventType, KeyEventType);
 declare_value_enum_conversion!(sixtyfps_corelib::items::EventResult, EventResult);
 declare_value_enum_conversion!(sixtyfps_corelib::items::FillRule, FillRule);

--- a/sixtyfps_runtime/interpreter/api.rs
+++ b/sixtyfps_runtime/interpreter/api.rs
@@ -307,6 +307,7 @@ declare_value_enum_conversion!(sixtyfps_corelib::items::TextOverflow, TextOverfl
 declare_value_enum_conversion!(sixtyfps_corelib::items::TextWrap, TextWrap);
 declare_value_enum_conversion!(sixtyfps_corelib::layout::LayoutAlignment, LayoutAlignment);
 declare_value_enum_conversion!(sixtyfps_corelib::items::ImageFit, ImageFit);
+declare_value_enum_conversion!(sixtyfps_corelib::items::ImageScaling, ImageScaling);
 declare_value_enum_conversion!(sixtyfps_corelib::input::KeyEventType, KeyEventType);
 declare_value_enum_conversion!(sixtyfps_corelib::items::EventResult, EventResult);
 declare_value_enum_conversion!(sixtyfps_corelib::items::FillRule, FillRule);

--- a/sixtyfps_runtime/rendering_backends/gl/images.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/images.rs
@@ -15,7 +15,7 @@ use std::rc::Rc;
 use sixtyfps_corelib::graphics::{SharedImageBuffer, Size};
 #[cfg(target_arch = "wasm32")]
 use sixtyfps_corelib::Property;
-use sixtyfps_corelib::{slice::Slice, ImageInner, items::ImageScaling, SharedString};
+use sixtyfps_corelib::{slice::Slice, ImageInner, items::ImageRendering, SharedString};
 
 use super::{CanvasRc, GLItemRenderer};
 
@@ -236,14 +236,14 @@ impl CachedImage {
     // Upload the image to the GPU? if that hasn't happened yet. This function could take just a canvas
     // as parameter, but since an upload requires a current context, this is "enforced" by taking
     // a renderer instead (which implies a current context).
-    pub fn ensure_uploaded_to_gpu(&self, current_renderer: &GLItemRenderer, scaling: Option<ImageScaling>) -> femtovg::ImageId {
+    pub fn ensure_uploaded_to_gpu(&self, current_renderer: &GLItemRenderer, scaling: Option<ImageRendering>) -> femtovg::ImageId {
         use std::convert::TryFrom;
 
         let canvas = &current_renderer.canvas;
 
         let image_flags = match scaling.unwrap_or_default() {
-            ImageScaling::smooth => femtovg::ImageFlags::empty(),
-            ImageScaling::pixelated => femtovg::ImageFlags::NEAREST,
+            ImageRendering::smooth => femtovg::ImageFlags::empty(),
+            ImageRendering::pixelated => femtovg::ImageFlags::NEAREST,
         };
 
         let img = &mut *self.0.borrow_mut();
@@ -289,15 +289,15 @@ impl CachedImage {
         &self,
         current_renderer: &GLItemRenderer,
         target_size: euclid::default::Size2D<u32>,
-        scaling: ImageScaling,
+        scaling: ImageRendering,
     ) -> Option<Self> {
         use std::convert::TryFrom;
 
         let canvas = &current_renderer.canvas;
 
         let image_flags = match scaling {
-            ImageScaling::smooth => femtovg::ImageFlags::empty(),
-            ImageScaling::pixelated => femtovg::ImageFlags::NEAREST,
+            ImageRendering::smooth => femtovg::ImageFlags::empty(),
+            ImageRendering::pixelated => femtovg::ImageFlags::NEAREST,
         };
 
         match &*self.0.borrow() {

--- a/sixtyfps_runtime/rendering_backends/gl/images.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/images.rs
@@ -15,7 +15,7 @@ use std::rc::Rc;
 use sixtyfps_corelib::graphics::{SharedImageBuffer, Size};
 #[cfg(target_arch = "wasm32")]
 use sixtyfps_corelib::Property;
-use sixtyfps_corelib::{slice::Slice, ImageInner, items::ImageRendering, SharedString};
+use sixtyfps_corelib::{items::ImageRendering, slice::Slice, ImageInner, SharedString};
 
 use super::{CanvasRc, GLItemRenderer};
 
@@ -236,7 +236,11 @@ impl CachedImage {
     // Upload the image to the GPU? if that hasn't happened yet. This function could take just a canvas
     // as parameter, but since an upload requires a current context, this is "enforced" by taking
     // a renderer instead (which implies a current context).
-    pub fn ensure_uploaded_to_gpu(&self, current_renderer: &GLItemRenderer, scaling: Option<ImageRendering>) -> femtovg::ImageId {
+    pub fn ensure_uploaded_to_gpu(
+        &self,
+        current_renderer: &GLItemRenderer,
+        scaling: Option<ImageRendering>,
+    ) -> femtovg::ImageId {
         use std::convert::TryFrom;
 
         let canvas = &current_renderer.canvas;
@@ -249,9 +253,7 @@ impl CachedImage {
         let img = &mut *self.0.borrow_mut();
         if let ImageData::DecodedImage(decoded_image) = img {
             let image_id = match femtovg::ImageSource::try_from(&*decoded_image) {
-                Ok(image_source) => {
-                    canvas.borrow_mut().create_image(image_source, image_flags)
-                }
+                Ok(image_source) => canvas.borrow_mut().create_image(image_source, image_flags),
                 Err(_) => {
                     let converted = image::DynamicImage::ImageRgba8(decoded_image.to_rgba8());
                     let image_source = femtovg::ImageSource::try_from(&converted).unwrap();
@@ -263,16 +265,15 @@ impl CachedImage {
             *img = Texture { id: image_id, canvas: canvas.clone() }.into()
         } else if let ImageData::EmbeddedImage(buffer) = img {
             let (image_source, flags) = image_buffer_to_image_source(buffer);
-            let image_id = canvas.borrow_mut().create_image(image_source, flags | image_flags).unwrap();
+            let image_id =
+                canvas.borrow_mut().create_image(image_source, flags | image_flags).unwrap();
             *img = Texture { id: image_id, canvas: canvas.clone() }.into()
         }
 
         #[cfg(target_arch = "wasm32")]
         if let ImageData::HTMLImage(html_image) = img {
-            let image_id = canvas
-                .borrow_mut()
-                .create_image(&html_image.dom_element, image_flags)
-                .unwrap();
+            let image_id =
+                canvas.borrow_mut().create_image(&html_image.dom_element, image_flags).unwrap();
             *img = Texture { id: image_id, canvas: canvas.clone() }.into()
         }
 
@@ -304,9 +305,7 @@ impl CachedImage {
             ImageData::Texture(_) => None, // internal error: Cannot call upload_to_gpu on previously uploaded image,
             ImageData::DecodedImage(decoded_image) => {
                 let image_id = match femtovg::ImageSource::try_from(&*decoded_image) {
-                    Ok(image_source) => {
-                        canvas.borrow_mut().create_image(image_source, image_flags)
-                    }
+                    Ok(image_source) => canvas.borrow_mut().create_image(image_source, image_flags),
                     Err(_) => {
                         let converted = image::DynamicImage::ImageRgba8(decoded_image.to_rgba8());
                         let image_source = femtovg::ImageSource::try_from(&converted).unwrap();
@@ -333,10 +332,8 @@ impl CachedImage {
             },
             #[cfg(target_arch = "wasm32")]
             ImageData::HTMLImage(html_image) => html_image.size().map(|_| {
-                let image_id = canvas
-                    .borrow_mut()
-                    .create_image(&html_image.dom_element, image_flags)
-                    .unwrap();
+                let image_id =
+                    canvas.borrow_mut().create_image(&html_image.dom_element, image_flags).unwrap();
                 Self::new_on_gpu(canvas, image_id)
             }),
         }

--- a/sixtyfps_runtime/rendering_backends/gl/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/lib.rs
@@ -26,7 +26,7 @@ use std::rc::Rc;
 use euclid::approxeq::ApproxEq;
 use sixtyfps_corelib::graphics::{Brush, Color, Image, IntRect, Point, Rect, RenderingCache, Size};
 use sixtyfps_corelib::item_rendering::{CachedRenderingData, ItemRenderer};
-use sixtyfps_corelib::items::{FillRule, ImageFit, ImageScaling};
+use sixtyfps_corelib::items::{FillRule, ImageFit, ImageRendering};
 use sixtyfps_corelib::properties::Property;
 use sixtyfps_corelib::window::Window;
 
@@ -404,7 +404,7 @@ impl ItemRenderer for GLItemRenderer {
             sixtyfps_corelib::items::ImageItem::FIELD_OFFSETS.height.apply_pin(image),
             image.image_fit(),
             None,
-            image.image_scaling(),
+            image.image_rendering(),
         );
     }
 
@@ -429,7 +429,7 @@ impl ItemRenderer for GLItemRenderer {
                     .colorize
                     .apply_pin(clipped_image),
             ),
-            clipped_image.image_scaling(),
+            clipped_image.image_rendering(),
         );
     }
 
@@ -1029,7 +1029,7 @@ impl GLItemRenderer {
         &self,
         original_cache_entry: ItemGraphicsCacheEntry,
         colorize_property: Option<Pin<&Property<Brush>>>,
-        scaling: ImageScaling,
+        scaling: ImageRendering,
     ) -> ItemGraphicsCacheEntry {
         let colorize_brush = colorize_property.map_or(Brush::default(), |prop| prop.get());
         if colorize_brush.is_transparent() {
@@ -1043,8 +1043,8 @@ impl GLItemRenderer {
         };
 
         let scaling_flags = match scaling {
-            ImageScaling::smooth => femtovg::ImageFlags::empty(),
-            ImageScaling::pixelated => femtovg::ImageFlags::empty() | femtovg::ImageFlags::NEAREST,
+            ImageRendering::smooth => femtovg::ImageFlags::empty(),
+            ImageRendering::pixelated => femtovg::ImageFlags::empty() | femtovg::ImageFlags::NEAREST,
         };
 
         let image_id = original_image.ensure_uploaded_to_gpu(self, Some(scaling));
@@ -1104,7 +1104,7 @@ impl GLItemRenderer {
         target_height: std::pin::Pin<&Property<f32>>,
         image_fit: ImageFit,
         colorize_property: Option<Pin<&Property<Brush>>>,
-        scaling: ImageScaling,
+        scaling: ImageRendering,
     ) {
         let target_w = target_width.get() * self.scale_factor;
         let target_h = target_height.get() * self.scale_factor;

--- a/sixtyfps_runtime/rendering_backends/gl/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/lib.rs
@@ -1044,7 +1044,9 @@ impl GLItemRenderer {
 
         let scaling_flags = match scaling {
             ImageRendering::smooth => femtovg::ImageFlags::empty(),
-            ImageRendering::pixelated => femtovg::ImageFlags::empty() | femtovg::ImageFlags::NEAREST,
+            ImageRendering::pixelated => {
+                femtovg::ImageFlags::empty() | femtovg::ImageFlags::NEAREST
+            }
         };
 
         let image_id = original_image.ensure_uploaded_to_gpu(self, Some(scaling));
@@ -1150,7 +1152,9 @@ impl GLItemRenderer {
                         })
                         .or_else(|| CachedImage::new_from_resource(image_inner).map(Rc::new))
                         .map(ItemGraphicsCacheEntry::Image)
-                        .map(|cache_entry| self.colorize_image(cache_entry, colorize_property, scaling))
+                        .map(|cache_entry| {
+                            self.colorize_image(cache_entry, colorize_property, scaling)
+                        })
                 });
 
             // Check if the image in the cache is loaded. If not, don't draw any image and we'll return

--- a/tests/cases/examples/image_rendering.60
+++ b/tests/cases/examples/image_rendering.60
@@ -7,7 +7,6 @@
     This file is also available under commercial licensing terms.
     Please contact info@sixtyfps.io for more information.
 LICENSE END */
-import { HorizontalLayout } from "sixtyfps_widgets.60";
 
 export MainWindow := Window {
     title: "SixtyFPS Image Scaling Example";

--- a/tests/cases/examples/image_rendering.60
+++ b/tests/cases/examples/image_rendering.60
@@ -1,0 +1,27 @@
+/* LICENSE BEGIN
+    This file is part of the SixtyFPS Project -- https://sixtyfps.io
+    Copyright (c) 2021 Olivier Goffart <olivier.goffart@sixtyfps.io>
+    Copyright (c) 2021 Simon Hausmann <simon.hausmann@sixtyfps.io>
+
+    SPDX-License-Identifier: GPL-3.0-only
+    This file is also available under commercial licensing terms.
+    Please contact info@sixtyfps.io for more information.
+LICENSE END */
+import { HorizontalLayout } from "sixtyfps_widgets.60";
+
+export MainWindow := Window {
+    title: "SixtyFPS Image Scaling Example";
+    preferred-width: 800px;
+    preferred-height: 600px;
+
+    HorizontalLayout {
+        Image {
+            source: @image-url("../../../examples/printerdemo/ui/images/cat_preview_round.png");
+            image-rendering: smooth;
+        }
+        Image {
+            source: @image-url("../../../examples/printerdemo/ui/images/cat_preview_round.png");
+            image-rendering: pixelated;
+        }
+    }
+}


### PR DESCRIPTION
Like CSS image-rendering it has "smooth" and "pixelated" options. Only OpenGL has been tested right now, have not tested WASM or Qt. Right now the first instance of a `@image-url()` will set the scaling for that specific image. The same image used from memory on the otherhand can all have a different scaling property.

![This example shows scaling a 8x8 pixel image](https://user-images.githubusercontent.com/1617326/132109503-05c3a324-4ac7-4bc5-a78e-e3fe473f6745.PNG)

Still need to update documentation, but I wanted to get other backends working, possibly fix the image-url issue, and ask if there is a better way to implement this first.