### PR TITLE
Fix granularity of run-time borrows in GL backend window handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
  - Fixed panic when using `TabWidget` with `Text` elements and the native style.
+ - Fixed panic when caling `hide()` on a `sixtyfps::Window` from within a callback triggered by keyboard/mouse input
+   when using the GL backend.
 
 ## [0.1.2] - 2021-09-09
 

--- a/sixtyfps_runtime/corelib/backend.rs
+++ b/sixtyfps_runtime/corelib/backend.rs
@@ -17,6 +17,7 @@ use std::rc::Rc;
 use crate::graphics::{Image, Size};
 use crate::window::Window;
 
+#[derive(Copy, Clone)]
 /// Behavior describing how the event loop should terminate.
 pub enum EventLoopQuitBehavior {
     /// Terminate the event loop when the last window was closed.

--- a/sixtyfps_runtime/rendering_backends/gl/event_loop.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/event_loop.rs
@@ -193,7 +193,6 @@ fn process_window_event(
     cursor_pos: &mut Point,
     pressed: &mut bool,
 ) {
-    corelib::animations::update_animations();
     let runtime_window = window.self_weak.upgrade().unwrap();
     match event {
         WindowEvent::Resized(size) => {
@@ -213,6 +212,7 @@ fn process_window_event(
             }
         }
         WindowEvent::ReceivedCharacter(ch) => {
+            corelib::animations::update_animations();
             // On Windows, X11 and Wayland sequences like Ctrl+C will send a ReceivedCharacter after the pressed keyboard input event,
             // with a control character. We choose not to forward those but try to use the current key code instead.
             let text: Option<SharedString> = if ch.is_control() {
@@ -240,6 +240,7 @@ fn process_window_event(
             runtime_window.set_focus(have_focus);
         }
         WindowEvent::KeyboardInput { ref input, .. } => {
+            corelib::animations::update_animations();
             window.currently_pressed_key_code.set(match input.state {
                 winit::event::ElementState::Pressed => input.virtual_keycode.clone(),
                 _ => None,
@@ -282,6 +283,7 @@ fn process_window_event(
             window.set_current_keyboard_modifiers(modifiers);
         }
         WindowEvent::CursorMoved { position, .. } => {
+            corelib::animations::update_animations();
             let position = position.to_logical(window.scale_factor() as f64);
             *cursor_pos = euclid::point2(position.x, position.y);
             window.process_mouse_input(MouseEvent::MouseMoved { pos: *cursor_pos });
@@ -290,11 +292,13 @@ fn process_window_event(
             // On the html canvas, we don't get the mouse move or release event when outside the canvas. So we have no choice but canceling the event
             #[cfg(target_arch = "wasm32")]
             if *pressed {
+                corelib::animations::update_animations();
                 *pressed = false;
                 window.process_mouse_input(MouseEvent::MouseExit);
             }
         }
         WindowEvent::MouseWheel { delta, .. } => {
+            corelib::animations::update_animations();
             let delta = match delta {
                 winit::event::MouseScrollDelta::LineDelta(lx, ly) => {
                     euclid::point2(lx * 60., ly * 60.)
@@ -307,6 +311,7 @@ fn process_window_event(
             window.process_mouse_input(MouseEvent::MouseWheel { pos: *cursor_pos, delta });
         }
         WindowEvent::MouseInput { state, button, .. } => {
+            corelib::animations::update_animations();
             let button = match button {
                 winit::event::MouseButton::Left => PointerEventButton::left,
                 winit::event::MouseButton::Right => PointerEventButton::right,
@@ -326,6 +331,7 @@ fn process_window_event(
             window.process_mouse_input(ev);
         }
         WindowEvent::Touch(touch) => {
+            corelib::animations::update_animations();
             let location = touch.location.to_logical(window.scale_factor() as f64);
             let pos = euclid::point2(location.x, location.y);
             let ev = match touch.phase {


### PR DESCRIPTION
When processing window specific events, or generally when accessing
the ALL_WINDOWS refcell, keep the time for borrow to an absolute
miniumum. That way any subsequent method calls may further acquire the
refcell.

This patch re-organizes the entire deeply nested window event handling
in a function with slightly less indentation.

Fixes a panic when calling hide on a Window from within a callback
handler.

Fixes #539