### PR TITLE
GL backend: image svg cache fix

### DIFF
--- a/sixtyfps_runtime/corelib/graphics/image.rs
+++ b/sixtyfps_runtime/corelib/graphics/image.rs
@@ -241,6 +241,19 @@ impl Default for ImageInner {
     }
 }
 
+impl ImageInner {
+    /// Returns true if the image is a scalable vector image.
+    pub fn is_svg(&self) -> bool {
+        match self {
+            ImageInner::AbsoluteFilePath(path) => path.ends_with(".svg") || path.ends_with(".svgz"),
+            ImageInner::EmbeddedData { format, .. } => {
+                format.as_slice() == b"svg" || format.as_slice() == b"svgz"
+            }
+            _ => false,
+        }
+    }
+}
+
 impl<'a> From<&'a Image> for &'a ImageInner {
     fn from(other: &'a Image) -> Self {
         &other.0

--- a/sixtyfps_runtime/rendering_backends/gl/glwindow.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/glwindow.rs
@@ -15,7 +15,7 @@ use core::cell::{Cell, RefCell};
 use core::pin::Pin;
 use std::rc::{Rc, Weak};
 
-use super::{ImageCache, ItemGraphicsCache};
+use super::{ItemGraphicsCache, TextureCache};
 use crate::event_loop::WinitWindow;
 use const_field_offset::FieldOffsets;
 use corelib::component::ComponentRc;
@@ -40,7 +40,7 @@ pub struct GLWindow {
 
     pub(crate) graphics_cache: RefCell<ItemGraphicsCache>,
     // This cache only contains textures. The cache for decoded CPU side images is in crate::IMAGE_CACHE.
-    pub(crate) texture_cache: RefCell<ImageCache>,
+    pub(crate) texture_cache: RefCell<TextureCache>,
 
     #[cfg(target_arch = "wasm32")]
     canvas_id: String,
@@ -412,7 +412,7 @@ impl PlatformWindow for GLWindow {
         // Release GL textures and other GPU bound resources.
         self.with_current_context(|| {
             self.graphics_cache.borrow_mut().clear();
-            self.texture_cache.borrow_mut().remove_textures();
+            self.texture_cache.borrow_mut().clear();
         });
 
         self.map_state.replace(GraphicsWindowBackendState::Unmapped);

--- a/sixtyfps_runtime/rendering_backends/gl/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/lib.rs
@@ -902,7 +902,7 @@ impl GLItemRenderer {
                     let image = source_property.get();
                     let image_inner = (&image).into();
 
-                    ImageCacheKey::new(image_inner, Some(image_rendering))
+                    TextureCacheKey::new(image_inner, image_rendering)
                         .and_then(|cache_key| {
                             self.graphics_window
                                 .texture_cache


### PR DESCRIPTION
This refactors the image handling a little in the GL renderer a bit and fixes the cache invalidation when rendering SVGs where the target scaled size depends on the scale factor.

cc #734