### PR TITLE
Mark constant properties as not needing dependency nodes when accessed

### DIFF
--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -866,6 +866,10 @@ fn generate_component(
     super::handle_property_bindings_init(component, |elem, prop, binding| {
         handle_property_binding(component, elem, prop, binding, &mut init)
     });
+    super::for_each_const_properties(component, |elem, prop| {
+        let rust_property = access_member(elem, prop, component, quote!(_self), false);
+        init.push(quote!(#rust_property.set_constant();))
+    });
 
     let resource_symbols: Vec<proc_macro2::TokenStream> = component
         .embedded_file_resources

--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -577,8 +577,8 @@ fn generate_component(
                     self.item_names.push(field_name);
                     self.item_types.push(ident(&item.base_type.as_native().class_name));
                     #[cfg(sixtyfps_debug_property)]
-                    for (prop, ty) in &item.base_type.as_native().properties {
-                        if ty.is_property_type()
+                    for (prop, info) in &item.base_type.as_native().properties {
+                        if info.ty.is_property_type()
                             && !prop.starts_with("viewport")
                             && prop != "commands"
                         {

--- a/sixtyfps_compiler/langtype.rs
+++ b/sixtyfps_compiler/langtype.rs
@@ -291,7 +291,9 @@ impl Type {
             Type::Builtin(b) => {
                 b.properties.iter().map(|(k, t)| (k.clone(), t.ty.clone())).collect()
             }
-            Type::Native(n) => n.properties.iter().map(|(k, t)| (k.clone(), t.clone())).collect(),
+            Type::Native(n) => {
+                n.properties.iter().map(|(k, t)| (k.clone(), t.ty.clone())).collect()
+            }
             _ => Vec::new(),
         }
     }
@@ -537,7 +539,7 @@ pub struct NativeClass {
     pub parent: Option<Rc<NativeClass>>,
     pub class_name: String,
     pub cpp_vtable_getter: String,
-    pub properties: HashMap<String, Type>,
+    pub properties: HashMap<String, BuiltinPropertyInfo>,
     pub deprecated_aliases: HashMap<String, String>,
     pub cpp_type: Option<String>,
     pub rust_type_constructor: Option<String>,
@@ -556,7 +558,7 @@ impl NativeClass {
 
     pub fn new_with_properties(
         class_name: &str,
-        properties: impl IntoIterator<Item = (String, Type)>,
+        properties: impl IntoIterator<Item = (String, BuiltinPropertyInfo)>,
     ) -> Self {
         let mut class = Self::new(class_name);
         class.properties = properties.into_iter().collect();
@@ -568,8 +570,8 @@ impl NativeClass {
     }
 
     pub fn lookup_property(&self, name: &str) -> Option<Type> {
-        if let Some(ty) = self.properties.get(name) {
-            Some(ty.clone())
+        if let Some(bty) = self.properties.get(name) {
+            Some(bty.ty.clone())
         } else if let Some(parent_class) = &self.parent {
             parent_class.lookup_property(name)
         } else {

--- a/sixtyfps_compiler/namedreference.rs
+++ b/sixtyfps_compiler/namedreference.rs
@@ -104,7 +104,6 @@ impl NamedReference {
                 return true;
             }
             match &e.base_type {
-                Type::Native(_) => return false, // after resolving we don't know anymore if the property can be changed natively
                 Type::Component(c) => {
                     let next = c.root_element.clone();
                     drop(e);
@@ -113,6 +112,9 @@ impl NamedReference {
                 }
                 Type::Builtin(b) => {
                     return b.properties.get(self.name()).map_or(true, |pi| !pi.is_native_output)
+                }
+                Type::Native(n) => {
+                    return n.properties.get(self.name()).map_or(true, |pi| !pi.is_native_output)
                 }
                 _ => return true,
             }

--- a/sixtyfps_compiler/passes/flickable.rs
+++ b/sixtyfps_compiler/passes/flickable.rs
@@ -76,6 +76,20 @@ fn create_viewport_element(flickable_elem: &ElementRc, native_rect: &Rc<NativeCl
             }
         }
     }
+    viewport
+        .borrow()
+        .property_analysis
+        .borrow_mut()
+        .entry("y".into())
+        .or_default()
+        .is_set_externally = true;
+    viewport
+        .borrow()
+        .property_analysis
+        .borrow_mut()
+        .entry("x".into())
+        .or_default()
+        .is_set_externally = true;
     flickable.children.push(viewport);
 }
 

--- a/sixtyfps_compiler/passes/repeater_component.rs
+++ b/sixtyfps_compiler/passes/repeater_component.rs
@@ -71,6 +71,14 @@ fn create_repeater_components(component: &Rc<Component>) {
                     RefCell::new(Expression::PropertyReference(listview.listview_width).into()),
                 );
             }
+
+            comp.root_element
+                .borrow()
+                .property_analysis
+                .borrow_mut()
+                .entry("y".into())
+                .or_default()
+                .is_set_externally = true;
         }
 
         let weak = Rc::downgrade(&comp);

--- a/sixtyfps_compiler/passes/resolve_native_classes.rs
+++ b/sixtyfps_compiler/passes/resolve_native_classes.rs
@@ -91,14 +91,15 @@ fn select_minimal_class_based_on_property_usage<'a>(
 
 #[test]
 fn test_select_minimal_class_based_on_property_usage() {
+    use crate::langtype::BuiltinPropertyInfo;
     let first = Rc::new(NativeClass::new_with_properties(
         "first_class",
-        [("first_prop".to_owned(), Type::Int32)].iter().cloned(),
+        [("first_prop".to_owned(), BuiltinPropertyInfo::new(Type::Int32))].iter().cloned(),
     ));
 
     let mut second = NativeClass::new_with_properties(
         "second_class",
-        [("second_prop".to_owned(), Type::Int32)].iter().cloned(),
+        [("second_prop".to_owned(), BuiltinPropertyInfo::new(Type::Int32))].iter().cloned(),
     );
     second.parent = Some(first.clone());
     let second = Rc::new(second);


### PR DESCRIPTION
The first commit adds some debug facilities to the properties to aid debugging and benchmarking

This show that this patch reduces a lot the number of dependency nodes by not having them for property we know are constant.