### PR TITLE
Complete the C++ Timer API

### DIFF
--- a/api/sixtyfps-cpp/tests/eventloop.cpp
+++ b/api/sixtyfps-cpp/tests/eventloop.cpp
@@ -7,7 +7,7 @@
 #include <sixtyfps.h>
 #include <thread>
 
-TEST_CASE("C++ Timers")
+TEST_CASE("C++ Singleshot Timers")
 {
     using namespace sixtyfps;
     int called = 0;
@@ -20,6 +20,62 @@ TEST_CASE("C++ Timers")
     REQUIRE(called == 10);
 }
 
+TEST_CASE("C++ Repeated Timer")
+{
+    int timer_triggered = 0;
+    sixtyfps::Timer timer;
+
+    timer.start(sixtyfps::TimerMode::Repeated, std::chrono::milliseconds(30),
+                [&]() { timer_triggered++; });
+
+    REQUIRE(timer_triggered == 0);
+
+    bool timer_was_running = false;
+
+    sixtyfps::Timer::single_shot(std::chrono::milliseconds(500), [&]() {
+        timer_was_running = timer.running();
+        sixtyfps::quit_event_loop();
+    });
+
+    sixtyfps::run_event_loop();
+
+    REQUIRE(timer_triggered > 1);
+    REQUIRE(timer_was_running);
+}
+
+TEST_CASE("C++ Restart Singleshot Timer")
+{
+    int timer_triggered = 0;
+    sixtyfps::Timer timer;
+
+    timer.start(sixtyfps::TimerMode::SingleShot, std::chrono::milliseconds(30),
+                [&]() { timer_triggered++; });
+
+    REQUIRE(timer_triggered == 0);
+
+    bool timer_was_running = false;
+
+    sixtyfps::Timer::single_shot(std::chrono::milliseconds(500), [&]() {
+        timer_was_running = timer.running();
+        sixtyfps::quit_event_loop();
+    });
+
+    sixtyfps::run_event_loop();
+
+    REQUIRE(timer_triggered == 1);
+    REQUIRE(timer_was_running);
+    timer_triggered = 0;
+    timer.restart();
+    sixtyfps::Timer::single_shot(std::chrono::milliseconds(500), [&]() {
+        timer_was_running = timer.running();
+        sixtyfps::quit_event_loop();
+    });
+
+    sixtyfps::run_event_loop();
+
+    REQUIRE(timer_triggered == 1);
+    REQUIRE(timer_was_running);
+}
 
 TEST_CASE("Quit from event")
 {
@@ -32,7 +88,6 @@ TEST_CASE("Quit from event")
     sixtyfps::run_event_loop();
     REQUIRE(called == 10);
 }
-
 
 TEST_CASE("Event from thread")
 {
@@ -50,15 +105,13 @@ TEST_CASE("Event from thread")
     t.join();
 }
 
-
 TEST_CASE("Blocking Event from thread")
 {
     std::atomic<int> called = 0;
     auto t = std::thread([&] {
         // test returning a, unique_ptr because it is movable-only
-        std::unique_ptr foo = sixtyfps::blocking_invoke_from_event_loop([&] {
-            return std::make_unique<int>(42);
-        });
+        std::unique_ptr foo = sixtyfps::blocking_invoke_from_event_loop(
+                [&] { return std::make_unique<int>(42); });
         called = *foo;
         int xxx = 123;
         sixtyfps::blocking_invoke_from_event_loop([&] {

--- a/sixtyfps_runtime/corelib/timers.rs
+++ b/sixtyfps_runtime/corelib/timers.rs
@@ -356,9 +356,10 @@ pub(crate) mod ffi {
         }
     }
 
-    /// Start a timer with the given duration in millisecond.
-    /// Returns the timer id.
-    /// The timer MUST be stopped with sixtyfps_timer_stop
+    /// Start a timer with the given mode, duration in millisecond and callback. A timer id may be provided (first argument).
+    /// A value of -1 for the timer id means a new timer is to be allocated.
+    /// The (new) timer id is returned.
+    /// The timer MUST be destroyed with sixtyfps_timer_stop.
     #[no_mangle]
     pub extern "C" fn sixtyfps_timer_start(
         id: i64,


### PR DESCRIPTION
With this patch it matches the Rust API, with start(), restart(), running() and
a default constructor.