### PR TITLE
Fix support for OpenGL ES 2.0

### DIFF
--- a/sixtyfps_runtime/rendering_backends/gl/Cargo.toml
+++ b/sixtyfps_runtime/rendering_backends/gl/Cargo.toml
@@ -27,7 +27,7 @@ rgb = "0.8"
 imgref = "1.6.1"
 vtable = { version = "0.1", path = "../../../helper_crates/vtable" }
 by_address = "1.0.4"
-femtovg = { version = "0.2.6" }
+femtovg = { version = "0.2.7" }
 euclid = "0.22.1"
 pin-weak = "1"
 scoped-tls-hkt = "0.1"


### PR DESCRIPTION
We default to querying GlLatest from glutin, which might run into a code
path in glutin's `bind_and_get_api` in `egl/mod.rs` that will return
None as version and pass that to `choose_fbconfig`. That function will
panic with unimplemented() if the bound API is GLES, because we need to
know which version of GLES. The bound API in turn might be GLES if
desktop GL is not supported.

To accomodate for this situation, this patch changes the GL context
creation logic to first try explicitly GLES 2.0 and then fall back to
the GlLatest variants.

In addition this pulls in a newer version of femtovg to fix FBO
rendering with stencil with GLES 2.0.