### PR TITLE
Parser: make the parentheses around `if` element optional

### DIFF
--- a/docs/langref.md
+++ b/docs/langref.md
@@ -607,14 +607,14 @@ Example := Window {
 ## Conditional element
 
 Similar to `for`, the `if` construct can instantiate element only if a given condition is true.
-The syntax is `if (condition) : id := Element { ... }`
+The syntax is `if condition : id := Element { ... }`
 
 ```60
 Example := Window {
     height: 50px;
     width: 50px;
-    if (true) : foo := Rectangle { background: blue; }
-    if (false) : Rectangle { background: red; }
+    if true : foo := Rectangle { background: blue; }
+    if false : Rectangle { background: red; }
 }
 ```
 

--- a/sixtyfps_compiler/parser/element.rs
+++ b/sixtyfps_compiler/parser/element.rs
@@ -36,7 +36,7 @@ pub fn parse_element(p: &mut impl Parser) -> bool {
 /// property1: value; property2: value;
 /// sub := Sub { }
 /// for xx in model: Sub {}
-/// if (condition) : Sub {}
+/// if condition : Sub {}
 /// clicked => {}
 /// callback foobar;
 /// property<int> width;
@@ -73,7 +73,7 @@ pub fn parse_element_content(p: &mut impl Parser) {
                 SyntaxKind::Identifier if p.peek().as_str() == "property" => {
                     parse_property_declaration(&mut *p);
                 }
-                SyntaxKind::LParent if p.peek().as_str() == "if" => {
+                _ if p.peek().as_str() == "if" => {
                     parse_if_element(&mut *p);
                 }
                 SyntaxKind::LBracket if p.peek().as_str() == "states" => {
@@ -168,19 +168,15 @@ fn parse_repeated_element(p: &mut impl Parser) {
 /// if (condition) : Elem { }
 /// if (foo ? bar : xx) : Elem { foo:bar; Elem {}}
 /// if (true) : foo := Elem {}
+/// if true && true : Elem {}
 /// ```
 /// Must consume at least one token
 fn parse_if_element(p: &mut impl Parser) {
     debug_assert_eq!(p.peek().as_str(), "if");
     let mut p = p.start_node(SyntaxKind::ConditionalElement);
     p.consume(); // "if"
-    if !p.expect(SyntaxKind::LParent) {
-        drop(p.start_node(SyntaxKind::Expression));
-        drop(p.start_node(SyntaxKind::SubElement).start_node(SyntaxKind::Element));
-        return;
-    }
     parse_expression(&mut *p);
-    if !p.expect(SyntaxKind::RParent) || !p.expect(SyntaxKind::Colon) {
+    if !p.expect(SyntaxKind::Colon) {
         drop(p.start_node(SyntaxKind::SubElement).start_node(SyntaxKind::Element));
         return;
     }

--- a/sixtyfps_compiler/tests/syntax/lookup/if.60
+++ b/sixtyfps_compiler/tests/syntax/lookup/if.60
@@ -28,7 +28,7 @@ Hello := Rectangle {
     }
 
     if (width) : Rectangle {
-//      ^error{Cannot convert length to bool}
+//    ^error{Cannot convert length to bool}
 
     }
 }

--- a/sixtyfps_compiler/tests/syntax/parse_error/if0.60
+++ b/sixtyfps_compiler/tests/syntax/parse_error/if0.60
@@ -10,6 +10,9 @@ LICENSE END */
 
 TestCase := Window {
     if  //
-//    ^error{Parse error}
     Foo { }
+    //  ^error{expected Colon}
+    //  ^^error{Parse error}
   }
+//^error{expected Identifier}
+

--- a/sixtyfps_compiler/tests/syntax/parse_error/if1.60
+++ b/sixtyfps_compiler/tests/syntax/parse_error/if1.60
@@ -12,5 +12,6 @@ TestCase := Window {
     if (
 
   }
-//^error{Syntax error: expected RParent}
-//^^error{invalid expression}
+//^error{invalid expression}
+//^^error{expected RParent}
+//^^^error{expected Colon}

--- a/sixtyfps_compiler/tests/syntax/parse_error/if3.60
+++ b/sixtyfps_compiler/tests/syntax/parse_error/if3.60
@@ -10,6 +10,6 @@ LICENSE END */
 
 TestCase := Window {
     if goo
-//    ^error{Parse error}
 
-}
+  }
+//^error{expected Colon}

--- a/sixtyfps_compiler/tests/syntax/parse_error/if4.60
+++ b/sixtyfps_compiler/tests/syntax/parse_error/if4.60
@@ -11,6 +11,7 @@ LICENSE END */
 TestCase := Window {
     if (true false) : Rectangle { }
 //           ^error{Syntax error: expected RParent}
-//                ^^error{Parse error}
+//           ^^error{expected Colon}
+//                ^^^error{Parse error}
     Foo { }
   }


### PR DESCRIPTION
closes #466

Note: this does not change the `if` expression