### PR TITLE
Make it possible to delegate the timer handling to the backend

### DIFF
--- a/sixtyfps_runtime/corelib/Cargo.toml
+++ b/sixtyfps_runtime/corelib/Cargo.toml
@@ -18,7 +18,7 @@ rtti = []
 # Expose C ABI
 ffi = []
 # Use the standard library
-std = ["euclid/std", "once_cell/std", "scoped-tls-hkt", "lyon_path", "lyon_algorithms", "lyon_geom"]
+std = ["euclid/std", "once_cell/std", "scoped-tls-hkt", "lyon_path", "lyon_algorithms", "lyon_geom", "instant"]
 
 default = ["std"]
 
@@ -37,7 +37,7 @@ lyon_geom = { version = "0.17.0", optional = true  }
 euclid = { version = "0.22.1", default-features = false }
 triomphe = { version = "0.1.1", default-features = false }
 once_cell = { version = "1.5", default-features = false }
-instant = { version = "0.1", features = [ "now" ] }
+instant = { version = "0.1", features = [ "now" ], optional = true }
 derive_more = "0.99.5"
 scoped-tls-hkt = { version = "0.1", optional = true }
 static_assertions = "1.1"

--- a/sixtyfps_runtime/corelib/flickable.rs
+++ b/sixtyfps_runtime/corelib/flickable.rs
@@ -9,7 +9,7 @@
 LICENSE END */
 //! The implementation details behind the Flickable
 
-use instant::Duration;
+use core::time::Duration;
 
 use crate::animations::EasingCurve;
 use crate::animations::Instant;

--- a/sixtyfps_runtime/corelib/tests.rs
+++ b/sixtyfps_runtime/corelib/tests.rs
@@ -23,7 +23,7 @@ use crate::SharedString;
 pub extern "C" fn sixtyfps_mock_elapsed_time(time_in_ms: u64) {
     crate::animations::CURRENT_ANIMATION_DRIVER.with(|driver| {
         let mut tick = driver.current_tick();
-        tick += instant::Duration::from_millis(time_in_ms);
+        tick += core::time::Duration::from_millis(time_in_ms);
         driver.update_animations(tick)
     })
 }

--- a/sixtyfps_runtime/corelib/timers.rs
+++ b/sixtyfps_runtime/corelib/timers.rs
@@ -18,6 +18,8 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::cell::{Cell, RefCell};
 
+use crate::animations::Instant;
+
 type TimerCallback = Box<dyn Fn()>;
 type SingleShotTimerCallback = Box<dyn FnOnce()>;
 
@@ -157,7 +159,7 @@ struct TimerData {
 #[derive(Clone, Copy)]
 struct ActiveTimer {
     id: usize,
-    timeout: instant::Instant,
+    timeout: Instant,
 }
 
 /// TimerList provides the interface to the event loop for activating times and
@@ -173,7 +175,7 @@ pub struct TimerList {
 impl TimerList {
     /// Returns the timeout of the timer that should fire the soonest, or None if there
     /// is no timer active.
-    pub fn next_timeout() -> Option<instant::Instant> {
+    pub fn next_timeout() -> Option<Instant> {
         CURRENT_TIMERS.with(|timers| {
             timers
                 .borrow()
@@ -186,7 +188,7 @@ impl TimerList {
     /// Activates any expired timers by calling their callback function. Returns true if any timers were
     /// activated; false otherwise.
     pub fn maybe_activate_timers() -> bool {
-        let now = instant::Instant::now();
+        let now = Instant::now();
         // Shortcut: Is there any timer worth activating?
         if TimerList::next_timeout().map(|timeout| now < timeout).unwrap_or(false) {
             return false;
@@ -263,7 +265,7 @@ impl TimerList {
     fn activate_timer(&mut self, timer_id: usize) {
         self.register_active_timer(ActiveTimer {
             id: timer_id,
-            timeout: instant::Instant::now() + self.timers[timer_id].duration,
+            timeout: Instant::now() + self.timers[timer_id].duration,
         });
     }
 

--- a/sixtyfps_runtime/rendering_backends/gl/event_loop.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/event_loop.rs
@@ -589,7 +589,7 @@ pub fn run(quit_behavior: sixtyfps_corelib::backend::EventLoopQuitBehavior) {
 
             if *control_flow == winit::event_loop::ControlFlow::Wait {
                 if let Some(next_timer) = corelib::timers::TimerList::next_timeout() {
-                    *control_flow = winit::event_loop::ControlFlow::WaitUntil(next_timer);
+                    *control_flow = winit::event_loop::ControlFlow::WaitUntil(next_timer.into());
                 }
             }
         })

--- a/sixtyfps_runtime/rendering_backends/qt/qt_window.rs
+++ b/sixtyfps_runtime/rendering_backends/qt/qt_window.rs
@@ -1523,6 +1523,7 @@ pub(crate) fn timer_event() {
 
     let mut timeout = sixtyfps_corelib::timers::TimerList::next_timeout().map(|instant| {
         let now = std::time::Instant::now();
+        let instant: std::time::Instant = instant.into();
         if instant > now {
             instant.duration_since(now).as_millis() as i32
         } else {


### PR DESCRIPTION
When building with no_std, the backend can seed the Instant wrapper and
provide updates to it.