### PR TITLE
Rename the sub component id to avoid error in the generated code with duplicated names

### DIFF
--- a/sixtyfps_compiler/generator/cpp.rs
+++ b/sixtyfps_compiler/generator/cpp.rs
@@ -1789,6 +1789,8 @@ fn component_id(component: &Rc<Component>) -> String {
         ident(&component.root_element.borrow().id).into_owned()
     } else if component.id.is_empty() {
         format!("Component_{}", ident(&component.root_element.borrow().id))
+    } else if component.is_sub_component() {
+        ident(&format!("{}_{}", component.id, component.root_element.borrow().id)).into_owned()
     } else {
         ident(&component.id).into_owned()
     }

--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -1385,6 +1385,8 @@ fn public_component_id(component: &Component) -> proc_macro2::Ident {
         let id =
             it.next().map(|c| c.to_ascii_uppercase()).into_iter().chain(it).collect::<String>();
         ident(&id)
+    } else if component.is_sub_component() {
+        ident(&format!("{}_{}", component.id, component.root_element.borrow().id))
     } else {
         ident(&component.id)
     }

--- a/tests/cases/imports/duplicated_name.60
+++ b/tests/cases/imports/duplicated_name.60
@@ -1,0 +1,29 @@
+/* LICENSE BEGIN
+    This file is part of the SixtyFPS Project -- https://sixtyfps.io
+    Copyright (c) 2021 Olivier Goffart <olivier.goffart@sixtyfps.io>
+    Copyright (c) 2021 Simon Hausmann <simon.hausmann@sixtyfps.io>
+
+    SPDX-License-Identifier: GPL-3.0-only
+    This file is also available under commercial licensing terms.
+    Please contact info@sixtyfps.io for more information.
+LICENSE END */
+//include_path: ../../helper_components
+import { ColorButton } from "test_button.60";
+import { TestButton as TheRealTestButton  } from "re_export.60";
+
+// ColorButton uses TestButtonImpl
+TestButtonImpl := Rectangle {
+    property <int> abc: 12;
+}
+
+// Testbutton is another name for TestButtonImpl
+TestButton := Rectangle {
+    property <string> abc: "hello";
+}
+
+TestCase := Rectangle {
+    ColorButton { button_color: red; }
+    TestButtonImpl { abc: 4; }
+    TestButton { abc: "world"; }
+    TheRealTestButton{ button-text: "yo"; }
+}


### PR DESCRIPTION
This is a regression because of non-inlining discovered by the new "crater" test