### PR TITLE
Rewrite build system part of C++ header file generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ node_modules
 tools/figma_import/target
 tools/figma_import/figma_output
 *.code-workspace
-api/sixtyfps-cpp/generated_include

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 tools/figma_import/target
 tools/figma_import/figma_output
 *.code-workspace
+api/sixtyfps-cpp/generated_include

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+ - Due to changes in the build system, the C++ build now requires CMake >= 3.19.
+
 ### Added
 
  - sixtyfps-compiler and sixtyfps-viewer can read the .60 file content from stdin by passing `-`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ include(CTest)
 
 add_subdirectory(api/sixtyfps-cpp/)
 
-option(SIXTYFPS_BUILD_EXAMPLES "Build SixtyFPS Examples" ON)
+option(SIXTYFPS_BUILD_EXAMPLES "Build SixtyFPS Examples" OFF)
 add_feature_info(SIXTYFPS_BUILD_EXAMPLES SIXTYFPS_BUILD_EXAMPLES "configure whether to build the examples")
 
 if(SIXTYFPS_BUILD_EXAMPLES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # This file is also available under commercial licensing terms.
 # Please contact info@sixtyfps.io for more information.
 # LICENSE END
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.19)
 
 project(SixtyFPS LANGUAGES CXX)
 
@@ -39,9 +39,7 @@ if(SIXTYFPS_BUILD_EXAMPLES)
     if (SIXTYFPS_FEATURE_INTERPRETER)
         add_subdirectory(examples/qt_viewer/)
     endif()
-    # iot-dashboard uses fmtlib via FetchContent and 3.16 has a bug
-    # configuring it (issue #232)
-    if (SIXTYFPS_FEATURE_INTERPRETER AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.17.0)
+    if (SIXTYFPS_FEATURE_INTERPRETER)
         add_subdirectory(examples/iot-dashboard/)
     endif()
     if(BUILD_TESTING)

--- a/api/sixtyfps-cpp/CMakeLists.txt
+++ b/api/sixtyfps-cpp/CMakeLists.txt
@@ -7,7 +7,7 @@
 # This file is also available under commercial licensing terms.
 # Please contact info@sixtyfps.io for more information.
 # LICENSE END
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.19)
 project(SixtyFPS LANGUAGES CXX)
 
 include(FeatureSummary)
@@ -23,93 +23,85 @@ FetchContent_MakeAvailable(Corrosion)
 corrosion_import_crate(MANIFEST_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../Cargo.toml"
     CRATES sixtyfps-compiler sixtyfps-cpp xtask)
 
-if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.19.0)
-    # For the CMake build don't rely on qmake being in PATH but use CMake to locate Qt. This
-    # means usually CMAKE_PREFIX_PATH is set.
-    find_package(Qt5 5.15 QUIET COMPONENTS Core Widgets)
-    if (TARGET Qt5::qmake)
-        set_property(
-            TARGET sixtyfps-cpp
-            APPEND
-            PROPERTY CORROSION_ENVIRONMENT_VARIABLES
-            QMAKE=$<TARGET_PROPERTY:Qt5::qmake,LOCATION>
-        )
-    else()
-        set_property(
-            TARGET sixtyfps-cpp
-            APPEND
-            PROPERTY CORROSION_ENVIRONMENT_VARIABLES
-            SIXTYFPS_NO_QT=1
-        )
-    endif()
+# For the CMake build don't rely on qmake being in PATH but use CMake to locate Qt. This
+# means usually CMAKE_PREFIX_PATH is set.
+find_package(Qt5 5.15 QUIET COMPONENTS Core Widgets)
+if (TARGET Qt5::qmake)
+    set_property(
+        TARGET sixtyfps-cpp
+        APPEND
+        PROPERTY CORROSION_ENVIRONMENT_VARIABLES
+        QMAKE=$<TARGET_PROPERTY:Qt5::qmake,LOCATION>
+    )
+else()
+    set_property(
+        TARGET sixtyfps-cpp
+        APPEND
+        PROPERTY CORROSION_ENVIRONMENT_VARIABLES
+        SIXTYFPS_NO_QT=1
+    )
 endif()
 
-if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.19.0)
-    set_property(
-        TARGET xtask
-        PROPERTY CORROSION_USE_HOST_BUILD 1
-    )
-    set_property(
-        TARGET sixtyfps-compiler
-        PROPERTY CORROSION_USE_HOST_BUILD 1
-    )
-elseif(CMAKE_CROSSCOMPILING)
-    message(FATAL_ERROR "Cross-compiling SixtyFPS requires CMake 3.19 or newer")
-endif()
+set_property(
+    TARGET xtask
+    PROPERTY CORROSION_USE_HOST_BUILD 1
+)
+set_property(
+    TARGET sixtyfps-compiler
+    PROPERTY CORROSION_USE_HOST_BUILD 1
+)
 
 add_library(SixtyFPS INTERFACE)
 add_library(SixtyFPS::SixtyFPS ALIAS SixtyFPS)
 target_link_libraries(SixtyFPS INTERFACE sixtyfps-cpp)
 target_compile_features(SixtyFPS INTERFACE cxx_std_17)
 
-if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.19.0)
-    function(define_cargo_feature cargo-feature description default)
-        # turn foo-bar into SIXTYFPS_FEATURE_FOO_BAR
-        string(TOUPPER "${cargo-feature}" cmake_option)
-        string(REPLACE "-"  "_" cmake_option "${cmake_option}")
-        set(cmake_option "SIXTYFPS_FEATURE_${cmake_option}")
-        option("${cmake_option}" "${description}" ${default})
-        if(${cmake_option})
-            list(APPEND features ${cargo-feature})
-        endif()
-        set(features "${features}" PARENT_SCOPE)
-        add_feature_info(${cmake_option} ${cmake_option} ${description})
-    endfunction()
+function(define_cargo_feature cargo-feature description default)
+    # turn foo-bar into SIXTYFPS_FEATURE_FOO_BAR
+    string(TOUPPER "${cargo-feature}" cmake_option)
+    string(REPLACE "-"  "_" cmake_option "${cmake_option}")
+    set(cmake_option "SIXTYFPS_FEATURE_${cmake_option}")
+    option("${cmake_option}" "${description}" ${default})
+    if(${cmake_option})
+        list(APPEND features ${cargo-feature})
+    endif()
+    set(features "${features}" PARENT_SCOPE)
+    add_feature_info(${cmake_option} ${cmake_option} ${description})
+endfunction()
 
-    function(define_cargo_dependent_feature cargo-feature description default depends_condition)
-        # turn foo-bar into SIXTYFPS_FEATURE_FOO_BAR
-        string(TOUPPER "${cargo-feature}" cmake_option)
-        string(REPLACE "-"  "_" cmake_option "${cmake_option}")
-        set(cmake_option "SIXTYFPS_FEATURE_${cmake_option}")
-        cmake_dependent_option("${cmake_option}" "${description}" ${default} ${depends_condition} OFF)
-        if(${cmake_option})
-            list(APPEND features ${cargo-feature})
-        endif()
-        set(features "${features}" PARENT_SCOPE)
-        add_feature_info(${cmake_option} ${cmake_option} ${description})
-    endfunction()
+function(define_cargo_dependent_feature cargo-feature description default depends_condition)
+    # turn foo-bar into SIXTYFPS_FEATURE_FOO_BAR
+    string(TOUPPER "${cargo-feature}" cmake_option)
+    string(REPLACE "-"  "_" cmake_option "${cmake_option}")
+    set(cmake_option "SIXTYFPS_FEATURE_${cmake_option}")
+    cmake_dependent_option("${cmake_option}" "${description}" ${default} ${depends_condition} OFF)
+    if(${cmake_option})
+        list(APPEND features ${cargo-feature})
+    endif()
+    set(features "${features}" PARENT_SCOPE)
+    add_feature_info(${cmake_option} ${cmake_option} ${description})
+endfunction()
 
-    # Features that are mapped to features in the Rust crate. These and their
-    # defaults need to be kept in sync with the Rust bit.
-    define_cargo_feature(interpreter "Enable support for the SixtyFPS interpeter to load .60 files at run-time" ON)
+# Features that are mapped to features in the Rust crate. These and their
+# defaults need to be kept in sync with the Rust bit.
+define_cargo_feature(interpreter "Enable support for the SixtyFPS interpeter to load .60 files at run-time" ON)
 
-    define_cargo_feature(backend-gl "Enable OpenGL ES 2.0 based rendering backend" ON)
-    define_cargo_dependent_feature(x11 "Enable X11 support when using GL backend" ON SIXTYFPS_FEATURE_BACKEND_GL OFF)
-    define_cargo_dependent_feature(wayland "Enable Wayland support when using the GL backend" OFF SIXTYFPS_FEATURE_BACKEND_GL OFF)
+define_cargo_feature(backend-gl "Enable OpenGL ES 2.0 based rendering backend" ON)
+define_cargo_dependent_feature(x11 "Enable X11 support when using GL backend" ON SIXTYFPS_FEATURE_BACKEND_GL OFF)
+define_cargo_dependent_feature(wayland "Enable Wayland support when using the GL backend" OFF SIXTYFPS_FEATURE_BACKEND_GL OFF)
 
-    define_cargo_feature(backend-qt "Enable Qt based rendering backend" ON)
+define_cargo_feature(backend-qt "Enable Qt based rendering backend" ON)
 
-    set_property(
-        TARGET sixtyfps-cpp
-        PROPERTY CORROSION_FEATURES
-        ${features}    
-    )
-    set_property(
-        TARGET sixtyfps-cpp
-        PROPERTY CORROSION_NO_DEFAULT_FEATURES
-        ${features}    
-    )    
-endif()
+set_property(
+    TARGET sixtyfps-cpp
+    PROPERTY CORROSION_FEATURES
+    ${features}
+)
+set_property(
+    TARGET sixtyfps-cpp
+    PROPERTY CORROSION_NO_DEFAULT_FEATURES
+    ${features}
+)
 
 file(GLOB api_headers RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/include/"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/*.h")

--- a/api/sixtyfps-cpp/CMakeLists.txt
+++ b/api/sixtyfps-cpp/CMakeLists.txt
@@ -21,7 +21,7 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(Corrosion)
 corrosion_import_crate(MANIFEST_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../Cargo.toml"
-    CRATES sixtyfps-compiler sixtyfps-cpp xtask)
+    CRATES sixtyfps-compiler sixtyfps-cpp)
 
 # For the CMake build don't rely on qmake being in PATH but use CMake to locate Qt. This
 # means usually CMAKE_PREFIX_PATH is set.
@@ -43,9 +43,12 @@ else()
 endif()
 
 set_property(
-    TARGET xtask
-    PROPERTY CORROSION_USE_HOST_BUILD 1
+    TARGET sixtyfps-cpp
+    APPEND
+    PROPERTY CORROSION_ENVIRONMENT_VARIABLES
+    SIXTYFPS_GENERATED_INCLUDE_DIR="${CMAKE_CURRENT_BINARY_DIR}/generated_include/"
 )
+
 set_property(
     TARGET sixtyfps-compiler
     PROPERTY CORROSION_USE_HOST_BUILD 1
@@ -124,18 +127,6 @@ set(generated_headers
     ${CMAKE_CURRENT_BINARY_DIR}/generated_include/sixtyfps_interpreter_internal.h
 )
 
-file(GLOB generated_headers_dependencies
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../sixtyfps_runtime/corelib/*.rs")
-
-add_custom_target(
-    generated_headers_target
-    COMMAND
-    xtask cbindgen --output-dir "${CMAKE_CURRENT_BINARY_DIR}/generated_include/"
-    BYPRODUCTS ${generated_headers}
-    DEPENDS ${generated_headers_dependencies}
-)
-
-add_dependencies(SixtyFPS generated_headers_target)
 foreach(header IN LISTS generated_headers)
     set_property(TARGET SixtyFPS APPEND PROPERTY PUBLIC_HEADER ${header})
 endforeach()

--- a/api/sixtyfps-cpp/Cargo.toml
+++ b/api/sixtyfps-cpp/Cargo.toml
@@ -3,6 +3,7 @@ name = "sixtyfps-cpp"
 version = "0.1.2"
 authors = ["SixtyFPS <info@sixtyfps.io>"]
 edition = "2018"
+build = "build.rs"
 license = "GPL-3.0-only"
 description = "SixtyFPS C++ integration"
 repository = "https://github.com/sixtyfpsui/sixtyfps"
@@ -29,3 +30,8 @@ sixtyfps-corelib = { version = "=0.1.2", path="../../sixtyfps_runtime/corelib", 
 sixtyfps-rendering-backend-default = { version = "=0.1.2", path="../../sixtyfps_runtime/rendering_backends/default" }
 sixtyfps-rendering-backend-testing = { version = "=0.1.2", path="../../sixtyfps_runtime/rendering_backends/testing", optional = true }
 sixtyfps-interpreter = { version = "=0.1.2", path="../../sixtyfps_runtime/interpreter", default-features = false, features = ["ffi"], optional = true }
+
+[build-dependencies]
+cbindgen = "0.20"
+anyhow = "1.0"
+proc-macro2 = "1.0.11"

--- a/api/sixtyfps-cpp/Cargo.toml
+++ b/api/sixtyfps-cpp/Cargo.toml
@@ -9,6 +9,8 @@ description = "SixtyFPS C++ integration"
 repository = "https://github.com/sixtyfpsui/sixtyfps"
 homepage = "https://sixtyfps.io"
 publish = false
+# prefix used to convey path to generated includes to the C++ test driver
+links = "sixtyfps_cpp"
 
 [lib]
 path = "lib.rs"

--- a/api/sixtyfps-cpp/README.md
+++ b/api/sixtyfps-cpp/README.md
@@ -25,7 +25,7 @@ First you need to install the prerequisites:
 
 * Install Rust by following the [Rust Getting Started Guide](https://www.rust-lang.org/learn/get-started). Once this is done,
   you should have the ```rustc``` compiler and the ```cargo``` build system installed in your path.
-* **cmake** (3.16 or newer)
+* **cmake** (3.19 or newer)
 * A C++ compiler that supports C++17 (e.g., **MSVC 2019** on Windows)
 
 You can include SixtyFPS in your CMake project using CMake's `FetchContent` feature. Insert the following snippet into your
@@ -98,7 +98,7 @@ in locating the package.
 A typical example looks like this:
 
 ```cmake
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.19)
 project(my_application LANGUAGES CXX)
 
 # Note: Use find_package(SixtyFPS) instead of the following three commands, if you prefer the package

--- a/api/sixtyfps-cpp/build.rs
+++ b/api/sixtyfps-cpp/build.rs
@@ -20,8 +20,12 @@ fn main() -> Result<(), anyhow::Error> {
         manifest_dir.to_string_lossy()
     ));
 
-    let output_dir = std::env::var_os("SIXTYFPS_GENERATED_INCLUDE_DIR")
-        .unwrap_or_else(|| Path::new(&manifest_dir).join("generated_include").into());
+    let output_dir = std::env::var_os("SIXTYFPS_GENERATED_INCLUDE_DIR").unwrap_or_else(|| {
+        Path::new(&std::env::var_os("OUT_DIR").unwrap()).join("generated_include").into()
+    });
+    let output_dir = Path::new(&output_dir);
 
-    cbindgen::gen_all(&root_dir, &Path::new(&output_dir))
+    println!("cargo:GENERATED_INCLUDE_DIR={}", output_dir.display());
+
+    cbindgen::gen_all(&root_dir, &output_dir)
 }

--- a/api/sixtyfps-cpp/build.rs
+++ b/api/sixtyfps-cpp/build.rs
@@ -1,0 +1,27 @@
+/* LICENSE BEGIN
+    This file is part of the SixtyFPS Project -- https://sixtyfps.io
+    Copyright (c) 2021 Olivier Goffart <olivier.goffart@sixtyfps.io>
+    Copyright (c) 2021 Simon Hausmann <simon.hausmann@sixtyfps.io>
+
+    SPDX-License-Identifier: GPL-3.0-only
+    This file is also available under commercial licensing terms.
+    Please contact info@sixtyfps.io for more information.
+LICENSE END */
+
+use std::path::Path;
+mod cbindgen;
+
+fn main() -> Result<(), anyhow::Error> {
+    let manifest_dir = std::env::var_os("CARGO_MANIFEST_DIR").unwrap();
+
+    // Go from $root/api/sixtyfps-cpp down to $root
+    let root_dir = Path::new(&manifest_dir).ancestors().nth(2).expect(&format!(
+        "Failed to locate root directory, relative to {}",
+        manifest_dir.to_string_lossy()
+    ));
+
+    let output_dir = std::env::var_os("SIXTYFPS_GENERATED_INCLUDE_DIR")
+        .unwrap_or_else(|| Path::new(&manifest_dir).join("generated_include").into());
+
+    cbindgen::gen_all(&root_dir, &Path::new(&output_dir))
+}

--- a/api/sixtyfps-cpp/docs/cmake.md
+++ b/api/sixtyfps-cpp/docs/cmake.md
@@ -14,7 +14,7 @@ First you need to install the prerequisites:
 
 * Install Rust by following the [Rust Getting Started Guide](https://www.rust-lang.org/learn/get-started). Once this is done,
   you should have the ```rustc``` compiler and the ```cargo``` build system installed in your path.
-* **cmake** (3.16 or newer)
+* **cmake** (3.19 or newer)
 * A C++ compiler that supports C++17 (e.g., **MSVC 2019** on Windows)
 
 You can include SixtyFPS in your CMake project using CMake's [`FetchContent`](https://cmake.org/cmake/help/latest/module/FetchContent.html) feature.

--- a/api/sixtyfps-cpp/docs/getting_started.md
+++ b/api/sixtyfps-cpp/docs/getting_started.md
@@ -11,7 +11,7 @@ Once SixtyFPS is built, you can use it in your CMake application or library targ
 A typical example looks like this:
 
 ```cmake
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.19)
 project(my_application LANGUAGES CXX)
 
 # Note: Use find_package(SixtyFPS) instead of the following three commands,

--- a/docs/building.md
+++ b/docs/building.md
@@ -34,7 +34,7 @@ You can still not build it by doing `cargo build --workspace --exclude sixtyfps-
 
 ### For the C++ dev (optional)
 
-* **cmake** (3.16 or newer)
+* **cmake** (3.19 or newer)
 * A C++ compiler that can do C++17 (e.g., **MSVC 2019** on Windows)
 
 ## Testing

--- a/docs/tutorial/cpp/src/getting_started.md
+++ b/docs/tutorial/cpp/src/getting_started.md
@@ -3,7 +3,7 @@
 In this tutorial, we use C++ as the host programming language. We also support other programming languages like
 [Rust](https://sixtyfps.io/docs/rust/sixtyfps/) or [JavaScript](https://sixtyfps.io/docs/node/).
 
-You will need a development environment that can compile C++17 with CMake 3.16.
+You will need a development environment that can compile C++17 with CMake 3.19.
 We do not provide binaries of SixtyFPS yet, so we will use the CMake integration that will automatically build
 the tools and library from source. Since it is implemented in the Rust programming language, this means that
 you also need to install a Rust compiler (1.48). You can easily install a Rust compiler
@@ -14,7 +14,7 @@ In a new directory, we create a new `CMakeLists.txt` file.
 
 ```cmake
 # CMakeLists.txt
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.19)
 project(memory LANGUAGES CXX)
 
 include(FetchContent)

--- a/examples/memory/CMakeLists.txt
+++ b/examples/memory/CMakeLists.txt
@@ -7,7 +7,7 @@
 # This file is also available under commercial licensing terms.
 # Please contact info@sixtyfps.io for more information.
 # LICENSE END
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.19)
 project(memory LANGUAGES CXX)
 
 if (NOT TARGET SixtyFPS::SixtyFPS)

--- a/tests/driver/cpp/Cargo.toml
+++ b/tests/driver/cpp/Cargo.toml
@@ -10,9 +10,11 @@ license = "GPL-3.0-only"
 path = "main.rs"
 name = "test-driver-cpp"
 
+[dependencies]
+sixtyfps-cpp = { path = "../../../api/sixtyfps-cpp", features = ["testing"] }
+
 [dev-dependencies]
 sixtyfps-compilerlib = { path = "../../../sixtyfps_compiler", features = ["cpp", "display-diagnostics"] }
-sixtyfps-cpp = { path = "../../../api/sixtyfps-cpp", features = ["testing"] }
 cc = "1.0.54"
 tempfile = "3"
 scopeguard = "1.1.0"

--- a/tests/driver/cpp/build.rs
+++ b/tests/driver/cpp/build.rs
@@ -8,7 +8,7 @@
     Please contact info@sixtyfps.io for more information.
 LICENSE END */
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// The root dir of the git repository
 fn root_dir() -> PathBuf {
@@ -34,13 +34,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("cargo:rustc-env=CPP_LIB_PATH={}", target_dir.display());
 
+    let generated_include_dir = std::env::var_os("DEP_SIXTYFPS_CPP_GENERATED_INCLUDE_DIR")
+        .expect("the sixtyfps-cpp crate needs to provide the meta-data that points to the directory with the generated includes");
+    println!(
+        "cargo:rustc-env=GENERATED_CPP_HEADERS_PATH={}",
+        Path::new(&generated_include_dir).display()
+    );
     let root_dir = root_dir();
     println!(
         "cargo:rustc-env=CPP_API_HEADERS_PATH={}/api/sixtyfps-cpp/include",
-        root_dir.display()
-    );
-    println!(
-        "cargo:rustc-env=GENERATED_CPP_HEADERS_PATH={}/api/sixtyfps-cpp/generated_include",
         root_dir.display()
     );
 

--- a/tests/driver/cpp/build.rs
+++ b/tests/driver/cpp/build.rs
@@ -10,9 +10,6 @@ LICENSE END */
 use std::io::Write;
 use std::path::PathBuf;
 
-#[path = "../../../xtask/src/cbindgen.rs"]
-mod cbindgen;
-
 /// The root dir of the git repository
 fn root_dir() -> PathBuf {
     let mut root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -37,23 +34,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("cargo:rustc-env=CPP_LIB_PATH={}", target_dir.display());
 
-    let mut include_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
-    include_dir.push("include");
-    println!("cargo:rustc-env=GENERATED_CPP_HEADERS_PATH={}", include_dir.display());
-    cbindgen::gen_all(&root_dir(), &include_dir)?;
-    // re-run cbindgen if files changes
     let root_dir = root_dir();
-    println!("cargo:rerun-if-changed={}/sixtyfps_runtime/corelib/", root_dir.display());
-    for entry in std::fs::read_dir(root_dir.join("sixtyfps_runtime/corelib/"))? {
-        let entry = entry?;
-        if entry.path().extension().map_or(false, |e| e == "rs") {
-            println!("cargo:rerun-if-changed={}", entry.path().display());
-        }
-    }
-    println!("cargo:rerun-if-changed={}/api/sixtyfps-cpp/lib.rs", root_dir.display());
-
     println!(
         "cargo:rustc-env=CPP_API_HEADERS_PATH={}/api/sixtyfps-cpp/include",
+        root_dir.display()
+    );
+    println!(
+        "cargo:rustc-env=GENERATED_CPP_HEADERS_PATH={}/api/sixtyfps-cpp/generated_include",
         root_dir.display()
     );
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 
 [dependencies]
 structopt = "0.3.14"
-cbindgen = "0.20"
 cargo_metadata = "0.14"
 anyhow = "1.0"
 lazy_static = "1.4.0"
@@ -16,4 +15,3 @@ regex = "1.4"
 toml_edit = "0.2.0"
 xshell = "0.1.6"
 serde_json = "1.0"
-proc-macro2 = "1.0.11"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -9,10 +9,9 @@
 LICENSE END */
 use anyhow::Context;
 use std::error::Error;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use structopt::StructOpt;
 
-mod cbindgen;
 mod cppdocs;
 mod license_headers_check;
 mod nodepackage;
@@ -23,8 +22,6 @@ pub enum TaskCommand {
     CheckLicenseHeaders(license_headers_check::LicenseHeaderCheck),
     #[structopt(name = "cppdocs")]
     CppDocs(CppDocsCommand),
-    #[structopt(name = "cbindgen")]
-    Cbindgen(CbindgenCommand),
     #[structopt(name = "node_package")]
     NodePackage,
 }
@@ -34,12 +31,6 @@ pub enum TaskCommand {
 pub struct ApplicationArguments {
     #[structopt(subcommand)]
     pub command: TaskCommand,
-}
-
-#[derive(Debug, StructOpt)]
-pub struct CbindgenCommand {
-    #[structopt(long)]
-    output_dir: String,
 }
 
 #[derive(Debug, StructOpt)]
@@ -94,7 +85,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     match ApplicationArguments::from_args().command {
         TaskCommand::CheckLicenseHeaders(cmd) => cmd.check_license_headers()?,
         TaskCommand::CppDocs(cmd) => cppdocs::generate(cmd.show_warnings)?,
-        TaskCommand::Cbindgen(cmd) => cbindgen::gen_all(&root_dir(), Path::new(&cmd.output_dir))?,
         TaskCommand::NodePackage => nodepackage::generate()?,
     };
 


### PR DESCRIPTION
This first bumps the cmake version and then moves the cbindgen xtask into sixtyfps-cpp's build.rs.

The CMake bump could - in theory - be omitted, but short of the ability to forward environment variables to the corrosion build, we would have to generate header files in the source directory, which is also a kind of boo-boo :)