### PR TITLE
Pr/fuzz fixes

### DIFF
--- a/sixtyfps_compiler/lexer.rs
+++ b/sixtyfps_compiler/lexer.rs
@@ -132,7 +132,7 @@ pub fn lex_string(text: &str, state: &mut LexState) -> usize {
                     state.template_string_stack.push(0);
                     return stop + 2;
                 }
-                end = stop + 1 + text[stop + 1 ..].chars().next().map_or(0, |c| c.len_utf8())
+                end = stop + 1 + text[stop + 1..].chars().next().map_or(0, |c| c.len_utf8())
             }
             _ => unreachable!(),
         }
@@ -325,6 +325,6 @@ fn basic_lexer_test() {
             (crate::parser::SyntaxKind::Star, "*"),
         ],
     );
-    compare(r#""\"#, &[(crate::parser::SyntaxKind::StringLiteral, "\"\\")]);
+    compare(r#""\"#, &[(crate::parser::SyntaxKind::Error, "\"\\")]);
     compare(r#""\ޱ"#, &[(crate::parser::SyntaxKind::Error, "\"\\ޱ")]);
 }

--- a/sixtyfps_compiler/lexer.rs
+++ b/sixtyfps_compiler/lexer.rs
@@ -123,6 +123,9 @@ pub fn lex_string(text: &str, state: &mut LexState) -> usize {
                 return stop + 1;
             }
             b'\\' => {
+                if text.as_bytes().len() == stop + 1 {
+                    return stop + 1;
+                }
                 if text.as_bytes()[stop + 1] == b'{' {
                     state.template_string_stack.push(0);
                     return stop + 2;
@@ -320,4 +323,5 @@ fn basic_lexer_test() {
             (crate::parser::SyntaxKind::Star, "*"),
         ],
     );
+    compare(r#""\"#, &[(crate::parser::SyntaxKind::StringLiteral, "\"\\")]);
 }

--- a/sixtyfps_compiler/lexer.rs
+++ b/sixtyfps_compiler/lexer.rs
@@ -125,7 +125,8 @@ pub fn lex_string(text: &str, state: &mut LexState) -> usize {
             }
             b'\\' => {
                 if text_len <= stop + 1 {
-                    return text_len;
+                    // FIXME: report an error for unterminated string
+                    return 0;
                 }
                 if text.as_bytes()[stop + 1] == b'{' {
                     state.template_string_stack.push(0);

--- a/sixtyfps_compiler/lexer.rs
+++ b/sixtyfps_compiler/lexer.rs
@@ -131,14 +131,7 @@ pub fn lex_string(text: &str, state: &mut LexState) -> usize {
                     state.template_string_stack.push(0);
                     return stop + 2;
                 }
-                end = stop + 1;
-                while end < text_len && text.as_bytes()[end] > 127u8 {
-                    // Iterate till end of UTF8 sequence started at stop + 1
-                    end += 1;
-                }
-                if end < text_len {
-                    end = end + 1 // begin of next UTF8 sequence
-                }
+                end = stop + 1 + text[stop + 1 ..].chars().next().map_or(0, |c| c.len_utf8())
             }
             _ => unreachable!(),
         }

--- a/sixtyfps_compiler/lexer.rs
+++ b/sixtyfps_compiler/lexer.rs
@@ -72,7 +72,7 @@ pub fn lex_comment(text: &str, _: &mut LexState) -> usize {
                 if star > offset && bytes[star - 1] == b'/' {
                     nested += 1;
                     offset = star + 1;
-                } else if bytes[star + 1] == b'/' {
+                } else if star < bytes.len() - 1 && bytes[star + 1] == b'/' {
                     if nested == 0 {
                         return star + 2;
                     }
@@ -308,6 +308,16 @@ fn basic_lexer_test() {
             (crate::parser::SyntaxKind::Identifier, "h"),
             (crate::parser::SyntaxKind::StringLiteral, r#"}i""#),
             (crate::parser::SyntaxKind::Identifier, "j"),
+        ],
+    );
+
+    // Fuzzer tests:
+    compare(
+        r#"/**"#,
+        &[
+            (crate::parser::SyntaxKind::Div, "/"),
+            (crate::parser::SyntaxKind::Star, "*"),
+            (crate::parser::SyntaxKind::Star, "*"),
         ],
     );
 }


### PR DESCRIPTION
Some fixes for the first three panics in the compilerlib parser triggered by `cargo fuzz`.