### PR TITLE
Introduce builtin namespaces for the Colors and Math functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+ - Colors names can now be accessed through the `Colors` namespace
+
 ### Fixed
 
  - Memory leak in C++

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
  - Colors names can now be accessed through the `Colors` namespace
+ - Math function are now available through the `Math` namespace
 
 ### Fixed
 

--- a/docs/langref.md
+++ b/docs/langref.md
@@ -939,6 +939,10 @@ the focus the very first time the window receives the focus - it becomes the ini
 
 The debug function take a string as an argument and prints it
 
+### `Math` namespace
+
+These functions are available both in the global scope and in the `Math` namespace.
+
 * **`min`**, **`max`**
 
 Return the arguments with the minimum (or maximum) value. All arguments must be of the same numeric type
@@ -967,6 +971,10 @@ The trigonometry function. Note that the should be typed with `deg` or `rad` uni
 * **`sqrt(float) -> float`**
 
 Square root
+
+### `Colors` namespace
+
+These functions are available both in the global scope, and in the `Colors` namespace.
 
 * **`rgb(int, int, int) -> color`**,  **`rgba(int, int, int, float) -> color`**
 

--- a/docs/langref.md
+++ b/docs/langref.md
@@ -471,14 +471,16 @@ Color literals follow the syntax of CSS:
 Example := Rectangle {
     background: blue;
     property<color> c1: #ffaaff;
+    property<brush> b2: Colors.red;
 }
 ```
-
-(TODO: currently color name are only limited to a handful and only supported in color property)
 
 In addition to plain colors, many elements have properties that are of type `brush` instead of `color`.
 A brush is a type that can be either a color or gradient. The brush is then used to fill an element or
 draw the outline.
+
+CSS Color names are only in scope in expressions of type `color` or `brush`. Otherwise, you can access
+colors from the `Colors` namespace.
 
 #### Methods
 

--- a/sixtyfps_compiler/passes/resolving.rs
+++ b/sixtyfps_compiler/passes/resolving.rs
@@ -563,6 +563,31 @@ impl Expression {
                 }
             }
             LookupResult::Expression { expression, .. } => maybe_lookup_object(expression, it, ctx),
+            LookupResult::Namespace(_) => {
+                if let Some(next_identifier) = it.next() {
+                    match result
+                        .lookup(ctx, &crate::parser::normalize_identifier(next_identifier.text()))
+                    {
+                        Some(LookupResult::Expression { expression, .. }) => {
+                            maybe_lookup_object(expression, it, ctx)
+                        }
+                        _ => {
+                            ctx.diag.push_error(
+                                format!(
+                                    "'{}' is not a member of the namespace {}",
+                                    next_identifier.text(),
+                                    first_str
+                                ),
+                                &next_identifier,
+                            );
+                            return Expression::Invalid;
+                        }
+                    }
+                } else {
+                    ctx.diag.push_error("Cannot take reference to a namespace".to_string(), &node);
+                    return Expression::Invalid;
+                }
+            }
         }
     }
 

--- a/sixtyfps_compiler/tests/syntax/lookup/color.60
+++ b/sixtyfps_compiler/tests/syntax/lookup/color.60
@@ -39,4 +39,11 @@ X := Rectangle {
         property<color> b: 123;
 //                        ^error{Cannot convert float to color}
     }
+
+    Rectangle {
+        background: Colors;
+//                  ^error{Cannot take reference to a namespace}
+        property<color> xxx: Colors.xxx;
+//                                  ^error{'xxx' is not a member of the namespace Colors}
+    }
 }

--- a/tests/cases/expr/math.60
+++ b/tests/cases/expr/math.60
@@ -8,8 +8,8 @@
     Please contact info@sixtyfps.io for more information.
 LICENSE END */
  TestCase := Rectangle {
-    property <bool> test_sqrt: sqrt(100) == 10 && sqrt(1) == 1 && sqrt(6.25) == 2.5;
-    property <bool> test_abs: abs(100.5) == 100.5 && abs(-200.5) == 200.5 && abs(0) == 0;
+    property <bool> test_sqrt: sqrt(100) == 10 && Math.sqrt(1) == 1 && sqrt(6.25) == 2.5;
+    property <bool> test_abs: abs(100.5) == 100.5 && Math.abs(-200.5) == 200.5 && abs(0) == 0;
     property <bool> test: test_sqrt && test_abs;
 }
 /*

--- a/tests/cases/expr/minmax.60
+++ b/tests/cases/expr/minmax.60
@@ -11,6 +11,12 @@ LICENSE END */
     property <int> a;
     property <float> t1: max(41, 12, min(100, 12), max(-10000, 0+98.5), -4) + min(a, 0.5);
     property <bool> t2: round(10/4) == 3 && floor(10/4) == 2 && ceil(10/4) == 3;
+
+    r := Rectangle {
+        property <int> max: 42;
+        property <int> xx: Math.max(1, 2, 3) + max;
+    }
+    property <bool> test: t2 && r.xx == 42 + 3;
 }
 /*
 ```cpp

--- a/tests/cases/types/color.60
+++ b/tests/cases/types/color.60
@@ -29,6 +29,8 @@ Test := Rectangle {
     property<color> c3: rgba(39%, 50%, 16%, 81%);
 
     property<color> i1: rgb(0, 666, -85);
+
+    property<bool> test: b1 == b2 && b2 == b5 && b3 == Colors.blue && Colors.red == r4;
 }
 
 /*

--- a/tests/cases/types/color.60
+++ b/tests/cases/types/color.60
@@ -30,7 +30,7 @@ Test := Rectangle {
 
     property<color> i1: rgb(0, 666, -85);
 
-    property<bool> test: b1 == b2 && b2 == b5 && b3 == Colors.blue && Colors.red == r4;
+    property<bool> test: b1 == b2 && b2 == b5 && b3 == Colors.blue && Colors.red == r4 && y1 == Colors.rgba(255, 100%, 0, 100%);
 }
 
 /*

--- a/tools/lsp/completion.rs
+++ b/tools/lsp/completion.rs
@@ -332,6 +332,11 @@ fn completion_item_from_expression(str: &str, lookup_result: LookupResult) -> Co
             c.kind = Some(CompletionItemKind::ENUM);
             c
         }
+        LookupResult::Namespace(_) => CompletionItem {
+            label: str.to_string(),
+            kind: Some(CompletionItemKind::MODULE),
+            ..CompletionItem::default()
+        },
     }
 }
 


### PR DESCRIPTION
This fully closes https://github.com/sixtyfpsui/sixtyfps/issues/53  (although it said `Color.` instead of `Colors.`)