### PR TITLE
Further speed up font handling in the GL backend

### DIFF
--- a/sixtyfps_runtime/corelib/backend.rs
+++ b/sixtyfps_runtime/corelib/backend.rs
@@ -42,7 +42,7 @@ pub trait Backend: Send + Sync {
     /// font.
     fn register_font_from_memory(
         &'static self,
-        data: &[u8],
+        data: &'static [u8],
     ) -> Result<(), Box<dyn std::error::Error>>;
 
     /// This function can be used to register a custom TrueType font with SixtyFPS,

--- a/sixtyfps_runtime/rendering_backends/gl/Cargo.toml
+++ b/sixtyfps_runtime/rendering_backends/gl/Cargo.toml
@@ -35,9 +35,9 @@ smallvec = "1.4.1"
 once_cell = "1.5"
 lyon_path = "0.17.3"
 copypasta = { version = "0.7.0", default-features = false }
-fontdb = { version = "0.6.2", default-features = false }
-resvg = { version= "0.18", optional = true, default-features = false }
-usvg = { version= "0.18", optional = true, default-features = false, features = ["text"] }
+fontdb = { version = "0.7.0", default-features = false }
+resvg = { version= "0.19", optional = true, default-features = false }
+usvg = { version= "0.19", optional = true, default-features = false, features = ["text"] }
 tiny-skia = { version= "0.6", optional = true, default-features = false }
 derive_more = "0.99.5"
 # Use the same version was femtovg's rustybuzz, to avoid duplicate crates
@@ -54,9 +54,8 @@ winit = { version = "0.25", default-features = false, features = ["web-sys"] }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 winit = { version = "0.25", default-features = false }
 glutin = { version = "0.27", default-features = false }
-fontdb = { version = "0.6.2", features = ["memmap"] }
-memmap2 = { version = "0.5.0" }
-usvg = { version= "0.18", optional = true, default-features = false, features = ["text", "memmap-fonts"] }
+fontdb = { version = "0.7.0", features = ["memmap"] }
+usvg = { version= "0.19", optional = true, default-features = false, features = ["text", "memmap-fonts"] }
 
 [target.'cfg(target_family = "windows")'.dependencies]
 font-kit = { version = "0.10", features = [] }

--- a/sixtyfps_runtime/rendering_backends/gl/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/lib.rs
@@ -1455,7 +1455,7 @@ impl sixtyfps_corelib::backend::Backend for Backend {
 
     fn register_font_from_memory(
         &'static self,
-        data: &[u8],
+        data: &'static [u8],
     ) -> Result<(), Box<dyn std::error::Error>> {
         self::fonts::register_font_from_memory(data)
     }

--- a/sixtyfps_runtime/rendering_backends/qt/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/qt/lib.rs
@@ -157,7 +157,7 @@ impl sixtyfps_corelib::backend::Backend for Backend {
 
     fn register_font_from_memory(
         &'static self,
-        _data: &[u8],
+        _data: &'static [u8],
     ) -> Result<(), Box<dyn std::error::Error>> {
         #[cfg(not(no_qt))]
         {

--- a/sixtyfps_runtime/rendering_backends/testing/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/testing/lib.rs
@@ -45,7 +45,7 @@ impl sixtyfps_corelib::backend::Backend for TestingBackend {
 
     fn register_font_from_memory(
         &'static self,
-        _data: &[u8],
+        _data: &'static [u8],
     ) -> Result<(), Box<dyn std::error::Error>> {
         Ok(())
     }


### PR DESCRIPTION
Use the new fontdb API:

* When registering embedded fonts, we don't need to make a copy of the
  embedded font data anymore.
* We don't have to mmap the font files ourselves anymore, fontdb can
  do this now for us.