### PR TITLE
GL backend: Fix rendering of SVGs with text inside

### DIFF
--- a/sixtyfps_runtime/rendering_backends/gl/Cargo.toml
+++ b/sixtyfps_runtime/rendering_backends/gl/Cargo.toml
@@ -37,7 +37,7 @@ lyon_path = "0.17.3"
 copypasta = { version = "0.7.0", default-features = false }
 fontdb = { version = "0.6.2", default-features = false }
 resvg = { version= "0.17", optional = true, default-features = false }
-usvg = { version= "0.17", optional = true, default-features = false }
+usvg = { version= "0.17", optional = true, default-features = false, features = ["text"] }
 tiny-skia = { version= "0.6", optional = true, default-features = false }
 derive_more = "0.99.5"
 # Use the same version was femtovg's rustybuzz, to avoid duplicate crates
@@ -56,6 +56,7 @@ winit = { version = "0.25", default-features = false }
 glutin = { version = "0.27", default-features = false }
 fontdb = { version = "0.6.2", features = ["memmap"] }
 memmap2 = { version = "0.3.1" }
+usvg = { version= "0.17", optional = true, default-features = false, features = ["text", "memmap-fonts"] }
 
 [target.'cfg(target_family = "windows")'.dependencies]
 font-kit = { version = "0.10", features = [] }

--- a/sixtyfps_runtime/rendering_backends/gl/fonts.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/fonts.rs
@@ -170,7 +170,7 @@ pub struct FontCache {
     // coverage of the font.
     loaded_font_coverage: HashMap<fontdb::ID, GlyphCoverage>,
     pub(crate) text_context: TextContext,
-    available_fonts: fontdb::Database,
+    pub(crate) available_fonts: fontdb::Database,
     available_families: HashSet<SharedString>,
     #[cfg(not(any(
         target_family = "windows",


### PR DESCRIPTION
It works with the Qt backend, and it should work with the GL backend as
well. usvg supports it, uses the same underlying shaper and the API even
allows sharing the font database.