### PR TITLE
MCU backend updates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
           command: build
-          args: --verbose --all-features --workspace
+          args: --verbose --all-features --workspace --exclude sixtyfps-rendering-backend-mcu # mcu backend requires nightly
     - name: Run tests
       uses: actions-rs/cargo@v1
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ default-members = [
     'sixtyfps_runtime/interpreter',
     'sixtyfps_runtime/rendering_backends/gl',
     'sixtyfps_runtime/rendering_backends/qt',
-    'sixtyfps_runtime/rendering_backends/mcu',
     'sixtyfps_runtime/rendering_backends/default',
     'sixtyfps_compiler',
     'api/sixtyfps-rs',

--- a/sixtyfps_runtime/corelib/Cargo.toml
+++ b/sixtyfps_runtime/corelib/Cargo.toml
@@ -56,6 +56,8 @@ atomic-polyfill = { version = "0.1.5" }
 num-traits = { version = "0.2", default-features = false }
 sixtyfps-common = { version = "=0.1.6", path = "../common" }
 
+defmt = { version = "0.3.0", optional = true }
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 instant = { version = "0.1", features = [ "wasm-bindgen", "now" ] }
 web_sys = { version = "0.3", package = "web-sys", features=["console", "CanvasRenderingContext2d", "TextMetrics", "HtmlSpanElement"] }

--- a/sixtyfps_runtime/corelib/lib.rs
+++ b/sixtyfps_runtime/corelib/lib.rs
@@ -20,9 +20,10 @@ extern crate alloc;
 
 /// Unsafe module that is only enabled when the unsafe_single_core feature is on.
 /// It re-implements the thread_local macro with statics
-#[cfg(all(not(feature = "std"), feature = "unsafe_single_core"))]
-pub(crate) mod unsafe_single_core {
+#[cfg(feature = "unsafe_single_core")]
+pub mod unsafe_single_core {
     #![allow(unsafe_code)]
+    #[macro_export]
     macro_rules! thread_local_ {
         ($(#[$($meta:tt)*])* $vis:vis static $ident:ident : $ty:ty = $expr:expr) => {
             $(#[$($meta)*])*
@@ -32,7 +33,7 @@ pub(crate) mod unsafe_single_core {
             };
         };
     }
-    pub(crate) struct FakeThreadStorage<T, F = fn() -> T>(once_cell::unsync::OnceCell<T>, F);
+    pub struct FakeThreadStorage<T, F = fn() -> T>(once_cell::unsync::OnceCell<T>, F);
     impl<T, F> FakeThreadStorage<T, F> {
         pub const fn new(f: F) -> Self {
             Self(once_cell::unsync::OnceCell::new(), f)
@@ -50,9 +51,9 @@ pub(crate) mod unsafe_single_core {
     unsafe impl<T, F> Send for FakeThreadStorage<T, F> {}
     unsafe impl<T, F> Sync for FakeThreadStorage<T, F> {}
 
-    pub(crate) use thread_local_ as thread_local;
+    pub use thread_local_ as thread_local;
 
-    pub(crate) struct OnceCell<T>(once_cell::unsync::OnceCell<T>);
+    pub struct OnceCell<T>(once_cell::unsync::OnceCell<T>);
     impl<T> OnceCell<T> {
         pub const fn new() -> Self {
             Self(once_cell::unsync::OnceCell::new())

--- a/sixtyfps_runtime/corelib/tests.rs
+++ b/sixtyfps_runtime/corelib/tests.rs
@@ -98,6 +98,13 @@ cfg_if::cfg_if! {
         macro_rules! debug_log {
             ($($t:tt)*) => ($crate::tests::log(&format_args!($($t)*).to_string()))
         }
+    } else if #[cfg(feature = "std")] {
+        /// This macro allows producing debug output that will appear on stderr in regular builds
+        /// and in the console log for wasm builds.
+        #[macro_export]
+        macro_rules! debug_log {
+            ($($t:tt)*) => (eprintln!($($t)*))
+        }
     } else if #[cfg(feature = "defmt")] {
         #[doc(hidden)]
         pub fn log(s: &str) {
@@ -108,13 +115,6 @@ cfg_if::cfg_if! {
         /// This macro allows producing debug output that will appear on the output of the debug probe
         macro_rules! debug_log {
             ($($t:tt)*) => ($crate::tests::log({ use alloc::string::ToString; &format_args!($($t)*).to_string() }))
-        }
-    } else {
-        /// This macro allows producing debug output that will appear on stderr in regular builds
-        /// and in the console log for wasm builds.
-        #[macro_export]
-        macro_rules! debug_log {
-            ($($t:tt)*) => (eprintln!($($t)*))
         }
     }
 }

--- a/sixtyfps_runtime/corelib/tests.rs
+++ b/sixtyfps_runtime/corelib/tests.rs
@@ -98,6 +98,17 @@ cfg_if::cfg_if! {
         macro_rules! debug_log {
             ($($t:tt)*) => ($crate::tests::log(&format_args!($($t)*).to_string()))
         }
+    } else if #[cfg(feature = "defmt")] {
+        #[doc(hidden)]
+        pub fn log(s: &str) {
+            defmt::println!("{=str}", s);
+        }
+
+        #[macro_export]
+        /// This macro allows producing debug output that will appear on the output of the debug probe
+        macro_rules! debug_log {
+            ($($t:tt)*) => ($crate::tests::log({ use alloc::string::ToString; &format_args!($($t)*).to_string() }))
+        }
     } else {
         /// This macro allows producing debug output that will appear on stderr in regular builds
         /// and in the console log for wasm builds.

--- a/sixtyfps_runtime/rendering_backends/default/Cargo.toml
+++ b/sixtyfps_runtime/rendering_backends/default/Cargo.toml
@@ -16,7 +16,7 @@ x11 = ["sixtyfps-rendering-backend-gl/x11"]
 wayland = ["sixtyfps-rendering-backend-gl/wayland"]
 
 [dependencies]
-sixtyfps-corelib = { version = "=0.1.6", path = "../../corelib" }
+sixtyfps-corelib = { version = "=0.1.6", path = "../../corelib", default-features = false }
 sixtyfps-rendering-backend-gl = { version = "=0.1.6", path = "../gl", optional = true }
 sixtyfps-rendering-backend-qt = { version = "=0.1.6", path = "../qt", optional = true }
 cfg-if = "1"

--- a/sixtyfps_runtime/rendering_backends/mcu/Cargo.toml
+++ b/sixtyfps_runtime/rendering_backends/mcu/Cargo.toml
@@ -16,6 +16,8 @@ simulator = ["winit", "glutin", "femtovg", "embedded-graphics-simulator", "sixty
 default = ["simulator"]
 unsafe_single_core = ["sixtyfps-corelib/unsafe_single_core"]
 
+snapshot_renderer = []
+
 [dependencies]
 sixtyfps-corelib = { version = "=0.1.6", path = "../../corelib", default-features = false }
 sixtyfps-common = { version = "=0.1.6", path = "../../common", default-features = false }
@@ -25,7 +27,7 @@ vtable = { version = "0.1", path = "../../../helper_crates/vtable" }
 by_address = "1.0.4"
 euclid = { version = "0.22.1", default-features = false }
 pin-weak = { version = "1", default-features = false }
-once_cell = { version = "1.5", default-features = false }
+once_cell = { version = "1.9", default-features = false, features = ["alloc", "atomic-polyfill"] }
 derive_more = "0.99.5"
 winit = { version = "0.26.0", default-features = false, optional = true, features = ["x11"] }
 glutin = { version = "0.28", default-features = false, optional = true, features = ["x11"] }

--- a/sixtyfps_runtime/rendering_backends/mcu/Cargo.toml
+++ b/sixtyfps_runtime/rendering_backends/mcu/Cargo.toml
@@ -14,6 +14,9 @@ path = "lib.rs"
 [features]
 simulator = ["winit", "glutin", "femtovg", "embedded-graphics-simulator", "sixtyfps-corelib/std", "imgref", "scoped-tls-hkt"]
 default = ["simulator"]
+
+pico-st7789 = ["unsafe_single_core", "rp-pico", "embedded-hal", "cortex-m-rt", "alloc-cortex-m", "embedded-time", "cortex-m", "display-interface-spi", "st7789", "defmt", "defmt-rtt", "panic-probe" ]
+
 unsafe_single_core = ["sixtyfps-corelib/unsafe_single_core"]
 
 snapshot_renderer = []
@@ -36,6 +39,20 @@ scoped-tls-hkt = { version = "0.1", optional = true }
 imgref = { version = "1.6.1", optional = true }
 embedded-graphics = "0.7.1"
 embedded-graphics-simulator = { version = "0.3.0", optional = true, default-features = false }
+
+rp-pico = { version = "0.2.0", optional = true }
+embedded-hal = { version = "0.2.5", optional = true }
+cortex-m-rt = { version = "0.7", optional = true }
+alloc-cortex-m = { version = "0.4.1", optional = true }
+panic-halt= { version = "0.2.0", optional = true }
+embedded-time = { version = "0.12.0", optional = true }
+cortex-m = { version = "0.7.2", optional = true }
+display-interface-spi = { version = "0.4.1", optional = true }
+st7789 = { version = "0.6.1", optional = true }
+
+defmt = { version = "0.3.0", optional = true }
+defmt-rtt = { version = "0.3.0", optional = true }
+panic-probe = { version = "0.3.0", optional = true, features = ["print-defmt"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = { version = "0.24.0" }

--- a/sixtyfps_runtime/rendering_backends/mcu/Cargo.toml
+++ b/sixtyfps_runtime/rendering_backends/mcu/Cargo.toml
@@ -15,7 +15,7 @@ path = "lib.rs"
 simulator = ["winit", "glutin", "femtovg", "embedded-graphics-simulator", "sixtyfps-corelib/std", "imgref", "scoped-tls-hkt"]
 default = ["simulator"]
 
-pico-st7789 = ["unsafe_single_core", "rp-pico", "embedded-hal", "cortex-m-rt", "alloc-cortex-m", "embedded-time", "cortex-m", "display-interface-spi", "st7789", "defmt", "defmt-rtt", "panic-probe" ]
+pico-st7789 = ["unsafe_single_core", "rp-pico", "embedded-hal", "cortex-m-rt", "alloc-cortex-m", "embedded-time", "cortex-m", "display-interface-spi", "st7789", "defmt", "defmt-rtt", "panic-probe", "sixtyfps-corelib/defmt" ]
 
 unsafe_single_core = ["sixtyfps-corelib/unsafe_single_core"]
 

--- a/sixtyfps_runtime/rendering_backends/mcu/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/mcu/lib.rs
@@ -244,9 +244,24 @@ where
 
 #[cfg(not(feature = "simulator"))]
 pub fn init_with_mock_display() {
-    init_with_display(embedded_graphics::mock_display::MockDisplay::<
-        embedded_graphics::pixelcolor::Rgb888,
-    >::new());
+    struct EmptyDisplay;
+    impl embedded_graphics::draw_target::DrawTarget for EmptyDisplay {
+        type Color = embedded_graphics::pixelcolor::Rgb888;
+        type Error = ();
+        fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+        where
+            I: IntoIterator<Item = embedded_graphics::Pixel<Self::Color>>,
+        {
+            let _ = pixels.into_iter().count();
+            Ok(())
+        }
+    }
+    impl embedded_graphics::geometry::OriginDimensions for EmptyDisplay {
+        fn size(&self) -> embedded_graphics::geometry::Size {
+            embedded_graphics::geometry::Size::new(320, 240)
+        }
+    }
+    init_with_display(EmptyDisplay);
 }
 
 #[cfg(feature = "pico-st7789")]

--- a/sixtyfps_runtime/rendering_backends/mcu/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/mcu/lib.rs
@@ -13,6 +13,7 @@ only be used with `version = "=x.y.z"` in Cargo.toml.
 */
 #![doc(html_logo_url = "https://sixtyfps.io/resources/logo.drawio.svg")]
 #![cfg_attr(not(feature = "simulator"), no_std)]
+#![cfg_attr(feature = "pico-st7789", feature(alloc_error_handler))]
 
 extern crate alloc;
 
@@ -207,7 +208,7 @@ mod snapshotbackend {
         }
 
         fn duration_since_start(&'static self) -> core::time::Duration {
-            todo!()
+            Default::default()
         }
     }
 }
@@ -244,3 +245,9 @@ pub fn init_with_mock_display() {
         embedded_graphics::pixelcolor::Rgb888,
     >::new());
 }
+
+#[cfg(feature = "pico-st7789")]
+mod pico_st7789;
+
+#[cfg(feature = "pico-st7789")]
+pub use pico_st7789::*;

--- a/sixtyfps_runtime/rendering_backends/mcu/lib.rs
+++ b/sixtyfps_runtime/rendering_backends/mcu/lib.rs
@@ -76,6 +76,9 @@ mod snapshotbackend {
         fn show(self: Rc<Self>) {
             use embedded_graphics::draw_target::DrawTargetExt;
             let runtime_window = self.self_weak.upgrade().unwrap();
+            runtime_window.set_scale_factor(
+                option_env!("SIXTYFPS_SCALE_FACTOR").and_then(|x| x.parse().ok()).unwrap_or(1.),
+            );
 
             runtime_window.update_window_properties();
 

--- a/sixtyfps_runtime/rendering_backends/mcu/pico_st7789.rs
+++ b/sixtyfps_runtime/rendering_backends/mcu/pico_st7789.rs
@@ -1,0 +1,87 @@
+// Copyright © SixtyFPS GmbH <info@sixtyfps.io>
+// SPDX-License-Identifier: (GPL-3.0-only OR LicenseRef-SixtyFPS-commercial)
+
+use embedded_time::rate::*;
+use rp_pico::hal;
+use rp_pico::hal::pac;
+use rp_pico::hal::prelude::*;
+
+use embedded_hal::digital::v2::OutputPin;
+
+pub use cortex_m_rt::entry;
+
+use defmt_rtt as _; // global logger
+use panic_probe as _;
+
+#[alloc_error_handler]
+fn oom(_: core::alloc::Layout) -> ! {
+    loop {}
+}
+use alloc_cortex_m::CortexMHeap;
+
+const HEAP_SIZE: usize = 128 * 1024;
+static mut HEAP: [u8; HEAP_SIZE] = [0; HEAP_SIZE];
+
+#[global_allocator]
+static ALLOCATOR: CortexMHeap = CortexMHeap::empty();
+
+pub fn init_board() {
+    let mut pac = pac::Peripherals::take().unwrap();
+    let core = pac::CorePeripherals::take().unwrap();
+
+    let mut watchdog = hal::watchdog::Watchdog::new(pac.WATCHDOG);
+
+    let clocks = hal::clocks::init_clocks_and_plls(
+        rp_pico::XOSC_CRYSTAL_FREQ,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+    .ok()
+    .unwrap();
+
+    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().integer());
+
+    let sio = hal::sio::Sio::new(pac.SIO);
+
+    let pins = rp_pico::Pins::new(pac.IO_BANK0, pac.PADS_BANK0, sio.gpio_bank0, &mut pac.RESETS);
+
+    let _spi_sclk = pins.gpio10.into_mode::<hal::gpio::FunctionSpi>();
+    let _spi_mosi = pins.gpio11.into_mode::<hal::gpio::FunctionSpi>();
+    let _spi_miso = pins.gpio12.into_mode::<hal::gpio::FunctionSpi>();
+
+    let spi = hal::spi::Spi::<_, _, 8>::new(pac.SPI1);
+
+    let spi = spi.init(
+        &mut pac.RESETS,
+        clocks.peripheral_clock.freq(),
+        4_000_000u32.Hz(),
+        &embedded_hal::spi::MODE_3,
+    );
+
+    let rst = pins.gpio15.into_push_pull_output();
+
+    let dc = pins.gpio8.into_push_pull_output();
+    let cs = pins.gpio9.into_push_pull_output();
+    let di = display_interface_spi::SPIInterface::new(spi, dc, cs);
+
+    let mut display = st7789::ST7789::new(di, rst, 320, 240);
+
+    // Turn on backlight
+    {
+        let mut bl = pins.gpio13.into_push_pull_output();
+        bl.set_low().unwrap();
+        delay.delay_us(10_000);
+        bl.set_high().unwrap();
+    }
+
+    unsafe { ALLOCATOR.init(&mut HEAP as *const u8 as usize, core::mem::size_of_val(&HEAP)) }
+
+    display.init(&mut delay).unwrap();
+    display.set_orientation(st7789::Orientation::Landscape).unwrap();
+
+    crate::init_with_display(display);
+}


### PR DESCRIPTION
This cherry-picks (and squashes) the backend specific changes from the MCU branch.

One of the main option questions is if the linker flags integration is the correct approach here or not. I remember that we agreed to eliminate the mcu-build crate, but I don't recall if we said that the mcu backend would write some json file or if we add the device specific flags to the sixtyfps-build crate.