### PR TITLE
Make sure MSVC is using utf-8, so that compiling `u"string"` won't cause error on other codepage.

### DIFF
--- a/sixtyfps_runtime/rendering_backends/qt/build.rs
+++ b/sixtyfps_runtime/rendering_backends/qt/build.rs
@@ -41,6 +41,9 @@ fn main() {
     config.flag_if_supported("/std:c++17");
     // Make sure that MSVC reports the correct value for __cplusplus
     config.flag_if_supported("/Zc:__cplusplus");
+    // Make sure that MSVC is using utf-8 for source encoding
+    // Ref: https://docs.microsoft.com/en-us/cpp/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8
+    config.flag_if_supported("/utf-8");
 
     if cfg!(target_os = "macos") {
         config.flag("-F");


### PR DESCRIPTION
Without doing this, I got this error when compiling "backend-qt":
```
  lib.rs(257): warning C4458: declaration of 'fnbox' hides class member
  lib.rs(241): note: see declaration of 'EventHolder::fnbox'
  qt_widgets\listviewitem.rs(108): warning C4819: The file contains a character that cannot be represented in the current code page (936). Save the filein Unicode format to prevent data loss
  qt_window.rs(526): error C2001: newline in constant
  qt_window.rs(527): error C2146: syntax error: missing ')' before identifier 'elided'
  qt_window.rs(527): error C2146: syntax error: missing ';' before identifier 'elided'
  exit code: 2
```
Because there is a `QStringView(u"…")` in "qt_window.rs", in Microsoft [documents](https://docs.microsoft.com/en-us/cpp/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8):

> By default, Visual Studio detects a byte-order mark to determine if the source file is in an encoded Unicode format, for example, UTF-16 or UTF-8. If no byte-order mark is found, it assumes the source file is encoded using the current user code page, unless you've specified a code page by using /utf-8 or the /source-charset option.

So, add `/utf-8` to the compiler flags will fix the issue.