### PR TITLE
Fix minimum size of line edit with placeholder text

### DIFF
--- a/sixtyfps_compiler/widgets/common/common.60
+++ b/sixtyfps_compiler/widgets/common/common.60
@@ -19,7 +19,7 @@ export LineEditInner := Rectangle {
     property enabled <=> input.enabled;
     property has-focus <=> input.has-focus;
     min-height: input.preferred-height;
-    min-width: 50px;
+    min-width: max(50px, placeholder.min-width);
     clip: true;
     forward-focus: input;
     input := TextInput {


### PR DESCRIPTION
A simple demonstrative test-case like

```
export App := Window {
    VerticalBox {
        LineEdit {
            placeholder-text: "Enter your name here";
        }
        Button {
            text: "Submit";
        }
     }
}
```

would not be wide enough - the place holder text would not be visible.