### PR TITLE
Use the GL backend in the CI for node tests

### DIFF
--- a/api/sixtyfps-node/native/Cargo.toml
+++ b/api/sixtyfps-node/native/Cargo.toml
@@ -16,16 +16,11 @@ path = "lib.rs"
 crate-type = ["cdylib"]
 name = "sixtyfps_node_native"
 
-[features]
-# Enable some function used by the integration tests
-testing = ["sixtyfps-rendering-backend-testing"]
-
 [dependencies]
 once_cell = "1.5"
 sixtyfps-compilerlib = { version = "=0.1.2", path="../../../sixtyfps_compiler" }
 sixtyfps-interpreter = { version = "=0.1.2", path="../../../sixtyfps_runtime/interpreter",  features = ["display-diagnostics"] }
 sixtyfps-corelib = { version = "=0.1.2", path="../../../sixtyfps_runtime/corelib" }
-sixtyfps-rendering-backend-testing = { version = "=0.1.2", path="../../../sixtyfps_runtime/rendering_backends/testing", optional = true }
 scoped-tls-hkt = "0.1"
 neon = "0.8.0"
 css-color-parser2 = "1.0.1"

--- a/api/sixtyfps-node/native/lib.rs
+++ b/api/sixtyfps-node/native/lib.rs
@@ -547,8 +547,6 @@ register_module!(mut m, {
     m.export_function("load", load)?;
     m.export_function("mock_elapsed_time", mock_elapsed_time)?;
     m.export_function("singleshot_timer", singleshot_timer)?;
-    #[cfg(feature = "testing")]
-    m.export_function("init_testing_backend", init_testing_backend)?;
     Ok(())
 });
 
@@ -556,11 +554,5 @@ register_module!(mut m, {
 fn mock_elapsed_time(mut cx: FunctionContext) -> JsResult<JsValue> {
     let ms = cx.argument::<JsNumber>(0)?.value();
     sixtyfps_corelib::tests::sixtyfps_mock_elapsed_time(ms as _);
-    Ok(JsUndefined::new().as_value(&mut cx))
-}
-
-#[cfg(feature = "testing")]
-fn init_testing_backend(mut cx: FunctionContext) -> JsResult<JsValue> {
-    sixtyfps_rendering_backend_testing::init();
     Ok(JsUndefined::new().as_value(&mut cx))
 }

--- a/sixtyfps_runtime/interpreter/Cargo.toml
+++ b/sixtyfps_runtime/interpreter/Cargo.toml
@@ -35,6 +35,7 @@ sixtyfps-rendering-backend-gl = { version = "=0.1.2", path = "../../sixtyfps_run
 
 [dev-dependencies]
 spin_on = "0.1"
+sixtyfps-rendering-backend-testing = { version = "=0.1.2", path = "../../sixtyfps_runtime/rendering_backends/testing" }
 
 [package.metadata.docs.rs]
 features = ["display-diagnostics"]

--- a/sixtyfps_runtime/interpreter/tests.rs
+++ b/sixtyfps_runtime/interpreter/tests.rs
@@ -10,6 +10,7 @@ LICENSE END */
 
 #[test]
 fn reuse_window() {
+    sixtyfps_rendering_backend_testing::init();
     use crate::{ComponentCompiler, SharedString, Value};
     let code = r#"
         MainWindow := Window {

--- a/tests/driver/nodejs/Cargo.toml
+++ b/tests/driver/nodejs/Cargo.toml
@@ -12,7 +12,7 @@ name = "test-driver-nodejs"
 
 [dev-dependencies]
 test_driver_lib = { path = "../driverlib" }
-sixtyfps-node = { path = "../../../api/sixtyfps-node/native", features = ["testing"] }
+sixtyfps-node = { path = "../../../api/sixtyfps-node/native" }
 lazy_static = "1.4.0"
 which = "4.0.2"
 tempfile = "3.2"

--- a/tests/driver/nodejs/nodejs.rs
+++ b/tests/driver/nodejs/nodejs.rs
@@ -54,7 +54,6 @@ pub fn test(testcase: &test_driver_lib::TestCase) -> Result<(), Box<dyn Error>> 
         r#"
                 const assert = require('assert').strict;
                 let sixtyfpslib = require(String.raw`{sixtyfpspath}`);
-                sixtyfpslib.private_api.init_testing_backend();
                 let sixtyfps = require(String.raw`{path}`);
         "#,
         sixtyfpspath = sixtyfpspath.to_string_lossy(),


### PR DESCRIPTION
In the CI we set SIXTYFPS_NO_QT=1 and this change removes the testing
backend from the nodejs tests, in order to fix #419 .