### PR TITLE
Document MSRV in the crate README

### DIFF
--- a/api/sixtyfps-rs/README.md
+++ b/api/sixtyfps-rs/README.md
@@ -60,3 +60,7 @@ You can quickly try out the [examples](/examples) by cloning this repo and runni
 # Runs the "printerdemo" example
 cargo run --release --bin printerdemo
 ```
+
+### Minimum Supported Rust Version
+
+ This crate's minimum supported `rustc` version is `1.54.0`.


### PR DESCRIPTION
Another option would be to spell out an entire policy, like this](https://github.com/BurntSushi/byteorder/commit/663358f9d29bddadc1a8e84290ec96925f2cb851). 

I'm fine with just the version, but happy to adjust this merge requests to include policy text like that if that's preferred.

