### PR TITLE
Add sixtyfps::Window::show_fullscreen() and show_normal()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this project will be documented in this file.
  - sixtyfps-viewer gained ability to read or save the property values to a json file with `--save-data` and `--load-data`
  - `sixtyfps::Image` has now a `path()` accessor function in Rust and C++ to access the optional path
    of the file on disk that's backing the image.
+ - `sixtyfps::Window::show_fullscreen()` in Rust/C++/JavaSCript allows showing the window in full screen size. The
+   sibling function `show_normal()` can be used to exit fullscreen mode and show the window with its intrinsic size
+   and window decorations.
 
 ### Fixed
 

--- a/api/sixtyfps-cpp/cbindgen.rs
+++ b/api/sixtyfps-cpp/cbindgen.rs
@@ -243,6 +243,7 @@ fn gen_corelib(root_dir: &Path, include_dir: &Path) -> anyhow::Result<()> {
             "sixtyfps_windowrc_drop",
             "sixtyfps_windowrc_clone",
             "sixtyfps_windowrc_show",
+            "sixtyfps_windowrc_show_with_state",
             "sixtyfps_windowrc_hide",
             "sixtyfps_windowrc_get_scale_factor",
             "sixtyfps_windowrc_set_scale_factor",

--- a/api/sixtyfps-cpp/include/sixtyfps.h
+++ b/api/sixtyfps-cpp/include/sixtyfps.h
@@ -107,6 +107,10 @@ public:
     }
 
     void show() const { sixtyfps_windowrc_show(&inner); }
+    void show_with_state(cbindgen_private::WindowState target_state) const
+    {
+        sixtyfps_windowrc_show_with_state(&inner, target_state);
+    }
     void hide() const { sixtyfps_windowrc_hide(&inner); }
 
     float scale_factor() const { return sixtyfps_windowrc_get_scale_factor(&inner); }
@@ -314,6 +318,14 @@ public:
 
     /// Registers the window with the windowing system in order to make it visible on the screen.
     void show() { inner.show(); }
+    /// Registers the window with the windowing system in order to make it visible on the screen
+    /// with its intrinsic size and with window decorations. If the window was previously shown
+    /// in full screen size, then it will exit fullscreen mode.
+    void show_normal() { inner.show_with_state(cbindgen_private::WindowState::Normal); }
+
+    /// Registers the window with the windowing system in order to make it visible on the screen
+    /// with a size to cover the entire screen and without window decorations.
+    void show_fullscreen() { inner.show_with_state(cbindgen_private::WindowState::Fullscreen); }
     /// De-registers the window from the windowing system, therefore hiding it.
     void hide() { inner.hide(); }
 
@@ -404,7 +416,8 @@ inline bool operator!=(const LayoutInfo &a, const LayoutInfo &b)
 
 namespace private_api {
 /// Access the layout cache of an item within a repeater
-inline float layout_cache_access(const SharedVector<float> &cache, int offset, int repeater_index) {
+inline float layout_cache_access(const SharedVector<float> &cache, int offset, int repeater_index)
+{
     size_t idx = size_t(cache[offset]) + repeater_index * 2;
     return idx < cache.size() ? cache[idx] : 0;
 }
@@ -447,7 +460,8 @@ public:
     /// The default implementation will print a warning to stderr.
     ///
     /// If the model can update the data, it should also call `row_changed`
-    virtual void set_row_data(int, const ModelData &) {
+    virtual void set_row_data(int, const ModelData &)
+    {
         std::cerr << "Model::set_row_data was called on a read-only model" << std::endl;
     };
 
@@ -844,7 +858,8 @@ void invoke_from_event_loop(Functor f)
 /// }
 /// ```
 template<typename Functor>
-auto blocking_invoke_from_event_loop(Functor f) -> std::invoke_result_t<Functor> {
+auto blocking_invoke_from_event_loop(Functor f) -> std::invoke_result_t<Functor>
+{
     std::optional<std::invoke_result_t<Functor>> result;
     std::mutex mtx;
     std::condition_variable cv;

--- a/api/sixtyfps-node/lib/index.ts
+++ b/api/sixtyfps-node/lib/index.ts
@@ -63,6 +63,8 @@ class Component {
 
 interface Window {
     show(): void;
+    show_normal(): void;
+    show_fullscreen(): void;
     hide(): void;
 }
 

--- a/api/sixtyfps-node/native/lib.rs
+++ b/api/sixtyfps-node/native/lib.rs
@@ -11,7 +11,7 @@ use core::cell::RefCell;
 use neon::prelude::*;
 use rand::RngCore;
 use sixtyfps_compilerlib::langtype::Type;
-use sixtyfps_corelib::window::WindowHandleAccess;
+use sixtyfps_corelib::window::{WindowHandleAccess, WindowState};
 use sixtyfps_corelib::{ImageInner, SharedVector};
 
 mod js_model;
@@ -484,6 +484,22 @@ declare_types! {
             let window = cx.borrow(&this, |x| x.0.as_ref().cloned());
             let window = window.ok_or(()).or_else(|()| cx.throw_error("Invalid type"))?;
             window.show();
+            Ok(JsUndefined::new().as_value(&mut cx))
+        }
+
+        method show_normal(mut cx) {
+            let this = cx.this();
+            let window = cx.borrow(&this, |x| x.0.as_ref().cloned());
+            let window = window.ok_or(()).or_else(|()| cx.throw_error("Invalid type"))?;
+            window.show_with_state(WindowState::Normal);
+            Ok(JsUndefined::new().as_value(&mut cx))
+        }
+
+        method show_fullscreen(mut cx) {
+            let this = cx.this();
+            let window = cx.borrow(&this, |x| x.0.as_ref().cloned());
+            let window = window.ok_or(()).or_else(|()| cx.throw_error("Invalid type"))?;
+            window.show_with_state(WindowState::Fullscreen);
             Ok(JsUndefined::new().as_value(&mut cx))
         }
 

--- a/sixtyfps_runtime/rendering_backends/testing/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/testing/lib.rs
@@ -20,7 +20,7 @@ use image::GenericImageView;
 use sixtyfps_corelib::component::ComponentRc;
 use sixtyfps_corelib::graphics::{Image, Point, Size};
 use sixtyfps_corelib::slice::Slice;
-use sixtyfps_corelib::window::{PlatformWindow, Window};
+use sixtyfps_corelib::window::{PlatformWindow, Window, WindowState};
 use sixtyfps_corelib::ImageInner;
 use std::path::Path;
 use std::pin::Pin;
@@ -104,11 +104,15 @@ impl Default for TestingWindow {
     }
 }
 impl PlatformWindow for TestingWindow {
-    fn show(self: Rc<Self>) {
+    fn show(self: Rc<Self>, _target_state: WindowState) {
         unimplemented!("showing a testing window")
     }
 
     fn hide(self: Rc<Self>) {}
+
+    fn is_visible(&self) -> bool {
+        false
+    }
 
     fn request_redraw(&self) {}
 


### PR DESCRIPTION
This adds the API that was missing to programmatically create
full-screen apps.

The API surface for Rust, C++ and NodeJS are show_normal() and
show_fullscreen() as new functions in the Window type.