### PR TITLE
Fix opacity property not affecting the shadow color

### DIFF
--- a/sixtyfps_compiler/passes.rs
+++ b/sixtyfps_compiler/passes.rs
@@ -105,15 +105,18 @@ pub async fn run_passes(
         lower_popups::lower_popups(component, &doc.local_registry, diag);
         lower_layout::lower_layouts(component, &mut type_loader, diag).await;
         z_order::reorder_by_z_order(component, diag);
-        lower_shadows::lower_shadow_properties(component, &doc.local_registry, diag);
-        clip::handle_clip(component, &global_type_registry.borrow(), diag);
         transform_and_opacity::handle_transform_and_opacity(
             component,
             &global_type_registry.borrow(),
             diag,
         );
-        default_geometry::default_geometry(component, diag);
+        lower_shadows::lower_shadow_properties(component, &doc.local_registry, diag);
+        clip::handle_clip(component, &global_type_registry.borrow(), diag);
         visible::handle_visible(component, &global_type_registry.borrow());
+        // Apply the default geometry after any synthetic elements may have been injected as root in repeaters (opacity, box shadow, etc.).
+        // The geometry bindings are moved to the new injected roots, but the previous elements rely on the default geometry pass to size
+        // them correctly relative to the new root.
+        default_geometry::default_geometry(component, diag);
         materialize_fake_properties::materialize_fake_properties(component);
     }
     collect_globals::collect_globals(&doc, diag);

--- a/sixtyfps_compiler/passes/lower_shadows.rs
+++ b/sixtyfps_compiler/passes/lower_shadows.rs
@@ -83,7 +83,7 @@ fn inject_shadow_element_in_repeated_element(
     let element_with_shadow_property =
         &repeated_element.borrow().base_type.as_component().root_element.clone();
 
-    let mut shadow_element = match create_box_shadow_element(
+    let shadow_element = match create_box_shadow_element(
         shadow_property_bindings,
         element_with_shadow_property,
         type_register,
@@ -92,25 +92,6 @@ fn inject_shadow_element_in_repeated_element(
         Some(element) => element,
         None => return,
     };
-
-    // The values for properties that affect the geometry may be supplied in two different ways:
-    //
-    //   * When coming from the outside, for example by the repeater being inside a layout, we need
-    //     the values to apply to the shadow element and the old root just needs to follow.
-    //   * When coming from the inside, for example when the repeater just creates rectangles that
-    //     calculate their own position, we need to move those bindings as well to the shadow.
-    //
-    //  Finally we default geometry pass following this shadow lowering will apply a binding to
-    //  the width and height of the inner to follow the size of the parent (the shadow).
-    {
-        let mut element_with_shadow_property = element_with_shadow_property.borrow_mut();
-        for (binding_to_move, _) in crate::typeregister::RESERVED_GEOMETRY_PROPERTIES.iter() {
-            let binding_to_move = binding_to_move.to_string();
-            if let Some(binding) = element_with_shadow_property.bindings.remove(&binding_to_move) {
-                shadow_element.bindings.insert(binding_to_move, binding);
-            }
-        }
-    }
 
     crate::object_tree::inject_element_as_repeated_element(
         repeated_element,


### PR DESCRIPTION
The opacity on a rectangle should be applied before the shadow, so that it has
a visible effect.

This is a partial fix for #714 but needs also #725 to be entirely visually correct.