### PR TITLE
Make it possible to disable the GL backend in the CMake build

### DIFF
--- a/api/sixtyfps-cpp/CMakeLists.txt
+++ b/api/sixtyfps-cpp/CMakeLists.txt
@@ -10,6 +10,8 @@
 cmake_minimum_required(VERSION 3.16)
 project(SixtyFPS LANGUAGES CXX)
 
+include(CMakeDependentOption)
+
 include(FetchContent)
 FetchContent_Declare(
     Corrosion
@@ -72,12 +74,26 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.19.0)
         set(features "${features}" PARENT_SCOPE)
     endfunction()
 
+    function(define_cargo_dependent_feature cargo-feature description default depends_condition)
+        # turn foo-bar into SIXTYFPS_FEATURE_FOO_BAR
+        string(TOUPPER "${cargo-feature}" cmake_option)
+        string(REPLACE "-"  "_" cmake_option "${cmake_option}")
+        set(cmake_option "SIXTYFPS_FEATURE_${cmake_option}")
+        cmake_dependent_option("${cmake_option}" "${description}" ${default} ${depends_condition} OFF)
+        if(${cmake_option})
+            list(APPEND features ${cargo-feature})
+        endif()
+        set(features "${features}" PARENT_SCOPE)
+    endfunction()
+
     # Features that are mapped to features in the Rust crate. These and their
     # defaults need to be kept in sync with the Rust bit.
     define_cargo_feature(interpreter "Enable support for the SixtyFPS interpeter to load .60 files at run-time" ON)
-    define_cargo_feature(x11 "Enable X11 support when using GL backend" ON)
-    define_cargo_feature(wayland "Enable Wayland support when using the GL backend" OFF)
+
     define_cargo_feature(backend-gl "Enable OpenGL ES 2.0 based rendering backend" ON)
+    define_cargo_dependent_feature(x11 "Enable X11 support when using GL backend" ON SIXTYFPS_FEATURE_BACKEND_GL OFF)
+    define_cargo_dependent_feature(wayland "Enable Wayland support when using the GL backend" OFF SIXTYFPS_FEATURE_BACKEND_GL OFF)
+
     define_cargo_feature(backend-qt "Enable Qt based rendering backend" ON)
 
     set_property(

--- a/api/sixtyfps-cpp/Cargo.toml
+++ b/api/sixtyfps-cpp/Cargo.toml
@@ -28,4 +28,4 @@ testing = ["sixtyfps-rendering-backend-testing"]
 sixtyfps-corelib = { version = "=0.1.2", path="../../sixtyfps_runtime/corelib", features = ["ffi"] }
 sixtyfps-rendering-backend-default = { version = "=0.1.2", path="../../sixtyfps_runtime/rendering_backends/default" }
 sixtyfps-rendering-backend-testing = { version = "=0.1.2", path="../../sixtyfps_runtime/rendering_backends/testing", optional = true }
-sixtyfps-interpreter = { version = "=0.1.2", path="../../sixtyfps_runtime/interpreter", features = ["ffi"], optional = true }
+sixtyfps-interpreter = { version = "=0.1.2", path="../../sixtyfps_runtime/interpreter", default-features = false, features = ["ffi"], optional = true }

--- a/sixtyfps_runtime/interpreter/Cargo.toml
+++ b/sixtyfps_runtime/interpreter/Cargo.toml
@@ -14,10 +14,15 @@ path = "lib.rs"
 [features]
 display-diagnostics = ["sixtyfps-compilerlib/display-diagnostics"]
 ffi = ["spin_on", "sixtyfps-corelib/ffi"]
+x11 = ["sixtyfps-rendering-backend-default/x11"]
+wayland = ["sixtyfps-rendering-backend-default/wayland"]
+backend-gl = ["sixtyfps-rendering-backend-default/sixtyfps-rendering-backend-gl"]
+backend-qt = ["sixtyfps-rendering-backend-default/sixtyfps-rendering-backend-qt"]
+default = ["backend-gl", "backend-qt"]
 
 [dependencies]
 sixtyfps-corelib = { version = "=0.1.2", path = "../corelib", features = ["rtti"] }
-sixtyfps-rendering-backend-default = { version = "=0.1.2", path = "../../sixtyfps_runtime/rendering_backends/default", features = ["sixtyfps-rendering-backend-gl"] }
+sixtyfps-rendering-backend-default = { version = "=0.1.2", path = "../../sixtyfps_runtime/rendering_backends/default" }
 vtable = { version = "0.1.1", path="../../helper_crates/vtable" }
 sixtyfps-compilerlib = { version = "=0.1.2", path = "../../sixtyfps_compiler" }
 lyon_path = { version = "0.17.3" }

--- a/sixtyfps_runtime/rendering_backends/default/Cargo.toml
+++ b/sixtyfps_runtime/rendering_backends/default/Cargo.toml
@@ -14,7 +14,6 @@ path = "lib.rs"
 [features]
 x11 = ["sixtyfps-rendering-backend-gl/x11"]
 wayland = ["sixtyfps-rendering-backend-gl/wayland"]
-default = ["sixtyfps-rendering-backend-gl"]
 
 [dependencies]
 sixtyfps-corelib = { version = "=0.1.2", path = "../../corelib" }


### PR DESCRIPTION
Even if SIXTYFPS_BACKEND_GL is set to OFF, we would default to enabling
X11, which translates to enabling the x11 feature, which in turn
implicitly activates the GL backend. In addition, the interpreter Rust
API crate also enables the GL backend in its defeaults.

In order to make it possible to turn off the GL backend, three changes are necessary:

* The default backend no more selects a default :-). Instead the Rust
  API crate, Rust interpreter API crate and the CMake project define
  the same features and defaults.
* The C++ crate depends on the interpreter without its defaults (which enable GL)
* In CMake the X11 and Wayland features become dependent options, that
  are only show in the CMake configure UI if the GL backend is enabled.
  This way a GL-disabled build won't also pass --features x11.