### PR TITLE
Array index

### DIFF
--- a/docs/langref.md
+++ b/docs/langref.md
@@ -257,6 +257,7 @@ Example := Window {
 ```
 
 * **`length`**: One can query the length of an array and model using the builtin `.length` property.
+* **`array[index]`**: Individual elements of an array can be retrieved using the `array[index]` syntax.
 
 ### Conversions
 

--- a/sixtyfps_compiler/expression_tree.rs
+++ b/sixtyfps_compiler/expression_tree.rs
@@ -513,9 +513,7 @@ impl Expression {
                 _ => Type::Invalid,
             },
             Expression::ArrayIndex { array, .. } => match array.ty() {
-                Type::Array(ty) => {
-                    (*ty).clone()
-                }
+                Type::Array(ty) => (*ty).clone(),
                 _ => Type::Invalid,
             },
             Expression::Cast { to, .. } => to.clone(),

--- a/sixtyfps_compiler/expression_tree.rs
+++ b/sixtyfps_compiler/expression_tree.rs
@@ -811,7 +811,7 @@ impl Expression {
             Expression::FunctionParameterReference { .. } => false,
             Expression::BuiltinMacroReference { .. } => true,
             Expression::StructFieldAccess { base, .. } => base.is_constant(),
-            Expression::ArrayIndex { array, .. } => array.is_constant(),
+            Expression::ArrayIndex { array, index } => array.is_constant() && index.is_constant(),
             Expression::Cast { from, .. } => from.is_constant(),
             Expression::CodeBlock(sub) => sub.len() == 1 && sub.first().unwrap().is_constant(),
             Expression::FunctionCall { function, arguments, .. } => {

--- a/sixtyfps_compiler/generator/cpp.rs
+++ b/sixtyfps_compiler/generator/cpp.rs
@@ -1681,7 +1681,7 @@ fn compile_expression(
         },
         Expression::ArrayIndex { array, index } => match array.ty() {
             Type::Array(_) => {
-                format!("({}).row_data({})", compile_expression(array, component), compile_expression(index, component))
+                format!("({})->row_data({})", compile_expression(array, component), compile_expression(index, component))
             }
             _ => panic!("Expression::ArrayIndex's base expression is not an Array type"),
         },

--- a/sixtyfps_compiler/generator/cpp.rs
+++ b/sixtyfps_compiler/generator/cpp.rs
@@ -1679,6 +1679,12 @@ fn compile_expression(
             }
             _ => panic!("Expression::ObjectAccess's base expression is not an Object type"),
         },
+        Expression::ArrayIndex { array, index } => match array.ty() {
+            Type::Array(_) => {
+                format!("({}).row_data({})", compile_expression(array, component), compile_expression(index, component))
+            }
+            _ => panic!("Expression::ArrayIndex's base expression is not an Array type"),
+        },
         Expression::Cast { from, to } => {
             let f = compile_expression(&*from, component);
             match (from.ty(), to) {

--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -1302,6 +1302,14 @@ fn compile_expression(expr: &Expression, component: &Rc<Component>) -> TokenStre
             }
             _ => panic!("Expression::ObjectAccess's base expression is not an Object type"),
         },
+        Expression::ArrayIndex { array, index } => match array.ty() {
+            Type::Array(ty) => {
+                let base_e = compile_expression(array, component);
+                let index_e = compile_expression(index, component);
+                quote!((#base_e).row_data(#index_e))
+            }
+            _ => panic!("Expression::ArrayIndex's base expression is not an Array type"),
+        },
         Expression::CodeBlock(sub) => {
             let map = sub.iter().map(|e| compile_expression(e, component));
             quote!({ #(#map);* })

--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -1303,7 +1303,7 @@ fn compile_expression(expr: &Expression, component: &Rc<Component>) -> TokenStre
             _ => panic!("Expression::ObjectAccess's base expression is not an Object type"),
         },
         Expression::ArrayIndex { array, index } => match array.ty() {
-            Type::Array(ty) => {
+            Type::Array(_) => {
                 let base_e = compile_expression(array, component);
                 let index_e = compile_expression(index, component);
                 quote!((#base_e).row_data(#index_e))

--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -1306,7 +1306,7 @@ fn compile_expression(expr: &Expression, component: &Rc<Component>) -> TokenStre
             Type::Array(_) => {
                 let base_e = compile_expression(array, component);
                 let index_e = compile_expression(index, component);
-                quote!((#base_e).row_data(#index_e))
+                quote!((#base_e).row_data((#index_e) as usize))
             }
             _ => panic!("Expression::ArrayIndex's base expression is not an Array type"),
         },

--- a/sixtyfps_compiler/langtype.rs
+++ b/sixtyfps_compiler/langtype.rs
@@ -407,7 +407,6 @@ impl Type {
             }
             true
         };
-        
         match (self, other) {
             (a, b) if a == b => true,
             (_, Type::Invalid)

--- a/sixtyfps_compiler/langtype.rs
+++ b/sixtyfps_compiler/langtype.rs
@@ -407,7 +407,7 @@ impl Type {
             }
             true
         };
-
+        
         match (self, other) {
             (a, b) if a == b => true,
             (_, Type::Invalid)

--- a/sixtyfps_compiler/parser.rs
+++ b/sixtyfps_compiler/parser.rs
@@ -363,7 +363,7 @@ declare_syntax! {
         CodeBlock-> [ *Expression, *ReturnStatement ],
         ReturnStatement -> [ ?Expression ],
         // FIXME: the test should test that as alternative rather than several of them (but it can also be a literal)
-        Expression-> [ ?Expression, ?FunctionCallExpression, ?SelfAssignment,
+        Expression-> [ ?Expression, ?FunctionCallExpression, ?IndexExpression, ?SelfAssignment,
                        ?ConditionalExpression, ?QualifiedName, ?BinaryExpression, ?Array, ?ObjectLiteral,
                        ?UnaryOpExpression, ?CodeBlock, ?StringTemplate, ?AtImageUrl, ?AtLinearGradient],
         /// Concatenate the Expressions to make a string (usually expended from a template string)
@@ -374,6 +374,8 @@ declare_syntax! {
         AtLinearGradient -> [*Expression],
         /// expression()
         FunctionCallExpression -> [*Expression],
+        /// expression[index]
+        IndexExpression -> [2 Expression],
         /// `expression += expression`
         SelfAssignment -> [2 Expression],
         /// `condition ? first : second`

--- a/sixtyfps_compiler/parser/expressions.rs
+++ b/sixtyfps_compiler/parser/expressions.rs
@@ -31,6 +31,7 @@ use super::prelude::*;
 /// -0.3px + 0.3px - 3.pt+3pt
 /// aa == cc && bb && (xxx || fff) && 3 + aaa == bbb
 /// [array]
+/// array[index]
 /// {object:42}
 /// ```
 pub fn parse_expression(p: &mut impl Parser) -> bool {
@@ -96,6 +97,14 @@ fn parse_expression_helper(p: &mut impl Parser, precedence: OperatorPrecedence) 
         }
         let mut p = p.start_node_at(checkpoint.clone(), SyntaxKind::FunctionCallExpression);
         parse_function_arguments(&mut *p);
+    } else if p.nth(0).kind() == SyntaxKind::LBracket {
+        {
+            let _ = p.start_node_at(checkpoint.clone(), SyntaxKind::Expression);
+        }
+        let mut p = p.start_node_at(checkpoint.clone(), SyntaxKind::IndexExpression);
+        p.expect(SyntaxKind::LBracket);
+        parse_expression(&mut *p);
+        p.expect(SyntaxKind::RBracket);
     }
 
     if precedence >= OperatorPrecedence::Mul {

--- a/sixtyfps_compiler/passes/resolving.rs
+++ b/sixtyfps_compiler/passes/resolving.rs
@@ -841,13 +841,16 @@ impl Expression {
             &mut ctx.diag,
         );
 
-        if let Type::Array(_) = array_expr.ty() {
-            Expression::ArrayIndex {
-                array: Box::new(array_expr),
-                index: Box::new(index_expr),
-            }
-        } else {
-            panic!();
+        let ty = array_expr.ty();
+        if let Type::Array(_) = ty {} else {
+            ctx.diag.push_error(
+                format!("{} is not an indexable type", ty),
+                &node,
+            );
+        }
+        Expression::ArrayIndex {
+            array: Box::new(array_expr),
+            index: Box::new(index_expr),
         }
     }
 

--- a/sixtyfps_compiler/passes/resolving.rs
+++ b/sixtyfps_compiler/passes/resolving.rs
@@ -833,7 +833,6 @@ impl Expression {
         ctx: &mut LookupCtx,
     ) -> Expression {
         let (array_expr_n, index_expr_n) = node.Expression();
-        
         let array_expr = Self::from_expression_node(array_expr_n, ctx);
         let index_expr = Self::from_expression_node(index_expr_n.clone(), ctx).maybe_convert_to(
             Type::Int32,
@@ -842,16 +841,11 @@ impl Expression {
         );
 
         let ty = array_expr.ty();
-        if let Type::Array(_) = ty {} else {
-            ctx.diag.push_error(
-                format!("{} is not an indexable type", ty),
-                &node,
-            );
+        if let Type::Array(_) = ty {
+        } else {
+            ctx.diag.push_error(format!("{} is not an indexable type", ty), &node);
         }
-        Expression::ArrayIndex {
-            array: Box::new(array_expr),
-            index: Box::new(index_expr),
-        }
+        Expression::ArrayIndex { array: Box::new(array_expr), index: Box::new(index_expr) }
     }
 
     fn from_object_literal_node(

--- a/sixtyfps_runtime/interpreter/eval.rs
+++ b/sixtyfps_runtime/interpreter/eval.rs
@@ -177,6 +177,25 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
                 Value::Void
             }
         }
+        Expression::ArrayIndex { array, index } => {
+            let array = eval_expression(array, local_context);
+            let index = eval_expression(index, local_context);
+            match (array, index) {
+                (Value::Array(vec), Value::Number(index)) => {
+                    vec.as_slice().get(index as usize).cloned().unwrap_or(Value::Void)
+                }
+                (Value::Model(model), Value::Number(index)) => {
+                    if (index as usize) < model.row_count() {
+                        model.row_data(index as usize)
+                    } else {
+                        Value::Void
+                    }
+                }
+                _ => {
+                    Value::Void
+                }
+            }
+        }
         Expression::Cast { from, to } => {
             let v = eval_expression(&*from, local_context);
             match (v, to) {

--- a/tests/cases/models/array.60
+++ b/tests/cases/models/array.60
@@ -11,6 +11,7 @@ LICENSE END */
 export TestCase := Rectangle {
     property<[int]> ints: [1, 2, 3, 4, 5];
     property<int> num_ints: ints.length;
+    property<int> n: ints[ints[4] - ints[1]];
 }
 
 /*
@@ -19,6 +20,7 @@ auto handle = TestCase::create();
 const TestCase &instance = *handle;
 
 assert_eq(instance.get_num_ints(), 5);
+assert_eq(instance.get_n(), 4);
 
 auto model = std::make_shared<sixtyfps::VectorModel<int>>(std::vector<int>{1, 2, 3, 4, 5, 6, 7});
 instance.set_ints(model);
@@ -32,6 +34,7 @@ assert_eq(instance.get_num_ints(), 8);
 let instance = TestCase::new();
 
 assert_eq!(instance.get_num_ints(), 5);
+assert_eq!(instance.get_n(), 4);
 
 let model: std::rc::Rc<sixtyfps::VecModel<i32>> = std::rc::Rc::new(vec![1, 2, 3, 4, 5, 6, 7].into());
 instance.set_ints(sixtyfps::ModelHandle::new(model.clone()));
@@ -44,6 +47,7 @@ assert_eq!(instance.get_num_ints(), 8);
 var instance = new sixtyfps.TestCase();
 
 assert.equal(instance.num_ints, 5);
+assert.equal(instance.n, 4);
 
 let model = new sixtyfpslib.ArrayModel([1, 2, 3, 4, 5, 6, 7]);
 instance.ints = model;


### PR DESCRIPTION
This branch adds support for indexing into arrays/models.
As it stands, out-of-bounds access will panic. Will change the behavior as directed.
As before, I am unfortunately not able to test the cpp implementation.