### PR TITLE
Add support for embedding data in generated C++ code

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -226,6 +226,10 @@ jobs:
         echo "CC=cl.exe" >> $GITHUB_ENV
         echo "CXX=cl.exe" >> $GITHUB_ENV
       if: matrix.os == 'windows-latest'
+    - name: Enable test coverage for resource embedding in C++ when building examples
+      if: matrix.os == 'ubuntu-20.04'
+      run: |
+          echo "SIXTYFPS_EMBED_RESOURCES=true" >> $GITHUB_ENV
     - name: C++ Build
       uses: lukka/run-cmake@v3.4
       with:

--- a/api/sixtyfps-cpp/include/sixtyfps.h
+++ b/api/sixtyfps-cpp/include/sixtyfps.h
@@ -863,12 +863,26 @@ auto blocking_invoke_from_event_loop(Functor f) -> std::invoke_result_t<Functor>
 namespace private_api {
 
 /// Registers a font by the specified path. The path must refer to an existing
-/// TrueType font font.
+/// TrueType font.
 /// \returns an empty optional on success, otherwise an error string
 inline std::optional<SharedString> register_font_from_path(const SharedString &path)
 {
     SharedString maybe_err;
     cbindgen_private::sixtyfps_register_font_from_path(&path, &maybe_err);
+    if (!maybe_err.empty()) {
+        return maybe_err;
+    } else {
+        return {};
+    }
+}
+
+/// Registers a font by the data. The data must be valid TrueType font data.
+/// \returns an empty optional on success, otherwise an error string
+inline std::optional<SharedString> register_font_from_data(const uint8_t *data, std::size_t len)
+{
+    SharedString maybe_err;
+    cbindgen_private::sixtyfps_register_font_from_data({ const_cast<uint8_t *>(data), len },
+                                                       &maybe_err);
     if (!maybe_err.empty()) {
         return maybe_err;
     } else {

--- a/api/sixtyfps-cpp/include/sixtyfps_image.h
+++ b/api/sixtyfps-cpp/include/sixtyfps_image.h
@@ -69,6 +69,9 @@ public:
     /// Returns false if \a a refers to the same image as \a b; true otherwise.
     friend bool operator!=(const Image &a, const Image &b) { return a.data != b.data; }
 
+    /// \private
+    explicit Image(cbindgen_private::types::Image inner) : data(inner) { }
+
 private:
     using Tag = cbindgen_private::types::ImageInner::Tag;
     using Data = cbindgen_private::types::Image;

--- a/api/sixtyfps-cpp/lib.rs
+++ b/api/sixtyfps-cpp/lib.rs
@@ -81,6 +81,20 @@ pub unsafe extern "C" fn sixtyfps_register_font_from_path(
     )
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn sixtyfps_register_font_from_data(
+    data: sixtyfps_corelib::slice::Slice<'static, u8>,
+    error_str: *mut sixtyfps_corelib::SharedString,
+) {
+    core::ptr::write(
+        error_str,
+        match crate::backend().register_font_from_memory(data.as_slice()) {
+            Ok(()) => Default::default(),
+            Err(err) => err.to_string().into(),
+        },
+    )
+}
+
 #[cfg(feature = "testing")]
 #[no_mangle]
 pub unsafe extern "C" fn sixtyfps_testing_init_backend() {

--- a/sixtyfps_compiler/generator/cpp.rs
+++ b/sixtyfps_compiler/generator/cpp.rs
@@ -604,11 +604,13 @@ pub fn generate(doc: &Document, diag: &mut BuildDiagnostics) -> Option<impl std:
 
             let mut init = "{ ".to_string();
 
+            use std::fmt::Write;
+
             for (index, byte) in data.iter().enumerate() {
                 if index > 0 {
                     init.push(',');
                 }
-                init.push_str(&format!("0x{:x}", byte));
+                write!(&mut init, "0x{:x}", byte).unwrap();
                 if index % 16 == 0 {
                     init.push('\n');
                 }

--- a/sixtyfps_compiler/generator/cpp.rs
+++ b/sixtyfps_compiler/generator/cpp.rs
@@ -582,7 +582,6 @@ fn handle_repeater(
                 model_data_type(&parent_element, diag)
             ),
             name: repeater_id,
-            init: None,
             ..Default::default()
         }),
     ));
@@ -847,12 +846,7 @@ fn generate_component(
         if property_decl.is_alias.is_none() {
             component_struct.members.push((
                 if component.is_global() { Access::Public } else { Access::Private },
-                Declaration::Var(Var {
-                    ty,
-                    name: cpp_name.into_owned(),
-                    init: None,
-                    ..Default::default()
-                }),
+                Declaration::Var(Var { ty, name: cpp_name.into_owned(), ..Default::default() }),
             ));
         }
     }
@@ -869,7 +863,6 @@ fn generate_component(
                 Declaration::Var(Var {
                     ty: "sixtyfps::private_api::Property<int>".into(),
                     name: "index".into(),
-                    init: None,
                     ..Default::default()
                 }),
             ));
@@ -879,7 +872,6 @@ fn generate_component(
                 Declaration::Var(Var {
                     ty: format!("sixtyfps::private_api::Property<{}>", cpp_model_data_type),
                     name: "model_data".into(),
-                    init: None,
                     ..Default::default()
                 }),
             ));
@@ -1327,7 +1319,6 @@ fn generate_component(
             Declaration::Var(Var {
                 ty: "static const sixtyfps::private_api::ComponentVTable".to_owned(),
                 name: "static_vtable".to_owned(),
-                init: None,
                 ..Default::default()
             }),
         ));

--- a/sixtyfps_compiler/generator/cpp.rs
+++ b/sixtyfps_compiler/generator/cpp.rs
@@ -1832,9 +1832,10 @@ fn compile_expression(
                 crate::expression_tree::ImageReference::AbsolutePath(path) => format!(r#"sixtyfps::Image::load_from_path(sixtyfps::SharedString(u8"{}"))"#, escape_string(path.as_str())),
                 crate::expression_tree::ImageReference::EmbeddedData { resource_id, extension } => {
                     let symbol = format!("sfps_embedded_resource_{}", resource_id);
-                    let data_slice = format!("sixtyfps::Slice<uint8_t>{{std::data({}), std::size({})}}", symbol, symbol);
-                    let extension_slice = format!("sixtyfps::Slice<uint8_t>{{const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(\"{}\")), {}}}", extension, extension.as_bytes().len());
-                    format!("sixtyfps::Image(sixtyfps::cbindgen_private::types::ImageInner::EmbeddedData({}, {}))", data_slice, extension_slice)
+                    format!(
+                        r#"sixtyfps::Image(sixtyfps::cbindgen_private::types::ImageInner::EmbeddedData(sixtyfps::Slice<uint8_t>{{std::data({}), std::size({})}}, sixtyfps::Slice<uint8_t>{{const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(u8"{}")), {}}}))"#,
+                        symbol, symbol, escape_string(extension), extension.as_bytes().len()
+                    )
                 }
             }
         }


### PR DESCRIPTION
This allows compiling with SIXTYFPS_EMBED_RESOURCES=true and
images/fonts are embedded as inline variables.

Generated data is emitted into the header file as

   inline uint8_t sfps_embedded_resources_123[789] = {
       0x1, 0x2, 0x3,
   };