### PR TITLE
Initial support for mmapping fonts directly into femtovg

### DIFF
--- a/sixtyfps_runtime/rendering_backends/gl/Cargo.toml
+++ b/sixtyfps_runtime/rendering_backends/gl/Cargo.toml
@@ -27,7 +27,7 @@ rgb = "0.8"
 imgref = "1.6.1"
 vtable = { version = "0.1", path = "../../../helper_crates/vtable" }
 by_address = "1.0.4"
-femtovg = { version = "0.2.5" }
+femtovg = { version = "0.2.6" }
 euclid = "0.22.1"
 pin-weak = "1"
 scoped-tls-hkt = "0.1"
@@ -56,6 +56,7 @@ winit = { version = "0.25", default-features = false }
 glutin = { version = "0.27", default-features = false }
 glow = { version = "0.11.0", default-features = false }
 fontdb = { version = "0.6.2", features = ["memmap"] }
+memmap2 = { version = "0.3.1" }
 
 [target.'cfg(target_family = "windows")'.dependencies]
 font-kit = { version = "0.10", features = [] }

--- a/sixtyfps_runtime/rendering_backends/gl/fonts.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/fonts.rs
@@ -292,9 +292,8 @@ impl FontCache {
                     .entry(path.clone())
                     .or_insert_with(|| {
                         let file = std::fs::File::open(path).ok().expect("unable to open ttf file");
-                        eprintln!("mmap {:#?} -> size {}", path, file.metadata().unwrap().len());
                         MMappedFont(
-                            // Safety: We map font files into memory that - while we neve unmap them - may
+                            // Safety: We map font files into memory that - while we never unmap them - may
                             // theoretically get corrupted/truncated by another process and then we'll crash
                             // and burn. In practice that should not happen though, font files are - at worst -
                             // removed by a package manager and they unlink instead of truncate, even when


### PR DESCRIPTION
This version doesn't require the change to fontdb yet, but uses the new
femtovg API to allow feeding in shared (mmapped) font data. On macOS
this saves 4-5 MB of ram just for the gallery, on my default Ubuntu it's
roughly ~40MB.