### PR TITLE
Add support for additional non-printable keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+ - **Breaking:** The internal key code for the keys left, right, home and end
+   has changed. This was undocumented, but if one was handling this in the
+   `FocusScope` event, these keys will now be ignored. Use the `Keys.LeftArrow`
+   and other code exposed in the `Keys` namespace instead
+
 ### Added
 
  - Colors names can now be accessed through the `Colors` namespace
@@ -10,6 +17,8 @@ All notable changes to this project will be documented in this file.
  - `TouchArea` gained a `mouse-cursor` property to change the mouse cursor
  - C++: Added version macros
  - Optimize some property access by doing more constant propagation
+ - More special keyboard key codes are provided in the `FocusScope`, and
+   special keys are handled
 
 ### Fixed
 

--- a/docs/builtin_elements.md
+++ b/docs/builtin_elements.md
@@ -458,6 +458,10 @@ Example := Window {
 
 The FocusScope exposes callback to intercept the pressed key when it has focus.
 
+The KeyEvent has a text property which is a character of the key entered.
+When a non-printable key is pressed, the character will be either a control character,
+or a private unicode character. The special characters are available in the `Keys` namespace
+
 ### Properties
 
 * **`has-focus`** (*bool*): Set to `true` when item is focused and receives keyboard events.
@@ -481,6 +485,9 @@ Example := Window {
             debug(event.text);
             if (event.modifiers.control) {
                 debug("control was pressed during this event");
+            }
+            if (event.text == Keys.Escape) {
+                debug("Esc key was pressed")
             }
             accept
         }

--- a/docs/builtin_elements.md
+++ b/docs/builtin_elements.md
@@ -460,7 +460,7 @@ The FocusScope exposes callback to intercept the pressed key when it has focus.
 
 The KeyEvent has a text property which is a character of the key entered.
 When a non-printable key is pressed, the character will be either a control character,
-or a private unicode character. The special characters are available in the `Keys` namespace
+or it will be mapped to a private unicode character. The mapping of these non-printable, special characters is available in the `Keys` namespace
 
 ### Properties
 

--- a/sixtyfps_compiler/lookup/key_codes.rs
+++ b/sixtyfps_compiler/lookup/key_codes.rs
@@ -1,0 +1,1 @@
+../../sixtyfps_runtime/corelib/input/key_codes.rs

--- a/sixtyfps_compiler/widgets/fluent/sixtyfps_widgets.60
+++ b/sixtyfps_compiler/widgets/fluent/sixtyfps_widgets.60
@@ -386,6 +386,18 @@ export StandardListView := ListView {
             clicked => { current-item = idx; }
         }
     }
+    FocusScope {
+        key-pressed(event) => {
+            if (event.text == Keys.UpArrow && current-item > 0) {
+                current-item -= 1;
+                return accept;
+            } else if (event.text == Keys.DownArrow && current-item + 1 < model.length) {
+                current-item += 1;
+                return accept;
+            }
+            reject
+        }
+    }
 }
 
 export ComboBox := FocusScope {

--- a/sixtyfps_compiler/widgets/native/sixtyfps_widgets.60
+++ b/sixtyfps_compiler/widgets/native/sixtyfps_widgets.60
@@ -73,6 +73,18 @@ export StandardListView := ListView {
             has-hover <=> parent.has-hover;
         }
     }
+    FocusScope {
+        key-pressed(event) => {
+            if (event.text == Keys.UpArrow && current-item > 0) {
+                current-item -= 1;
+                return accept;
+            } else if (event.text == Keys.DownArrow && current-item + 1 < model.length) {
+                current-item += 1;
+                return accept;
+            }
+            reject
+        }
+    }
 }
 
 

--- a/sixtyfps_runtime/corelib/input.rs
+++ b/sixtyfps_runtime/corelib/input.rs
@@ -117,82 +117,15 @@ impl Default for InputEventFilterResult {
     }
 }
 
-/// InternalKeyCode is used to certain keys to unicode characters, since our
-/// public key event only exposes a string. This enum captures this mapping.
-#[derive(Debug, PartialEq, Clone)]
-pub enum InternalKeyCode {
-    /// Code corresponding to the left cursor key - encoded as 0xE ASCII (shift out)
-    Left,
-    /// Code corresponding to the right cursor key -- encoded as 0xF ASCII (shift in)
-    Right,
-    /// Code corresponding to the home key -- encoded as 0x2 ASCII (start of text)
-    Home,
-    /// Code corresponding to the end key -- encoded as 0x3 ASCII (end of text)
-    End,
-    /// Code corresponding to the backspace key -- encoded as 0x7 ASCII (backspace)
-    Back,
-    /// Code corresponding to the delete key -- encoded as 0x7F ASCII (delete)
-    Delete,
-    /// Code corresponding to the tab key -- encoded as 0x9 ASCII (horizontal tab)
-    Tab,
-    /// Code corresponding to the return key -- encoded as 0xA ASCII (newline)
-    Return,
-    /// Code corresponding to the return key -- encoded as 0x1b ASCII (escape)
-    Escape,
+macro_rules! for_each_special_keys {
+    ($($char:literal # $name:ident # $($_qt:ident)|* # $($_winit:ident)|* ;)*) => {
+        $(pub const $name : char = $char;)*
+    };
 }
 
-const LEFT_CODE: char = '\u{000E}'; // shift out
-const RIGHT_CODE: char = '\u{000F}'; // shift in
-const HOME_CODE: char = '\u{0002}'; // start of text
-const END_CODE: char = '\u{0003}'; // end of text
-const BACK_CODE: char = '\u{0007}'; // backspace \b
-const DELETE_CODE: char = '\u{007F}'; // cancel
-const TAB_CODE: char = '\u{0009}'; // \t
-const RETURN_CODE: char = '\u{000A}'; // \n
-const ESCAPE_CODE: char = '\u{001B}'; // esc
-
-impl InternalKeyCode {
-    /// Encodes the internal key code as string
-    pub fn encode_to_string(&self) -> SharedString {
-        let mut buffer = [0; 6];
-        SharedString::from(
-            match self {
-                InternalKeyCode::Left => LEFT_CODE,
-                InternalKeyCode::Right => RIGHT_CODE,
-                InternalKeyCode::Home => HOME_CODE,
-                InternalKeyCode::End => END_CODE,
-                InternalKeyCode::Back => BACK_CODE,
-                InternalKeyCode::Delete => DELETE_CODE,
-                InternalKeyCode::Tab => TAB_CODE,
-                InternalKeyCode::Return => RETURN_CODE,
-                InternalKeyCode::Escape => ESCAPE_CODE,
-            }
-            .encode_utf8(&mut buffer) as &str,
-        )
-    }
-    /// Tries to see if the provided string corresponds to a single special
-    /// encoded key.
-    pub fn try_decode_from_string(str: &SharedString) -> Option<Self> {
-        let mut chars = str.chars();
-        let ch = chars.next();
-        if ch.is_some() && chars.next().is_none() {
-            Some(match ch.unwrap() {
-                LEFT_CODE => Self::Left,
-                RIGHT_CODE => Self::Right,
-                HOME_CODE => Self::Home,
-                END_CODE => Self::End,
-                BACK_CODE => Self::Back,
-                DELETE_CODE => Self::Delete,
-                TAB_CODE => Self::Tab,
-                RETURN_CODE => Self::Return,
-                ESCAPE_CODE => Self::Escape,
-                _ => return None,
-            })
-        } else {
-            None
-        }
-    }
-}
+/// This module contains the constant character code used to represent the keys
+#[allow(missing_docs, non_upper_case_globals)]
+pub mod key_codes;
 
 /// KeyboardModifier provides booleans to indicate possible modifier keys
 /// on a keyboard, such as Shift, Control, etc.

--- a/sixtyfps_runtime/corelib/input/key_codes.rs
+++ b/sixtyfps_runtime/corelib/input/key_codes.rs
@@ -1,0 +1,95 @@
+/* LICENSE BEGIN
+    This file is part of the SixtyFPS Project -- https://sixtyfps.io
+    Copyright (c) 2021 Olivier Goffart <olivier.goffart@sixtyfps.io>
+    Copyright (c) 2021 Simon Hausmann <simon.hausmann@sixtyfps.io>
+
+    SPDX-License-Identifier: GPL-3.0-only
+    This file is also available under commercial licensing terms.
+    Please contact info@sixtyfps.io for more information.
+LICENSE END */
+
+// This module is meant to be included by different crate and each crate must define the macro for_each_keys
+
+// The key code comes from https://www.unicode.org/Public/MAPPINGS/VENDORS/APPLE/CORPCHAR.TXT
+// the names comes should match with https://www.w3.org/TR/uievents-key/#named-key-attribute-values,
+for_each_special_keys![
+'\u{0008}'  # Backspace   # Qt_Key_Key_Backspace    # Back          ;
+'\u{0009}'  # Tab         # Qt_Key_Key_Tab          # Tab           ;
+'\u{000a}'  # Return      # Qt_Key_Key_Enter|Qt_Key_Key_Return # NumpadEnter|Return ;
+'\u{001b}'  # Escape      # Qt_Key_Key_Escape       # Escape       ;
+'\u{007f}'  # Delete      # Qt_Key_Key_Delete       # Delete       ;
+
+'\u{F700}'	# UpArrow     # Qt_Key_Key_Up           # Up           ;
+'\u{F701}'	# DownArrow   # Qt_Key_Key_Down         # Down         ;
+'\u{F702}'	# LeftArrow   # Qt_Key_Key_Left         # Left         ;
+'\u{F703}'	# RightArrow  # Qt_Key_Key_Right        # Right        ;
+'\u{F704}'	# F1          # Qt_Key_Key_F1           # F1           ;
+'\u{F705}'	# F2          # Qt_Key_Key_F2           # F2           ;
+'\u{F706}'	# F3          # Qt_Key_Key_F3           # F3           ;
+'\u{F707}'	# F4          # Qt_Key_Key_F4           # F4           ;
+'\u{F708}'	# F5          # Qt_Key_Key_F5           # F5           ;
+'\u{F709}'	# F6          # Qt_Key_Key_F6           # F6           ;
+'\u{F70A}'	# F7          # Qt_Key_Key_F7           # F7           ;
+'\u{F70B}'	# F8          # Qt_Key_Key_F8           # F8           ;
+'\u{F70C}'	# F9          # Qt_Key_Key_F9           # F9           ;
+'\u{F70D}'	# F10         # Qt_Key_Key_F10          # F10          ;
+'\u{F70E}'	# F11         # Qt_Key_Key_F11          # F11          ;
+'\u{F70F}'	# F12         # Qt_Key_Key_F12          # F12          ;
+'\u{F710}'	# F13         # Qt_Key_Key_F13          # F13          ;
+'\u{F711}'	# F14         # Qt_Key_Key_F14          # F14          ;
+'\u{F712}'	# F15         # Qt_Key_Key_F15          # F15          ;
+'\u{F713}'	# F16         # Qt_Key_Key_F16          # F16          ;
+'\u{F714}'	# F17         # Qt_Key_Key_F17          # F17          ;
+'\u{F715}'	# F18         # Qt_Key_Key_F18          # F18          ;
+'\u{F716}'	# F19         # Qt_Key_Key_F19          # F19          ;
+'\u{F717}'	# F20         # Qt_Key_Key_F20          # F20          ;
+'\u{F718}'	# F21         # Qt_Key_Key_F21          # F21          ;
+'\u{F719}'	# F22         # Qt_Key_Key_F22          # F22          ;
+'\u{F71A}'	# F23         # Qt_Key_Key_F23          # F23          ;
+'\u{F71B}'	# F24         # Qt_Key_Key_F24          # F24          ;
+//'\u{F71C}'	# F25         # Qt_Key_Key_F25          #              ;
+//'\u{F71D}'	# F26         # Qt_Key_Key_F26          #              ;
+//'\u{F71E}'	# F27         # Qt_Key_Key_F27          #              ;
+//'\u{F71F}'	# F28         # Qt_Key_Key_F28          #              ;
+//'\u{F720}'	# F29         # Qt_Key_Key_F29          #              ;
+//'\u{F721}'	# F30         # Qt_Key_Key_F30          #              ;
+//'\u{F722}'	# F31         # Qt_Key_Key_F31          #              ;
+//'\u{F723}'	# F32         # Qt_Key_Key_F32          #              ;
+//'\u{F724}'	# F33         # Qt_Key_Key_F33          #              ;
+//'\u{F725}'	# F34         # Qt_Key_Key_F34          #              ;
+//'\u{F726}'	# F35         # Qt_Key_Key_F35          #              ;
+'\u{F727}'	# Insert      # Qt_Key_Key_Insert       # Insert       ;
+//'\u{F728}'	# Delete      # Qt_Key_Key_Delete       # Delete       ;  // already as a control code
+'\u{F729}'	# Home        # Qt_Key_Key_Home         # Home         ;
+//'\u{F72A}'	# Begin       #                         #              ;
+'\u{F72B}'	# End         # Qt_Key_Key_End          # End          ;
+'\u{F72C}'	# PageUp      # Qt_Key_Key_PageUp       # PageUp       ;
+'\u{F72D}'	# PageDown    # Qt_Key_Key_PageDown     # PageDown     ;
+//'\u{F72E}'	# PrintScreen #                         # Snapshot     ;
+'\u{F72F}'	# ScrollLock  # Qt_Key_Key_ScrollLock   # Scroll             ;
+'\u{F730}'	# Pause       # Qt_Key_Key_Pause        # Pause        ;
+'\u{F731}'	# SysReq      # Qt_Key_Key_SysReq       # Sysrq        ;
+//'\u{F732}'	# Break       #                         #              ;
+//'\u{F733}'	# Reset       #                         #              ;
+'\u{F734}'	# Stop        # Qt_Key_Key_Stop         # Stop         ;
+'\u{F735}'	# Menu        # Qt_Key_Key_Menu         #              ;
+//'\u{F736}'	# User        #                         #              ;
+//'\u{F737}'	# System      #                         #              ;
+//'\u{F738}'	# Print       # Qt_Key_Key_Print        #              ;
+//'\u{F739}'	# ClearLine   #                         #              ;
+//'\u{F73A}'	# ClearDisplay#                         #              ;
+//'\u{F73B}'	# InsertLine  #                         #              ;
+//'\u{F73C}'	# DeleteLine  #                         #              ;
+//'\u{F73D}'	# InsertChar  #                         #              ;
+//'\u{F73E}'	# DeleteChar  #                         #              ;
+//'\u{F73F}'	# Prev        #                         #              ;
+//'\u{F740}'	# Next        #                         #              ;
+//'\u{F741}'	# Select      # Qt_Key_Key_Select       #              ;
+//'\u{F742}'	# Execute     # Qt_Key_Key_Execute      #              ;
+//'\u{F743}'	# Undo        # Qt_Key_Key_Undo         #              ;
+//'\u{F744}'	# Redo        # Qt_Key_Key_Redo         #              ;
+//'\u{F745}'	# Find        # Qt_Key_Key_Find         #              ;
+//'\u{F746}'	# Help        # Qt_Key_Key_Help         #              ;
+//'\u{F747}'	# ModeSwitch  # Qt_Key_Key_Mode_switch  #            ;
+
+];

--- a/sixtyfps_runtime/corelib/items/text.rs
+++ b/sixtyfps_runtime/corelib/items/text.rs
@@ -385,6 +385,7 @@ impl Item for TextInput {
                 // Only insert/interpreter non-control character strings
                 if event.text.is_empty()
                     || event.text.as_str().chars().any(|ch| {
+                        // exclude the private use area as we encode special keys into it
                         (ch >= '\u{f700}' && ch <= '\u{f7ff}') || (ch.is_control() && ch != '\n')
                     })
                 {

--- a/sixtyfps_runtime/rendering_backends/gl/key_codes.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/key_codes.rs
@@ -1,0 +1,1 @@
+../../corelib/input/key_codes.rs

--- a/sixtyfps_runtime/rendering_backends/mcu/simulator/key_codes.rs
+++ b/sixtyfps_runtime/rendering_backends/mcu/simulator/key_codes.rs
@@ -1,0 +1,1 @@
+../../../corelib/input/key_codes.rs

--- a/sixtyfps_runtime/rendering_backends/qt/qt_window/key_codes.rs
+++ b/sixtyfps_runtime/rendering_backends/qt/qt_window/key_codes.rs
@@ -1,0 +1,1 @@
+../../../corelib/input/key_codes.rs

--- a/tests/cases/examples/key_press.60
+++ b/tests/cases/examples/key_press.60
@@ -14,6 +14,12 @@ W := Window {
         field := FocusScope {
             vertical_stretch: 1;
             key-pressed(event) => {
+                if (event.text == Keys.F1) {
+                    debug("F1");
+                }
+                if (event.text == Keys.PageUp) {
+                    debug("PageUp");
+                }
                 if (event.modifiers.control) {
                     debug("   (control modifier pressed)");
                 }

--- a/tests/cases/text/cursor_move.60
+++ b/tests/cases/text/cursor_move.60
@@ -20,12 +20,11 @@ TestCase := TextInput {
 /*
 ```rust
 
-// from input.rs
-const LEFT_CODE: char = '\u{000E}'; // shift out
-const RIGHT_CODE: char = '\u{000F}'; // shift in
-const HOME_CODE: char = '\u{0002}'; // start of text
-const END_CODE: char = '\u{0003}'; // end of text
-const BACK_CODE: char = '\u{0007}'; // backspace \b
+const LEFT_CODE: char = '\u{F702}';
+const RIGHT_CODE: char = '\u{F703}';
+const HOME_CODE: char = '\u{F729}';
+const END_CODE: char = '\u{F72B}';
+const BACK_CODE: char = '\u{0008}'; // backspace \b
 
 let shift_modifier = sixtyfps::re_exports::KeyboardModifiers {
     shift: true,

--- a/tests/cases/text/cursor_move_grapheme.60
+++ b/tests/cases/text/cursor_move_grapheme.60
@@ -20,9 +20,8 @@ TestCase := TextInput {
 /*
 ```rust
 
-// from input.rs
-const LEFT_CODE: char = '\u{000E}'; // shift out
-const BACK_CODE: char = '\u{0007}'; // backspace \b
+const LEFT_CODE: char = '\u{F702}';
+const BACK_CODE: char = '\u{0008}'; // backspace \b
 
 let shift_modifier = sixtyfps::re_exports::KeyboardModifiers {
     shift: true,

--- a/tests/cases/text/cut.60
+++ b/tests/cases/text/cut.60
@@ -20,9 +20,7 @@ TestCase := TextInput {
 /*
 ```rust
 
-
-// from input.rs
-const LEFT_CODE: char = '\u{000E}'; // shift out
+const LEFT_CODE: char = '\u{F702}';
 
 let shift_modifier = sixtyfps::re_exports::KeyboardModifiers {
     shift: true,

--- a/tests/cases/text/surrogate_cursor.60
+++ b/tests/cases/text/surrogate_cursor.60
@@ -20,9 +20,8 @@ TestCase := TextInput {
 /*
 ```rust
 
-// from input.rs
-const LEFT_CODE: char = '\u{000E}'; // shift out
-const BACK_CODE: char = '\u{0007}'; // backspace \b
+const LEFT_CODE: char = '\u{F702}';
+const BACK_CODE: char = '\u{0008}'; // backspace \b
 
 let shift_modifier = sixtyfps::re_exports::KeyboardModifiers {
     shift: true,

--- a/tests/cases/text/text_change.60
+++ b/tests/cases/text/text_change.60
@@ -26,8 +26,7 @@ TestCase := Window {
 /*
 ```rust
 
-// from input.rs
-const LEFT_CODE: char = '\u{000E}'; // shift out
+const LEFT_CODE: char = '\u{F702}';
 
 let instance = TestCase::new();
 sixtyfps::testing::send_mouse_click(&instance, 5., 5.);


### PR DESCRIPTION
Closes #170

 - centralize the list of keys in one file
 - add the ability to name the keys in the .60 files via `Keys`
 - As a test case, add support for up and down keys in the StandardListView

Note: 
 * I opted for a CamelCase key name in the Keys namespace because that's the same casing as what's used there: https://www.w3.org/TR/uievents-key/#named-key-attribute-values
Should we instead use the snake case: `Keys.left-arrow`  instead of `Keys.LeftArrow` ?

 * Thinking about it, the use of key code might be a problem if someone wants to print these text. Some replacement character will be used. We don't even have a is_printable API, or a way to say that a given code should not be used as text. (The code for the line edit hardcode the private range as an exclusion)



