### PR TITLE
Fix the C++ printer demo with disabled inline

### DIFF
--- a/sixtyfps_compiler/generator/cpp.rs
+++ b/sixtyfps_compiler/generator/cpp.rs
@@ -12,6 +12,8 @@ LICENSE END */
 
 // cSpell:ignore cstdlib cmath constexpr nullptr decltype intptr uintptr
 
+use std::fmt::Write;
+
 /// This module contains some data structure that helps represent a C++ code.
 /// It is then rendered into an actual C++ text using the Display trait
 mod cpp_ast {
@@ -609,8 +611,6 @@ pub fn generate(doc: &Document, diag: &mut BuildDiagnostics) -> Option<impl std:
 
             let mut init = "{ ".to_string();
 
-            use std::fmt::Write;
-
             for (index, byte) in data.iter().enumerate() {
                 if index > 0 {
                     init.push(',');
@@ -717,7 +717,6 @@ fn generate_struct(
     let mut members = fields
         .iter()
         .map(|(name, t)| {
-            use std::fmt::Write;
             write!(operator_eq, " && a.{0} == b.{0}", ident(name)).unwrap();
             (
                 Access::Public,
@@ -1280,7 +1279,8 @@ fn generate_component(
                 if sub_component_repeater_count > 0 {
                     let mut case_code = String::new();
                     for local_repeater_index in 0..sub_component_repeater_count {
-                        write!(case_code, "case {}: ", repeater_count + local_repeater_index).unwrap();
+                        write!(case_code, "case {}: ", repeater_count + local_repeater_index)
+                            .unwrap();
                     }
 
                     self.children_visitor_cases.push(format!(

--- a/sixtyfps_compiler/generator/cpp.rs
+++ b/sixtyfps_compiler/generator/cpp.rs
@@ -1280,9 +1280,7 @@ fn generate_component(
                 if sub_component_repeater_count > 0 {
                     let mut case_code = String::new();
                     for local_repeater_index in 0..sub_component_repeater_count {
-                        case_code.push_str("case ");
-                        case_code.push_str(&(repeater_count + local_repeater_index).to_string());
-                        case_code.push_str(": ");
+                        write!(case_code, "case {}: ", repeater_count + local_repeater_index).unwrap();
                     }
 
                     self.children_visitor_cases.push(format!(

--- a/sixtyfps_compiler/object_tree.rs
+++ b/sixtyfps_compiler/object_tree.rs
@@ -301,7 +301,7 @@ impl Component {
     }
 
     // Number of repeaters in this component, including sub-components
-    pub fn repeater_count(&self) -> i32 {
+    pub fn repeater_count(&self) -> u32 {
         let mut count = 0;
         recurse_elem(&self.root_element, &(), &mut |element, _| {
             let element = element.borrow();
@@ -1447,24 +1447,6 @@ pub fn recurse_elem<State>(
     let state = vis(elem, state);
     for sub in &elem.borrow().children {
         recurse_elem(sub, &state, vis);
-    }
-}
-
-/// Call the visitor for each children of the element recursively, starting with the element itself.
-/// The traversal happens in level-order, meaning each level of the element tree is visisted before
-/// going to the next depth.
-///
-/// The state returned by the visitor is passed to the children
-pub fn recurse_elem_level_order(elem: &ElementRc, vis: &mut impl FnMut(&ElementRc)) {
-    vis(elem);
-    visit_children(elem, vis);
-    fn visit_children(elem: &ElementRc, vis: &mut impl FnMut(&ElementRc)) {
-        for child in &elem.borrow().children {
-            vis(child);
-        }
-        for child in &elem.borrow().children {
-            visit_children(child, vis);
-        }
     }
 }
 

--- a/sixtyfps_compiler/passes/generate_item_indices.rs
+++ b/sixtyfps_compiler/passes/generate_item_indices.rs
@@ -94,4 +94,13 @@ impl crate::generator::ItemTreeBuilder for Helper {
         }
         true
     }
+
+    fn enter_component_children(
+        &mut self,
+        _item: &ElementRc,
+        _repeater_count: u32,
+        _component_state: &Self::SubComponentState,
+        _sub_component_state: &Self::SubComponentState,
+    ) {
+    }
 }

--- a/tests/cases/subcomponents/repeaters.60
+++ b/tests/cases/subcomponents/repeaters.60
@@ -1,0 +1,69 @@
+/* LICENSE BEGIN
+    This file is part of the SixtyFPS Project -- https://sixtyfps.io
+    Copyright (c) 2021 Olivier Goffart <olivier.goffart@sixtyfps.io>
+    Copyright (c) 2021 Simon Hausmann <simon.hausmann@sixtyfps.io>
+
+    SPDX-License-Identifier: GPL-3.0-only
+    This file is also available under commercial licensing terms.
+    Please contact info@sixtyfps.io for more information.
+LICENSE END */
+
+// Verify that two repeaters (if and for) are placed correctly in the item tree
+// and matched in the dyn_visit closure.
+// The two repeaters ended up being swapped and sub-component's repeater was
+// visisted when the Text's child's repeater should have been, resulting in
+// wrong rendering order. This is tested by clicking into the left half and
+// verifying that it did not hit the sub-component's repeater.
+
+SubCompo := Rectangle {
+    property <bool> clicked: false;
+    for x in 1: Text {
+        text: "I should appear in the right half";
+        ta := TouchArea {
+            clicked => {
+                root.clicked = true;
+            }
+        }
+    }
+}
+
+TestCase := Rectangle {
+    width: 300phx;
+    height: 300phx;
+    property clicked <=> c.clicked;
+    Text {
+        if (false): TouchArea {
+        }
+    }
+    c := SubCompo {
+        x: 200px;
+    }
+}
+
+/*
+```rust
+let instance = TestCase::new();
+
+assert!(!instance.get_clicked());
+sixtyfps::testing::send_mouse_click(&instance, 20., 5.);
+assert!(!instance.get_clicked());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(!instance.get_clicked());
+sixtyfps::testing::send_mouse_click(&instance, 20., 5.);
+assert(!instance.get_clicked());
+```
+
+
+```js
+var instance = new sixtyfps.TestCase({});
+assert(!instance.clicked);
+instance.send_mouse_click(20., 5.);
+assert(!instance.clicked);
+```
+
+
+*/


### PR DESCRIPTION
For the following reduced test-case the order in how the dynamic nodes
in the item tree were generated (and dyn indices assigned) differed from
the way the visit_dynamic_children slots were generated:

```
Blah := Rectangle {
    for x in 1: Text {
        text: "Should be on the right";
    }
}

MainWindow := Window {
    width: 772px;
    height: 504px;
    Text {
        if (false): TouchArea {
        }
    }
    Blah {
        x: 200px;
    }
}
```

The item tree node was constructed using build_item_tree, which
basically assigned dyn index 0 to the "repater" for the touch area
and "1" to the one for the repeater inside the sub-component.

Afterwards we traversed the element tree - without descending into the
sub-components - to generate the fields and the dispatch in in the
dynamic visitor. Here a subtle order would result in a mismatch of
indices:

recurse_elem_level_order would end up visiting Text, Blah and then
Text's children, assigning the first dynamic index to Blah.

This is now fixed by merging the two iterations into one.