### PR TITLE
compilerlib: Fix an assert triggered by linear_gradient

### DIFF
--- a/sixtyfps_compiler/parser/expressions.rs
+++ b/sixtyfps_compiler/parser/expressions.rs
@@ -20,6 +20,7 @@ use super::prelude::*;
 /// #aabbcc
 /// (something)
 /// @image-url("something")
+/// @image_url("something")
 /// some_id.some_property
 /// function_call()
 /// function_call(hello, world)
@@ -306,6 +307,7 @@ fn parse_template_string(p: &mut impl Parser) {
 /// @linear-gradient(0.25turn, #3f87a6, #ebf8e1, #f69d3c)
 /// @linear-gradient(to left, #333, #333 50%, #eee 75%, #333 75%)
 /// @linear-gradient(217deg, rgba(255,0,0,0.8), rgba(255,0,0,0) 70.71%)
+/// @linear_gradient(217deg, rgba(255,0,0,0.8), rgba(255,0,0,0) 70.71%)
 /// ```
 fn parse_at_linear_gradient(p: &mut impl Parser) {
     let mut p = p.start_node(SyntaxKind::AtLinearGradient);

--- a/sixtyfps_compiler/parser/expressions.rs
+++ b/sixtyfps_compiler/parser/expressions.rs
@@ -310,7 +310,7 @@ fn parse_template_string(p: &mut impl Parser) {
 fn parse_at_linear_gradient(p: &mut impl Parser) {
     let mut p = p.start_node(SyntaxKind::AtLinearGradient);
     p.expect(SyntaxKind::At);
-    debug_assert_eq!(p.peek().as_str(), "linear-gradient");
+    debug_assert!(p.peek().as_str() == "linear-gradient" || p.peek().as_str() == "linear_gradient");
     p.consume(); //"linear-gradient"
 
     p.expect(SyntaxKind::LParent);


### PR DESCRIPTION
Just remove the variant with the unserscore: Using it triggers a debug_assert down
the line, so it does not seem to be used in the wild:-)