### PR TITLE
viewer: Prettify help output

### DIFF
--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -31,12 +31,12 @@ struct Cli {
     path: std::path::PathBuf,
 
     /// The style name ('native', 'fluent', or 'ugly')
-    #[structopt(long, name = "style name", default_value)]
-    style: String,
+    #[structopt(long, name = "style name")]
+    style: Option<String>,
 
     /// The rendering backend
-    #[structopt(long, name = "backend", default_value)]
-    backend: String,
+    #[structopt(long, name = "backend")]
+    backend: Option<String>,
 
     /// Automatically watch the file system, and reload when it changes
     #[structopt(long)]
@@ -62,8 +62,8 @@ fn main() -> Result<()> {
         std::process::exit(-1);
     }
 
-    if !args.backend.is_empty() {
-        std::env::set_var("SIXTYFPS_BACKEND", &args.backend);
+    if let Some(backend) = &args.backend {
+        std::env::set_var("SIXTYFPS_BACKEND", backend);
     }
 
     let fswatcher = if args.auto_reload { Some(start_fswatch_thread(args.clone())?) } else { None };
@@ -135,8 +135,8 @@ fn init_compiler(
 ) -> sixtyfps_interpreter::ComponentCompiler {
     let mut compiler = sixtyfps_interpreter::ComponentCompiler::default();
     compiler.set_include_paths(args.include_paths.clone());
-    if !args.style.is_empty() {
-        compiler.set_style(args.style.clone());
+    if let Some(style) = &args.style {
+        compiler.set_style(style.clone());
     }
     if let Some(watcher) = fswatcher {
         notify::Watcher::watch(


### PR DESCRIPTION
The options in sixtyfps-viewer --help used to look like this:

```
OPTIONS:
        --backend <backend>                         The rendering backend [default: ]
    -I <include path for other .60 files>...
        --load-data <load data file>                Load properties from a json file ('-' for stdin)
        --save-data <save data file>                Store properties values in a json file at exit ('-' for stdout)
        --style <style name>                        The style name ('native', 'fluent', or 'ugly') [default: ]
```

This patch removes the useless "[default: ]" part. These are options,
so even without this text it should be very obvious that the `--style`
and the `--backend` parameters are indeed optional.