### PR TITLE
Add a simple fuzzer for the parser in the compilerlib

### DIFF
--- a/sixtyfps_compiler/fuzz/.gitignore
+++ b/sixtyfps_compiler/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target
+corpus
+artifacts

--- a/sixtyfps_compiler/fuzz/Cargo.toml
+++ b/sixtyfps_compiler/fuzz/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "sixtyfps-compilerlib-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.sixtyfps-compilerlib]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "parser"
+path = "fuzz_targets/parser.rs"
+test = false
+doc = false

--- a/sixtyfps_compiler/fuzz/fuzz_targets/parser.rs
+++ b/sixtyfps_compiler/fuzz/fuzz_targets/parser.rs
@@ -1,0 +1,21 @@
+/* LICENSE BEGIN
+    This file is part of the SixtyFPS Project -- https://sixtyfps.io
+    Copyright (c) 2021 Tobias Hunger <tobias.hunger@gmail.com>
+
+    SPDX-License-Identifier: GPL-3.0-only
+    This file is also available under commercial licensing terms.
+    Please contact info@sixtyfps.io for more information.
+LICENSE END */
+
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use sixtyfps_compilerlib::diagnostics::BuildDiagnostics;
+use sixtyfps_compilerlib::parser;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        let mut bd = BuildDiagnostics::default();
+        let _node = parser::parse(s.to_string(), None, &mut bd);
+    }
+});


### PR DESCRIPTION
Run with `cargo fuzz run parser`.

Fails very soon with this 3 ASCII char string: `/**`