### PR TITLE
LSP Sublime Text: Fix '%YAML indicator is required'

### DIFF
--- a/docs/builtin_elements.md
+++ b/docs/builtin_elements.md
@@ -417,7 +417,7 @@ When not part of a layout, its width or height default to 100% of the parent ele
 * **`pressed`** (*bool*): Set to `true` by the TouchArea when the mouse is pressed over it.
 * **`has-hover`** (*bool*): Set to `true` by the TouchArea when the mouse is over it.
 * **`mouse-x`**, **`mouse-y`** (*length*): Set by the TouchArea to the position of the mouse within it.
-* **`pressed-x`**, **`mouse-y`** (*length*): Set to `true` by the TouchArea to the position of the mouse at the moment it was last pressed.
+* **`pressed-x`**, **`pressed-y`** (*length*): Set to `true` by the TouchArea to the position of the mouse at the moment it was last pressed.
 
 ### Callbacks
 

--- a/tools/lsp/sublime/SixtyFPS.sublime-syntax
+++ b/tools/lsp/sublime/SixtyFPS.sublime-syntax
@@ -1,3 +1,5 @@
+%YAML 1.2
+---
 # LICENSE BEGIN
 # This file is part of the SixtyFPS Project -- https://sixtyfps.io
 # Copyright (c) 2021 Olivier Goffart <olivier.goffart@sixtyfps.io>
@@ -7,8 +9,6 @@
 # This file is also available under commercial licensing terms.
 # Please contact info@sixtyfps.io for more information.
 # LICENSE END
-%YAML 1.2
----
 # See http://www.sublimetext.com/docs/3/syntax.html
 name: SixtyFPS
 file_extensions:


### PR DESCRIPTION
Also includes a minor doc fix.