### PR TITLE
Fix regression when overriding the with of a Component that specifies limits

### DIFF
--- a/sixtyfps_compiler/layout.rs
+++ b/sixtyfps_compiler/layout.rs
@@ -492,13 +492,42 @@ pub fn layout_info_type() -> Type {
 
 /// Get the implicit layout info of a particular element
 pub fn implicit_layout_info_call(elem: &ElementRc, orientation: Orientation) -> Expression {
-    match &elem.borrow().base_type {
-        Type::Component(base_comp) => match &base_comp.root_element.borrow().layout_info_prop {
-            Some((hor, vert)) => Expression::PropertyReference(match orientation {
-                Orientation::Horizontal => hor.clone(),
-                Orientation::Vertical => vert.clone(),
-            }),
-            None => Expression::FunctionCall {
+    let mut elem_it = elem.clone();
+    loop {
+        return match &elem_it.clone().borrow().base_type {
+            Type::Component(base_comp) => {
+                match base_comp.root_element.borrow().layout_info_prop(orientation) {
+                    Some(nr) => {
+                        // We cannot take nr as is because it is relative to the elem's component. We therefore need to
+                        // use `elem` as an element for the PropertyReference, not `root` within the base of elem
+                        debug_assert!(Rc::ptr_eq(&nr.element(), &base_comp.root_element));
+                        Expression::PropertyReference(NamedReference::new(elem, nr.name()))
+                    }
+                    None => {
+                        elem_it = base_comp.root_element.clone();
+                        continue;
+                    }
+                }
+            }
+            Type::Builtin(base_type) if base_type.name == "Rectangle" => {
+                // hard-code the value for rectangle because many rectangle end up optimized away and we
+                // don't want to depend on the element.
+                Expression::Struct {
+                    ty: layout_info_type(),
+                    values: [("min", 0.), ("max", f32::MAX), ("preferred", 0.)]
+                        .iter()
+                        .map(|(s, v)| (s.to_string(), Expression::NumberLiteral(*v as _, Unit::Px)))
+                        .chain(
+                            [("min_percent", 0.), ("max_percent", 100.), ("stretch", 1.)]
+                                .iter()
+                                .map(|(s, v)| {
+                                    (s.to_string(), Expression::NumberLiteral(*v, Unit::None))
+                                }),
+                        )
+                        .collect(),
+                }
+            }
+            _ => Expression::FunctionCall {
                 function: Box::new(Expression::BuiltinFunctionReference(
                     BuiltinFunction::ImplicitLayoutInfo(orientation),
                     None,
@@ -506,30 +535,6 @@ pub fn implicit_layout_info_call(elem: &ElementRc, orientation: Orientation) -> 
                 arguments: vec![Expression::ElementReference(Rc::downgrade(elem))],
                 source_location: None,
             },
-        },
-        Type::Builtin(base_type) if base_type.name == "Rectangle" => {
-            // hard-code the value for rectangle because many rectangle end up optimized away and we
-            // don't want to depend on the element.
-            Expression::Struct {
-                ty: layout_info_type(),
-                values: [("min", 0.), ("max", f32::MAX), ("preferred", 0.)]
-                    .iter()
-                    .map(|(s, v)| (s.to_string(), Expression::NumberLiteral(*v as _, Unit::Px)))
-                    .chain(
-                        [("min_percent", 0.), ("max_percent", 100.), ("stretch", 1.)].iter().map(
-                            |(s, v)| (s.to_string(), Expression::NumberLiteral(*v, Unit::None)),
-                        ),
-                    )
-                    .collect(),
-            }
-        }
-        _ => Expression::FunctionCall {
-            function: Box::new(Expression::BuiltinFunctionReference(
-                BuiltinFunction::ImplicitLayoutInfo(orientation),
-                None,
-            )),
-            arguments: vec![Expression::ElementReference(Rc::downgrade(elem))],
-            source_location: None,
-        },
+        };
     }
 }

--- a/tests/cases/layout/override_from_parent.60
+++ b/tests/cases/layout/override_from_parent.60
@@ -1,0 +1,45 @@
+/* LICENSE BEGIN
+    This file is part of the SixtyFPS Project -- https://sixtyfps.io
+    Copyright (c) 2021 Olivier Goffart <olivier.goffart@sixtyfps.io>
+    Copyright (c) 2021 Simon Hausmann <simon.hausmann@sixtyfps.io>
+
+    SPDX-License-Identifier: GPL-3.0-only
+    This file is also available under commercial licensing terms.
+    Please contact info@sixtyfps.io for more information.
+LICENSE END */
+
+ComboBox := Rectangle {
+    min-width: 60px;
+}
+
+SubComp1 := Rectangle {
+    HorizontalLayout {
+        ComboBox {
+            width: 200px;
+        }
+    }
+}
+
+SubComp2 := HorizontalLayout {
+    ComboBox {
+        width: 200px;
+    }
+}
+
+SubComp3 := HorizontalLayout {
+    max-width: 500px;
+    Rectangle { }
+}
+
+
+TestCase := Rectangle {
+    width: 300phx;
+    height: 300phx;
+
+    sc1 := SubComp1 {}
+    sc2 := SubComp2 {}
+    // FIXME: the HorizontalLayout is required here because the sc3.max-width takes the existing binding instead of being re-materialized
+    sc3 := HorizontalLayout { SubComp3 { width: 200px; } }
+    property<bool> test: sc1.min-width == 200px && sc2.min-width == 200px && sc3.max-width == 200px;
+}
+

--- a/tests/cases/layout/override_from_parent.60
+++ b/tests/cases/layout/override_from_parent.60
@@ -31,6 +31,8 @@ SubComp3 := HorizontalLayout {
     Rectangle { }
 }
 
+SubComp4 := SubComp1 {}
+
 
 TestCase := Rectangle {
     width: 300phx;
@@ -40,6 +42,7 @@ TestCase := Rectangle {
     sc2 := SubComp2 {}
     // FIXME: the HorizontalLayout is required here because the sc3.max-width takes the existing binding instead of being re-materialized
     sc3 := HorizontalLayout { SubComp3 { width: 200px; } }
-    property<bool> test: sc1.min-width == 200px && sc2.min-width == 200px && sc3.max-width == 200px;
+    sc4 := SubComp4 {}
+    property<bool> test: sc1.min-width == 200px && sc2.min-width == 200px && sc3.max-width == 200px && sc4.min-width == 200px;
 }
 


### PR DESCRIPTION
We were comparing the priorities of different component, which does
not make sense

This is a regression found with the crater run