### PR TITLE
More clippy fixes

### DIFF
--- a/api/sixtyfps-rs/lib.rs
+++ b/api/sixtyfps-rs/lib.rs
@@ -530,6 +530,7 @@ pub trait ComponentHandle {
         Self: Sized;
 
     /// Returns a clone of this handle that's a strong reference.
+    #[must_use]
     fn clone_strong(&self) -> Self;
 
     /// Internal function used when upgrading a weak reference to a strong one.

--- a/api/sixtyfps-rs/sixtyfps-build/lib.rs
+++ b/api/sixtyfps-rs/sixtyfps-build/lib.rs
@@ -73,6 +73,7 @@ impl CompilerConfiguration {
 
     /// Create a new configuration that includes sets the include paths used for looking up
     /// `.60` imports to the specified vector of paths.
+    #[must_use]
     pub fn with_include_paths(self, include_paths: Vec<std::path::PathBuf>) -> Self {
         let mut config = self.config;
         config.include_paths = include_paths;
@@ -80,6 +81,7 @@ impl CompilerConfiguration {
     }
 
     /// Create a new configuration that selects the style to be used for widgets.
+    #[must_use]
     pub fn with_style(self, style: String) -> Self {
         let mut config = self.config;
         config.style = Some(style);

--- a/sixtyfps_compiler/diagnostics.rs
+++ b/sixtyfps_compiler/diagnostics.rs
@@ -469,6 +469,7 @@ impl BuildDiagnostics {
     }
 
     #[cfg(feature = "display-diagnostics")]
+    #[must_use]
     pub fn check_and_exit_on_error(self) -> Self {
         if self.has_error() {
             self.print();

--- a/sixtyfps_compiler/expression_tree.rs
+++ b/sixtyfps_compiler/expression_tree.rs
@@ -839,6 +839,7 @@ impl Expression {
     }
 
     /// Create a conversion node if needed, or throw an error if the type is not matching
+    #[must_use]
     pub fn maybe_convert_to(
         self,
         target_type: Type,

--- a/sixtyfps_compiler/generator.rs
+++ b/sixtyfps_compiler/generator.rs
@@ -313,7 +313,6 @@ pub fn build_item_tree<T: ItemTreeBuilder>(
         if item.borrow().repeated.is_some() {
             builder.push_repeated_item(item, *repeater_count, parent_index, component_state);
             *repeater_count += 1;
-            return;
         } else {
             let mut item = item.clone();
             let mut component_state = component_state.clone();

--- a/sixtyfps_compiler/passes/resolving.rs
+++ b/sixtyfps_compiler/passes/resolving.rs
@@ -547,12 +547,12 @@ impl Expression {
                                 ),
                                 &next_identifier,
                             );
-                            return Expression::Invalid;
+                            Expression::Invalid
                         }
                     }
                 } else {
                     ctx.diag.push_error("Cannot take reference to an enum".to_string(), &node);
-                    return Expression::Invalid;
+                    Expression::Invalid
                 }
             }
             LookupResult::Expression { expression, .. } => maybe_lookup_object(expression, it, ctx),
@@ -573,12 +573,12 @@ impl Expression {
                                 ),
                                 &next_identifier,
                             );
-                            return Expression::Invalid;
+                            Expression::Invalid
                         }
                     }
                 } else {
                     ctx.diag.push_error("Cannot take reference to a namespace".to_string(), &node);
-                    return Expression::Invalid;
+                    Expression::Invalid
                 }
             }
         }

--- a/sixtyfps_runtime/corelib/backend.rs
+++ b/sixtyfps_runtime/corelib/backend.rs
@@ -69,10 +69,10 @@ pub trait Backend: Send + Sync {
         #[cfg(feature = "std")]
         {
             let the_beginning = *INITIAL_INSTANT.get_or_init(instant::Instant::now);
-            return instant::Instant::now() - the_beginning;
+            instant::Instant::now() - the_beginning
         }
         #[cfg(not(feature = "std"))]
-        return core::time::Duration::ZERO;
+        core::time::Duration::ZERO
     }
 }
 

--- a/sixtyfps_runtime/corelib/graphics.rs
+++ b/sixtyfps_runtime/corelib/graphics.rs
@@ -142,6 +142,7 @@ pub struct FontRequest {
 impl FontRequest {
     /// Consumes the FontRequest, replaces any missing fields from the specified other request and
     /// returns the new request.
+    #[must_use]
     pub fn merge(self, other: &FontRequest) -> Self {
         Self {
             family: self.family.or_else(|| other.family.clone()),

--- a/sixtyfps_runtime/corelib/graphics/color.rs
+++ b/sixtyfps_runtime/corelib/graphics/color.rs
@@ -170,6 +170,7 @@ impl Color {
     /// The result is converted back to RGB and the alpha channel is unchanged.
     /// So for example `brighter(0.2)` will increase the brightness by 20%, and
     /// calling `brighter(-0.5)` will return a color that's 50% darker.
+    #[must_use]
     pub fn brighter(&self, factor: f32) -> Self {
         let rgba: RgbaColor<f32> = (*self).into();
         let mut hsva: HsvaColor = rgba.into();
@@ -183,6 +184,7 @@ impl Color {
     /// color space and dividing the brightness (value) by (1 + factor). The
     /// result is converted back to RGB and the alpha channel is unchanged.
     /// So for example `darker(0.3)` will decrease the brightness by 30%.
+    #[must_use]
     pub fn darker(&self, factor: f32) -> Self {
         let rgba: RgbaColor<f32> = (*self).into();
         let mut hsva: HsvaColor = rgba.into();

--- a/sixtyfps_runtime/corelib/layout.rs
+++ b/sixtyfps_runtime/corelib/layout.rs
@@ -53,6 +53,7 @@ impl Default for LayoutInfo {
 
 impl LayoutInfo {
     // Note: This "logic" is duplicated in the cpp generator's generated code for merging layout infos.
+    #[must_use]
     pub fn merge(&self, other: &LayoutInfo) -> Self {
         Self {
             min: self.min.max(other.min),

--- a/sixtyfps_runtime/corelib/properties.rs
+++ b/sixtyfps_runtime/corelib/properties.rs
@@ -1228,6 +1228,7 @@ pub trait InterpolatedPropertyValue: PartialEq + Default + 'static {
     /// Returns the interpolated value between self and target_value according to the
     /// progress parameter t that's usually between 0 and 1. With certain animation
     /// easing curves it may over- or undershoot though.
+    #[must_use]
     fn interpolate(&self, target_value: &Self, t: f32) -> Self;
 }
 

--- a/sixtyfps_runtime/corelib/string.rs
+++ b/sixtyfps_runtime/corelib/string.rs
@@ -66,7 +66,6 @@ impl SharedString {
         let mut iter = x.as_bytes().iter().copied();
         if self.inner.is_empty() {
             self.inner.extend(iter.chain(core::iter::once(0)));
-            return;
         } else if let Some(first) = iter.next() {
             // We skip the `first` from `iter` because we will write it at the
             // location of the previous `\0`, after extend did the re-alloc of the

--- a/sixtyfps_runtime/interpreter/api.rs
+++ b/sixtyfps_runtime/interpreter/api.rs
@@ -992,6 +992,7 @@ impl ComponentInstance {
     /// Clone is not implemented because of the danger of circular reference:
     /// If you want to use this instance in a callback, you should capture a weak
     /// reference given by [`Self::as_weak`].
+    #[must_use]
     pub fn clone_strong(&self) -> Self {
         Self { inner: self.inner.clone() }
     }

--- a/sixtyfps_runtime/interpreter/dynamic_component.rs
+++ b/sixtyfps_runtime/interpreter/dynamic_component.rs
@@ -836,7 +836,7 @@ pub(crate) fn generate_component<'id>(
             _children_offset: u32,
             _component_state: &Self::SubComponentState,
         ) -> Self::SubComponentState {
-            ()
+            /* nothing to do */
         }
 
         fn enter_component_children(

--- a/sixtyfps_runtime/rendering_backends/mcu/renderer.rs
+++ b/sixtyfps_runtime/rendering_backends/mcu/renderer.rs
@@ -341,7 +341,7 @@ impl PrepareScene {
     ) {
         let image_inner: &ImageInner = source.into();
         match image_inner {
-            ImageInner::None => return,
+            ImageInner::None => (),
             ImageInner::AbsoluteFilePath(_) | ImageInner::EmbeddedData { .. } => {
                 unimplemented!()
             }

--- a/sixtyfps_runtime/rendering_backends/qt/qt_window.rs
+++ b/sixtyfps_runtime/rendering_backends/qt/qt_window.rs
@@ -1493,7 +1493,7 @@ impl PlatformWindow for QtWindow {
                 return QPointF();
             return QPointF(textLine.x() + textLine.cursorToX(offset), textLine.y());
         }};
-        return Point::new(r.x as _, r.y as _);
+        Point::new(r.x as _, r.y as _)
     }
 
     fn as_any(&self) -> &dyn std::any::Any {


### PR DESCRIPTION
Based on earlier experience: These patches might not be uncontroversial, so I am putting them here for review:-)

1. The first one annotates some more functions with the #[must_use] directive. That is visual noise, but I find it rather worthwhile anyway.
2. The second one allows `clippy::transmute_num_to_bytes` in places where the `cpp` macro is used. That silences some warnings, but again at the price of some clutter.
3. The third removes some `return`s that `clippy` claims are redundant. I like that it removes the warning messages, but in some places I think the return has at least some aesthetic value.

Any opinions?