### PR TITLE
Include the VS runtime dlls in the binary package

### DIFF
--- a/api/sixtyfps-cpp/CMakeLists.txt
+++ b/api/sixtyfps-cpp/CMakeLists.txt
@@ -233,6 +233,10 @@ if(SIXTYFPS_PACKAGE_BUNDLE_QT)
             DESTINATION plugins/imageformats)
 
         install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../licenses/ DESTINATION licenses)
+
+        set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP TRUE)
+        include(InstallRequiredSystemLibraries)
+        install(FILES ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS} TYPE LIB)
     endif()
 endif(SIXTYFPS_PACKAGE_BUNDLE_QT)
 


### PR DESCRIPTION
We bundle Qt and Qt needs the VC runtime DLLs. There are two options:
Find and locate vcredist.exe, include it in the NSIS installer and run
it. Alternatively, a cmake module exists to locates the DLLs and
install them.

This patch uses the latter option, for simplicity. When upstream ticket
https://gitlab.kitware.com/cmake/cmake/-/issues/17725 is implemented, we
could switch to the first option.

Note: This might include a few DLLs that Qt probably doesn't
need.