### PR TITLE
wasm event proxy fixes

### DIFF
--- a/sixtyfps_runtime/rendering_backends/gl/event_loop.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/event_loop.rs
@@ -226,13 +226,11 @@ thread_local! {
 
 scoped_tls_hkt::scoped_thread_local!(static CURRENT_WINDOW_TARGET : for<'a> &'a RunningEventLoop<'a>);
 
-#[cfg(not(target_arch = "wasm32"))]
 pub(crate) enum GlobalEventLoopProxyOrEventQueue {
     Proxy(winit::event_loop::EventLoopProxy<CustomEvent>),
     Queue(Vec<CustomEvent>),
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 impl GlobalEventLoopProxyOrEventQueue {
     pub(crate) fn send_event(&mut self, event: CustomEvent) {
         match self {
@@ -256,7 +254,6 @@ impl GlobalEventLoopProxyOrEventQueue {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 impl Default for GlobalEventLoopProxyOrEventQueue {
     fn default() -> Self {
         Self::Queue(Vec::new())
@@ -267,6 +264,11 @@ impl Default for GlobalEventLoopProxyOrEventQueue {
 pub(crate) static GLOBAL_PROXY: once_cell::sync::OnceCell<
     std::sync::Mutex<GlobalEventLoopProxyOrEventQueue>,
 > = once_cell::sync::OnceCell::new();
+
+#[cfg(target_arch = "wasm32")]
+thread_local! {
+    pub(crate) static GLOBAL_PROXY: RefCell<Option<GlobalEventLoopProxyOrEventQueue>> = RefCell::new(None)
+}
 
 pub(crate) fn with_window_target<T>(callback: impl FnOnce(&dyn EventLoopInterface) -> T) -> T {
     if CURRENT_WINDOW_TARGET.is_set() {
@@ -519,13 +521,14 @@ pub fn run(quit_behavior: sixtyfps_corelib::backend::EventLoopQuitBehavior) {
 
     let event_loop_proxy = not_running_loop_instance.event_loop_proxy;
     #[cfg(not(target_arch = "wasm32"))]
-    {
-        GLOBAL_PROXY
-            .get_or_init(Default::default)
-            .lock()
-            .unwrap()
-            .set_proxy(event_loop_proxy.clone());
-    }
+    GLOBAL_PROXY.get_or_init(Default::default).lock().unwrap().set_proxy(event_loop_proxy.clone());
+    #[cfg(target_arch = "wasm32")]
+    GLOBAL_PROXY.with(|global_proxy| {
+        global_proxy
+            .borrow_mut()
+            .get_or_insert_with(Default::default)
+            .set_proxy(event_loop_proxy.clone())
+    });
 
     let mut winit_loop = not_running_loop_instance.instance;
 

--- a/sixtyfps_runtime/rendering_backends/gl/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/lib.rs
@@ -1226,11 +1226,31 @@ impl sixtyfps_corelib::backend::Backend for Backend {
     fn post_event(&'static self, event: Box<dyn FnOnce() + Send>) {
         let e = crate::event_loop::CustomEvent::UserEvent(event);
         #[cfg(not(target_arch = "wasm32"))]
-        crate::event_loop::GLOBAL_PROXY.get_or_init(Default::default).lock().unwrap().send_event(e);
-        #[cfg(target_arch = "wasm32")]
-        crate::event_loop::GLOBAL_PROXY.with(|global_proxy| {
-            global_proxy.borrow_mut().get_or_insert_with(Default::default).send_event(e)
-        });
+            crate::event_loop::GLOBAL_PROXY.get_or_init(Default::default).lock().unwrap().send_event(e);
+        #[cfg(target_arch = "wasm32")] {
+            use wasm_bindgen::closure::Closure;
+            use wasm_bindgen::JsCast;
+
+            let window = web_sys::window().expect("Failed to obtain window");
+            let send_event = || {
+                crate::event_loop::GLOBAL_PROXY.with(|global_proxy| {
+                    global_proxy.borrow_mut().get_or_insert_with(Default::default).send_event(e)
+                });
+            };
+
+            // Calling send_event is usually done by winit at the bottom of the stack,
+            // in event handlers, and thus winit might decide to process the event
+            // immediately within that stack.
+            // To prevent re-entrancy issues that might happen by getting the application
+            // event processed on top of the current stack, mimic the event handling
+            // use case and make sure that our event is processed on top of a clean stack.
+            window
+                .set_timeout_with_callback_and_timeout_and_arguments_0(
+                    &Closure::once_into_js(send_event).as_ref().unchecked_ref(),
+                    0,
+                )
+                .expect("Failed to set timeout");
+        }
     }
 
     fn image_size(&'static self, image: &Image) -> Size {

--- a/sixtyfps_runtime/rendering_backends/gl/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/lib.rs
@@ -1228,9 +1228,9 @@ impl sixtyfps_corelib::backend::Backend for Backend {
         #[cfg(not(target_arch = "wasm32"))]
         crate::event_loop::GLOBAL_PROXY.get_or_init(Default::default).lock().unwrap().send_event(e);
         #[cfg(target_arch = "wasm32")]
-        crate::event_loop::with_window_target(|event_loop| {
-            event_loop.event_loop_proxy().send_event(e).ok();
-        })
+        crate::event_loop::GLOBAL_PROXY.with(|global_proxy| {
+            global_proxy.borrow_mut().get_or_insert_with(Default::default).send_event(e)
+        });
     }
 
     fn image_size(&'static self, image: &Image) -> Size {

--- a/sixtyfps_runtime/rendering_backends/gl/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/lib.rs
@@ -1226,8 +1226,9 @@ impl sixtyfps_corelib::backend::Backend for Backend {
     fn post_event(&'static self, event: Box<dyn FnOnce() + Send>) {
         let e = crate::event_loop::CustomEvent::UserEvent(event);
         #[cfg(not(target_arch = "wasm32"))]
-            crate::event_loop::GLOBAL_PROXY.get_or_init(Default::default).lock().unwrap().send_event(e);
-        #[cfg(target_arch = "wasm32")] {
+        crate::event_loop::GLOBAL_PROXY.get_or_init(Default::default).lock().unwrap().send_event(e);
+        #[cfg(target_arch = "wasm32")]
+        {
             use wasm_bindgen::closure::Closure;
             use wasm_bindgen::JsCast;
 


### PR DESCRIPTION
This fixes an issue with invoke_from_event_loop not always working in WASM when called from outside the event loop and streamlines the code a little bit.

Not entirely sure that this will fix the doc example issue as well - the mouse handlers would go through the loop I think - but I haven't been able to test it.