### PR TITLE
Update Flickable and ScrollView docs

### DIFF
--- a/docs/builtin_elements.md
+++ b/docs/builtin_elements.md
@@ -578,6 +578,18 @@ FIXME: write docs
 
 FIXME: write docs
 
+The `Flickable` is a lower-level item that is the base for scrollable
+elements, such as the ScrollView widget. When the viewport-width or the
+viewport-height is greater than the parent width or parent height
+respectively the element becomes scrollable although the `Flickable`
+does not create a scrollbar. When using a for loop to populate the
+elements, the viewport-width and viewport-height are not automatically
+calculated and scrolling will not work properly until the viewport-width
+or viewport-height are set manually for the horizontal and vertical
+scrolling respectively. The ability to automatically calculate the
+viewport-width and viewport-height when using for loops may be added in
+the future and is tracked in issue #407.
+
 When not part of a layout, its width or height defaults to 100% of the parent element when not specified.
 
 ## `TextInput`

--- a/docs/builtin_elements.md
+++ b/docs/builtin_elements.md
@@ -576,21 +576,42 @@ FIXME: write docs
 
 ## `Flickable`
 
-FIXME: write docs
-
 The `Flickable` is a lower-level item that is the base for scrollable
 elements, such as the ScrollView widget. When the viewport-width or the
 viewport-height is greater than the parent width or parent height
 respectively the element becomes scrollable although the `Flickable`
-does not create a scrollbar. When using a for loop to populate the
-elements, the viewport-width and viewport-height are not automatically
-calculated and scrolling will not work properly until the viewport-width
-or viewport-height are set manually for the horizontal and vertical
-scrolling respectively. The ability to automatically calculate the
-viewport-width and viewport-height when using for loops may be added in
-the future and is tracked in issue #407.
-
+does not create a scrollbar. The viewport-width and viewport-height are
+calculated automatically except for when using a for loop to populate
+the elements. In that case they are not automatically calculated. The
+ability to automatically calculate the viewport-width and
+viewport-height when using for loops may be added in the future and is
+tracked in issue #407.
 When not part of a layout, its width or height defaults to 100% of the parent element when not specified.
+
+### Properties
+
+* **`viewport-height`** (*length*): The total scrollable height
+* **`viewport-width`** (*length*): The total scrollable width
+* **`viewport-x: native_output`** (*length*): 
+* **`viewport-y: native_output`** (*length*): 
+* **`interactive: true (*bool*):
+
+### Example
+
+```60
+Example := Window {
+    width: 270px;
+    height: 100px;
+
+    Flickable {
+        viewport-height: 300px;
+        Text {
+            y: 150px;
+            text: "This is some text that you have to scroll to see";
+        }
+    }
+}
+```
 
 ## `TextInput`
 

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -225,15 +225,14 @@ Example := Window {
 
 ## `ScrollView`
 
-A Scrollview contains a viewport that is bigger than the view and can be scrolled.
-It has scrollbar to interact with.
-When using a for loop to populate the elements, the viewport-width and
-viewport-height are not automatically calculated and scrolling will not
-work properly until the viewport-width or viewport-height are set
-manually for the horizontal and vertical scrolling respectively. 
-The ability to automatically calculate the viewport-width and
-viewport-height when using for loops may be added in the future and is 
-tracked in issue #407.
+A Scrollview contains a viewport that is bigger than the view and can be
+scrolled. It has scrollbar to interact with. The viewport-width and
+viewport-height are calculated automatically to create a scollable view
+except for when using a for loop to populate the elements. In that case
+the viewport-width and viewport-height are not calculated automatically
+and must be set manually for scrolling to work. The ability to
+automatically calculate the viewport-width and viewport-height when
+using for loops may be added in the future and is tracked in issue #407.
 
 ### Properties
 

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -227,6 +227,13 @@ Example := Window {
 
 A Scrollview contains a viewport that is bigger than the view and can be scrolled.
 It has scrollbar to interact with.
+When using a for loop to populate the elements, the viewport-width and
+viewport-height are not automatically calculated and scrolling will not
+work properly until the viewport-width or viewport-height are set
+manually for the horizontal and vertical scrolling respectively. 
+The ability to automatically calculate the viewport-width and
+viewport-height when using for loops may be added in the future and is 
+tracked in issue #407.
 
 ### Properties
 


### PR DESCRIPTION
Include documentation about needing to manually set the viewport-width and viewport-height when using a for loop.
I also added some more general documentation to `Flickable` but it likely needs to be edited as my explanation was a bit wordy. 
Are there other points in the documentation that need this same explanation or is this sufficient?