### PR TITLE
Allow the sixtyfps-compiler and sixtyfps-viewer to read from stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+ - sixtyfps-compiler and sixtyfps-viewer can read the .60 file content from stdin by passing `-`
+
 ### Fixed
 
 ## [0.1.2] - 2021-09-09

--- a/sixtyfps_runtime/interpreter/api.rs
+++ b/sixtyfps_runtime/interpreter/api.rs
@@ -516,6 +516,8 @@ impl ComponentCompiler {
     ///
     /// Diagnostics from previous calls are cleared when calling this function.
     ///
+    /// If the path is `"-"`, the file will be read from stdin.
+    ///
     /// This function is `async` but in practice, this is only asynchronous if
     /// [`Self::set_file_loader`] was called and its future is actually asynchronous.
     /// If that is not used, then it is fine to use a very simple executor, such as the one

--- a/tools/compiler/main.rs
+++ b/tools/compiler/main.rs
@@ -22,7 +22,7 @@ struct Cli {
     #[structopt(short = "I", name = "include path", number_of_values = 1)]
     include_paths: Vec<std::path::PathBuf>,
 
-    /// Path to .60 file
+    /// Path to .60 file ('-' for stdin)
     #[structopt(name = "file", parse(from_os_str))]
     path: std::path::PathBuf,
 

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -24,6 +24,7 @@ struct Cli {
     #[structopt(short = "I", name = "include path for other .60 files", number_of_values = 1)]
     include_paths: Vec<std::path::PathBuf>,
 
+    /// The .60 file to load ('-' for stdin)
     #[structopt(name = "path to .60 file", parse(from_os_str))]
     path: std::path::PathBuf,
 


### PR DESCRIPTION
By specifing `-` as a path