### PR TITLE
Tweak dialog error messages

### DIFF
--- a/sixtyfps_compiler/passes/lower_layout.rs
+++ b/sixtyfps_compiler/passes/lower_layout.rs
@@ -489,7 +489,7 @@ fn lower_dialog_layout(
             }
         } else if main_widget.is_some() {
             diag.push_error(
-                "A Dialog should have a single child element that is not StandardButton".into(),
+                "A Dialog can have only one child element that is not a StandardButton".into(),
                 &*layout_child.borrow(),
             );
         } else {
@@ -509,7 +509,7 @@ fn lower_dialog_layout(
         );
     } else {
         diag.push_error(
-            "A Dialog should have a single child element that is not StandardButton".into(),
+            "A Dialog must have a single child element that is not StandardButton".into(),
             &*dialog_element.borrow(),
         );
     }

--- a/sixtyfps_compiler/tests/syntax/basic/dialog.60
+++ b/sixtyfps_compiler/tests/syntax/basic/dialog.60
@@ -14,7 +14,7 @@ MyDiag1 := Dialog {
     Rectangle {}
     StandardButton { kind: cancel; }
     Rectangle {}
-//  ^error{A Dialog should have a single child element that is not StandardButton}
+//  ^error{A Dialog can have only one child element that is not a StandardButton}
 }
 
 MyDiag2 := Dialog {
@@ -44,7 +44,7 @@ MyDiag3 := Dialog {
 Test := Rectangle {
     MyDiag1 {}
     MyDiag2 {} // FIXME: not the best place for the error
-//  ^error{A Dialog should have a single child element that is not StandardButton}
+//  ^error{A Dialog must have a single child element that is not StandardButton}
     MyDiag3 {}
 }
 

--- a/sixtyfps_compiler/tests/syntax/basic/dialog2.60
+++ b/sixtyfps_compiler/tests/syntax/basic/dialog2.60
@@ -11,7 +11,7 @@ LICENSE END */
 import { StandardButton } from "sixtyfps_widgets.60";
 
 Test := Dialog {
-//     ^error{A Dialog should have a single child element that is not StandardButton}
+//     ^error{A Dialog must have a single child element that is not StandardButton}
     StandardButton { kind: ok; }
     StandardButton { }
 //  ^error{The `kind` property of the StandardButton in a Dialog must be set}


### PR DESCRIPTION
Replace "should" with "must"/"can only" to emphasize that this is an error.