### PR TITLE
Merge `Rc::ptr_eq` on traits use into a SharedModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ as well as the [Rust migration guide for the `sixtyfps` crate](api/sixtyfps-rs/m
  - In Rust and C++, `sixtyfps::Image::size()` now returns an integer size type.
  - `sixtyfps::interpreter::CallCallbackError` was renamed to `sixtyfps::interpreter::InvokeCallbackError`
  - Some deprecation warning in .60 became hard errors
+ - Replace `ModelHandle` with `ModelRc`
 
 ### Added
 

--- a/api/sixtyfps-rs/lib.rs
+++ b/api/sixtyfps-rs/lib.rs
@@ -181,7 +181,7 @@ The follow table summarizes the entire mapping:
 | `duration` | `i64` | At run-time, durations are always represented as signed 64-bit integers with millisecond precision. |
 | `angle` | `f32` | The value in degrees |
 | structure | `struct` of the same name | |
-| array | [`ModelHandle`] |  |
+| array | [`ModelRc`] |  |
 
 For user defined structures in the .60, an extra struct is generated.
 For example, if the `.60` contains
@@ -233,7 +233,7 @@ pub use sixtyfps_corelib::graphics::{
     Brush, Color, Image, LoadImageError, Rgb8Pixel, Rgba8Pixel, RgbaColor, SharedPixelBuffer,
 };
 pub use sixtyfps_corelib::model::{
-    Model, ModelHandle, ModelNotify, ModelPeer, ModelTracker, StandardListViewItem, VecModel,
+    Model, ModelNotify, ModelPeer, ModelRc, ModelTracker, StandardListViewItem, VecModel,
 };
 pub use sixtyfps_corelib::sharedvector::SharedVector;
 pub use sixtyfps_corelib::string::SharedString;

--- a/api/sixtyfps-rs/migration.md
+++ b/api/sixtyfps-rs/migration.md
@@ -62,3 +62,6 @@ fn model_tracker(&self) -> &dyn ModelTracker {
 }
 ```
 
+#### Minor changes to `Model`
+
+`ModelRc` replaces `ModelHandle`.

--- a/api/sixtyfps-rs/migration.md
+++ b/api/sixtyfps-rs/migration.md
@@ -64,4 +64,4 @@ fn model_tracker(&self) -> &dyn ModelTracker {
 
 #### Minor changes to `Model`
 
-`ModelRc` replaces `ModelHandle`.
+`ModelHandle` was renamed [`ModelRc`].

--- a/docs/tutorial/rust/src/main_game_logic_in_rust.rs
+++ b/docs/tutorial/rust/src/main_game_logic_in_rust.rs
@@ -20,7 +20,7 @@ fn main() {
     // ANCHOR: game_logic
     // Assign the shuffled Vec to the model property
     let tiles_model = std::rc::Rc::new(sixtyfps::VecModel::from(tiles));
-    main_window.set_memory_tiles(sixtyfps::ModelHandle::new(tiles_model.clone()));
+    main_window.set_memory_tiles(sixtyfps::ModelRc::new(tiles_model.clone()));
 
     let main_window_weak = main_window.as_weak();
     main_window.on_check_if_pair_solved(move || {

--- a/docs/tutorial/rust/src/main_tiles_from_rust.rs
+++ b/docs/tutorial/rust/src/main_tiles_from_rust.rs
@@ -20,7 +20,7 @@ fn main() {
 
     // Assign the shuffled Vec to the model property
     let tiles_model = std::rc::Rc::new(sixtyfps::VecModel::from(tiles));
-    main_window.set_memory_tiles(sixtyfps::ModelHandle::new(tiles_model));
+    main_window.set_memory_tiles(sixtyfps::ModelRc::new(tiles_model));
 
     main_window.run();
 }

--- a/examples/imagefilter/main.rs
+++ b/examples/imagefilter/main.rs
@@ -140,7 +140,7 @@ pub fn main() {
     ]);
     let filters = Rc::new(filters);
 
-    main_window.set_filters(sixtyfps::ModelHandle::new(filters.clone()));
+    main_window.set_filters(sixtyfps::ModelRc::new(filters.clone()));
 
     main_window.on_filter_image(move |filter_index| {
         let filter_fn = filters.0[filter_index as usize].apply_function;

--- a/examples/memory/main.rs
+++ b/examples/memory/main.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@sixtyfps.io>
 // SPDX-License-Identifier: (GPL-3.0-only OR LicenseRef-SixtyFPS-commercial)
 
-use sixtyfps::{Model, ModelHandle, Timer, VecModel};
+use sixtyfps::{Model, ModelRc, Timer, VecModel};
 use std::rc::Rc;
 use std::time::Duration;
 
@@ -30,7 +30,7 @@ pub fn main() {
 
     let tiles_model = Rc::new(VecModel::from(tiles));
 
-    main_window.set_memory_tiles(ModelHandle::new(tiles_model.clone()));
+    main_window.set_memory_tiles(ModelRc::new(tiles_model.clone()));
 
     let main_window_weak = main_window.as_weak();
 

--- a/examples/printerdemo/rust/main.rs
+++ b/examples/printerdemo/rust/main.rs
@@ -59,7 +59,7 @@ pub fn main() {
     });
     main_window
         .global::<PrinterQueue>()
-        .set_printer_queue(sixtyfps::ModelHandle::new(printer_queue.data.clone()));
+        .set_printer_queue(sixtyfps::ModelRc::new(printer_queue.data.clone()));
 
     main_window.on_quit(move || {
         #[cfg(not(target_arch = "wasm32"))]

--- a/examples/slide_puzzle/main.rs
+++ b/examples/slide_puzzle/main.rs
@@ -180,7 +180,7 @@ pub fn main() {
         finished: false,
     }));
     state.borrow_mut().randomize();
-    main_window.set_pieces(sixtyfps::ModelHandle::new(state.borrow().pieces.clone()));
+    main_window.set_pieces(sixtyfps::ModelRc::new(state.borrow().pieces.clone()));
 
     let state_copy = state.clone();
     main_window.on_piece_clicked(move |p| {

--- a/examples/todo/rust/main.rs
+++ b/examples/todo/rust/main.rs
@@ -45,7 +45,7 @@ pub fn main() {
         }
     });
 
-    main_window.set_todo_model(sixtyfps::ModelHandle::new(todo_model));
+    main_window.set_todo_model(sixtyfps::ModelRc::new(todo_model));
 
     main_window.run();
 }

--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -78,7 +78,7 @@ fn rust_type(ty: &Type) -> Option<proc_macro2::TokenStream> {
         Type::Struct { name: Some(name), .. } => Some(struct_name_to_tokens(name)),
         Type::Array(o) => {
             let inner = rust_type(o)?;
-            Some(quote!(sixtyfps::re_exports::ModelHandle<#inner>))
+            Some(quote!(sixtyfps::re_exports::ModelRc<#inner>))
         }
         Type::Enumeration(e) => {
             let e = ident(&e.name);
@@ -536,7 +536,7 @@ fn generate_sub_component(
 
         let mut model = compile_expression(&repeated.model, &ctx);
         if repeated.model.ty(&ctx) == Type::Bool {
-            model = quote!(sixtyfps::re_exports::ModelHandle::new(sixtyfps::re_exports::Rc::<bool>::new(#model)))
+            model = quote!(sixtyfps::re_exports::ModelRc::new(sixtyfps::re_exports::Rc::<bool>::new(#model)))
         }
 
         init.push(quote! {
@@ -1273,7 +1273,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
                     ))
                 }
                 (Type::Float32, Type::Model) | (Type::Int32, Type::Model) => {
-                    quote!(sixtyfps::re_exports::ModelHandle::new(sixtyfps::re_exports::Rc::<usize>::new(#f as usize)))
+                    quote!(sixtyfps::re_exports::ModelRc::new(sixtyfps::re_exports::Rc::<usize>::new(#f as usize)))
                 }
                 (Type::Float32, Type::Color) => {
                     quote!(sixtyfps::re_exports::Color::from_argb_encoded(#f as u32))
@@ -1446,7 +1446,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
             let base_e = compile_expression(array, ctx);
             let index_e = compile_expression(index, ctx);
             let value_e = compile_expression(value, ctx);
-            quote!((#base_e).set_row_data(#index_e as usize, #value_e as _);)
+            quote!((#base_e).set_row_data(#index_e as usize, #value_e as _))
         }
         Expression::BinaryExpression { lhs, rhs, op } => {
             let (conv1, conv2) = match crate::expression_tree::operator_class(*op) {
@@ -1536,7 +1536,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
             let val = values.iter().map(|e| compile_expression(e, ctx));
             if *as_model {
                 let rust_element_ty = rust_type(element_ty).unwrap();
-                quote!(sixtyfps::re_exports::ModelHandle::new(
+                quote!(sixtyfps::re_exports::ModelRc::new(
                     sixtyfps::re_exports::Rc::new(sixtyfps::re_exports::VecModel::<#rust_element_ty>::from(
                         sixtyfps::re_exports::vec![#(#val as _),*]
                     ))

--- a/sixtyfps_runtime/corelib/model.rs
+++ b/sixtyfps_runtime/corelib/model.rs
@@ -464,7 +464,7 @@ impl Model for bool {
 
 /// Properties of type Array in the .60 language are represented as
 /// a `ModelRc` that implements the `Model` trait.
-#[derive(derive_more::Deref, derive_more::DerefMut, derive_more::From, derive_more::Into)]
+#[derive(derive_more::Deref, derive_more::DerefMut)]
 pub struct ModelRc<T>(Option<Rc<dyn Model<Data = T>>>);
 
 impl<T> core::fmt::Debug for ModelRc<T> {

--- a/sixtyfps_runtime/corelib/model.rs
+++ b/sixtyfps_runtime/corelib/model.rs
@@ -463,7 +463,7 @@ impl Model for bool {
 }
 
 /// Properties of type Array in the .60 language are represented as
-/// a `ModelRc` that implements the `Model` trait.
+/// a `ModelRc` that implements the [`Model`] trait.
 #[derive(derive_more::Deref, derive_more::DerefMut)]
 pub struct ModelRc<T>(Option<Rc<dyn Model<Data = T>>>);
 

--- a/sixtyfps_runtime/corelib/model.rs
+++ b/sixtyfps_runtime/corelib/model.rs
@@ -751,16 +751,14 @@ impl<C: RepeatedComponent + 'static> Repeater<C> {
         listview_width: f32,
         listview_height: Pin<&Property<f32>>,
     ) {
-        let empty_model = || {
-            self.inner.borrow_mut().components.clear();
-            viewport_height.set(0.);
-            viewport_y.set(0.);
-        };
-
         let model = self.model();
         let row_count = model.row_count();
         if row_count == 0 {
-            return empty_model();
+            self.inner.borrow_mut().components.clear();
+            viewport_height.set(0.);
+            viewport_y.set(0.);
+
+            return;
         }
 
         let init = &init;

--- a/sixtyfps_runtime/interpreter/api.rs
+++ b/sixtyfps_runtime/interpreter/api.rs
@@ -4,7 +4,7 @@
 use core::convert::TryInto;
 use sixtyfps_compilerlib::langtype::Type as LangType;
 use sixtyfps_corelib::graphics::Image;
-use sixtyfps_corelib::model::{Model, ModelHandle};
+use sixtyfps_corelib::model::{Model, ModelRc};
 use sixtyfps_corelib::{Brush, PathData, SharedString, SharedVector};
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -92,7 +92,7 @@ pub enum Value {
     /// Correspond to the `image` type in .60
     Image(Image),
     /// A model (that includes array in .60)
-    Model(ModelHandle<Value>),
+    Model(ModelRc<Value>),
     /// An object
     Struct(Struct),
     /// Correspond to `brush` or `color` type in .60.  For color, this is then a [`Brush::SolidColor`]
@@ -144,11 +144,7 @@ impl PartialEq for Value {
             Value::Image(lhs) => matches!(other, Value::Image(rhs) if lhs == rhs),
             Value::Model(lhs) => {
                 if let Value::Model(rhs) = other {
-                    match (&lhs.0, &rhs.0) {
-                        (None, None) => true,
-                        (None, Some(_)) | (Some(_), None) => false,
-                        (Some(a), Some(b)) => Rc::ptr_eq(a, b),
-                    }
+                    lhs == rhs
                 } else {
                     false
                 }
@@ -1364,13 +1360,13 @@ fn component_definition_model_properties() {
 
     let instance = comp_def.create();
 
-    let int_model = Value::Model(ModelHandle::new(Rc::new(VecModel::from_slice(&[
+    let int_model = Value::Model(ModelRc::new(Rc::new(VecModel::from_slice(&[
         Value::Number(14.),
         Value::Number(15.),
         Value::Number(16.),
     ]))));
-    let empty_model = Value::Model(ModelHandle::new(Rc::new(VecModel::<Value>::default())));
-    let model_with_string = Value::Model(ModelHandle::new(Rc::new(VecModel::from_slice(&[
+    let empty_model = Value::Model(ModelRc::new(Rc::new(VecModel::<Value>::default())));
+    let model_with_string = Value::Model(ModelRc::new(Rc::new(VecModel::from_slice(&[
         Value::Number(1000.),
         Value::String("foo".into()),
         Value::Number(1111.),

--- a/sixtyfps_runtime/interpreter/dynamic_component.rs
+++ b/sixtyfps_runtime/interpreter/dynamic_component.rs
@@ -1355,9 +1355,7 @@ pub fn instantiate(
                     InstanceRef::from_pin_ref(c, guard)
                 }),
             );
-            sixtyfps_corelib::model::ModelHandle(Some(Rc::new(
-                crate::value_model::ValueModel::new(m),
-            )))
+            sixtyfps_corelib::model::ModelRc::new(Rc::new(crate::value_model::ValueModel::new(m)))
         });
     }
 

--- a/sixtyfps_runtime/interpreter/eval.rs
+++ b/sixtyfps_runtime/interpreter/eval.rs
@@ -7,7 +7,7 @@ use core::convert::TryInto;
 use core::pin::Pin;
 use corelib::graphics::{GradientStop, LinearGradientBrush, PathElement};
 use corelib::items::{ItemRef, PropertyAnimation};
-use corelib::model::{Model, ModelHandle};
+use corelib::model::{Model, ModelRc};
 use corelib::rtti::AnimatedBindingKind;
 use corelib::window::{WindowHandleAccess, WindowRc};
 use corelib::{Brush, Color, PathData, SharedString, SharedVector};
@@ -568,10 +568,10 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
             }
         }
         Expression::Array { values, .. } => Value::Model(
-            ModelHandle::new(Rc::new(corelib::model::SharedVectorModel::from(
+            ModelRc::new(Rc::new(corelib::model::SharedVectorModel::from(
                 values.iter().map(|e| eval_expression(e, local_context)).collect::<SharedVector<_>>()
-            )) as Rc<dyn corelib::model::Model<Data = Value>>)
-        ),
+            )
+        ))),
         Expression::Struct { values, .. } => Value::Struct(
             values
                 .iter()

--- a/sixtyfps_runtime/interpreter/ffi.rs
+++ b/sixtyfps_runtime/interpreter/ffi.rs
@@ -85,7 +85,7 @@ pub unsafe extern "C" fn sixtyfps_interpreter_value_new_array_model(
     let vec = std::mem::transmute::<SharedVector<ValueOpaque>, SharedVector<Value>>(a.clone());
     std::ptr::write(
         val as *mut Value,
-        Value::Model(ModelHandle::new(Rc::new(SharedVectorModel::<Value>::from(vec)))),
+        Value::Model(ModelRc::new(Rc::new(SharedVectorModel::<Value>::from(vec)))),
     )
 }
 
@@ -121,7 +121,7 @@ pub unsafe extern "C" fn sixtyfps_interpreter_value_new_model(
 ) {
     std::ptr::write(
         val as *mut Value,
-        Value::Model(ModelHandle::new(Rc::new(ModelAdaptorWrapper(model)))),
+        Value::Model(ModelRc::new(Rc::new(ModelAdaptorWrapper(model)))),
     )
 }
 

--- a/tests/cases/crashes/layout_deleted_item.60
+++ b/tests/cases/crashes/layout_deleted_item.60
@@ -52,7 +52,7 @@ assert(!instance.get_hover());
 use sixtyfps::Model;
 let instance = TestCase::new();
 let vec_model = std::rc::Rc::new(sixtyfps::VecModel::from(vec![1i32, 2i32]));
-instance.set_model(sixtyfps::ModelHandle::from(vec_model.clone() as std::rc::Rc<dyn Model<Data = i32>>));
+instance.set_model(sixtyfps::ModelRc::new(vec_model.clone() as std::rc::Rc<dyn Model<Data = i32>>));
 instance.on_clicked(move || dbg!(vec_model.remove(vec_model.row_count() - 1)));
 sixtyfps::testing::send_mouse_click(&instance, 95., 5.);
 assert_eq!(instance.get_model().row_count(), 1);

--- a/tests/cases/models/array.60
+++ b/tests/cases/models/array.60
@@ -39,7 +39,7 @@ assert_eq!(instance.get_n(), 4);
 assert_eq!(instance.get_third_int(), 3);
 
 let model: std::rc::Rc<sixtyfps::VecModel<i32>> = std::rc::Rc::new(vec![1, 2, 3, 4, 5, 6, 7].into());
-instance.set_ints(sixtyfps::ModelHandle::new(model.clone()));
+instance.set_ints(sixtyfps::ModelRc::new(model.clone()));
 assert_eq!(instance.get_num_ints(), 7);
 assert_eq!(instance.get_third_int(), 3);
 model.push(8);

--- a/tests/cases/models/model.60
+++ b/tests/cases/models/model.60
@@ -62,7 +62,7 @@ let another_model = std::rc::Rc::new(sixtyfps::VecModel::<ModelData>::from(
         ("a3".into(), "world".into(), 333.),
     ]));
 
-instance.set_model(sixtyfps::ModelHandle::new(another_model.clone()));
+instance.set_model(sixtyfps::ModelRc::new(another_model.clone()));
 
 sixtyfps::testing::send_mouse_click(&instance, 25., 5.);
 assert_eq!(instance.get_clicked_score(), 333000);

--- a/tests/cases/models/write_to_model.60
+++ b/tests/cases/models/write_to_model.60
@@ -61,7 +61,7 @@ let another_model = std::rc::Rc::new(sixtyfps::VecModel::<ModelData>::from(
         ("a3".into(), "world".into(), 333.),
     ]));
 
-instance.set_model(sixtyfps::ModelHandle::new(another_model.clone()));
+instance.set_model(sixtyfps::ModelRc::new(another_model.clone()));
 
 sixtyfps::testing::send_mouse_click(&instance, 25., 5.);
 assert_eq!(instance.get_clicked_score(), 336);

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -3,7 +3,7 @@
 
 #![doc = include_str!("README.md")]
 
-use sixtyfps_corelib::model::{Model, ModelHandle};
+use sixtyfps_corelib::model::{Model, ModelRc};
 use sixtyfps_corelib::SharedVector;
 use sixtyfps_interpreter::{ComponentInstance, SharedString, Value};
 use std::future::Future;
@@ -268,12 +268,9 @@ fn load_data(instance: &ComponentInstance, data_path: &std::path::Path) -> Resul
                 }
                 serde_json::Value::String(s) => SharedString::from(s.as_str()).into(),
                 serde_json::Value::Array(array) => sixtyfps_interpreter::Value::Model(
-                    ModelHandle::new(Rc::new(sixtyfps_corelib::model::SharedVectorModel::from(
+                    ModelRc::new(Rc::new(sixtyfps_corelib::model::SharedVectorModel::from(
                         array.iter().map(from_json).collect::<SharedVector<Value>>(),
-                    ))
-                        as Rc<
-                            dyn sixtyfps_corelib::model::Model<Data = sixtyfps_interpreter::Value>,
-                        >),
+                    ))),
                 ),
                 serde_json::Value::Object(obj) => obj
                     .iter()


### PR DESCRIPTION
It is now safe to replace the manual implementation with the derived
implementation, so do that.

This is a continuation of #311, which I accidentally closed when I deleted the branch.