### PR TITLE
Fix the Rust/C++ Timer API to be more convenient to use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
    has changed. This was undocumented, but if one was handling this in the
    `FocusScope` event, these keys will now be ignored. Use the `Keys.LeftArrow`
    and other code exposed in the `Keys` namespace instead
+ - For `sixtyfps::Timer` (C++ and Rust), it's now possible to call `restart()` after
+   a timer has been stopped previously by calling `stop()`.
 
 ### Added
 

--- a/api/sixtyfps-cpp/include/sixtyfps.h
+++ b/api/sixtyfps-cpp/include/sixtyfps.h
@@ -374,7 +374,7 @@ struct Timer
     }
     Timer(const Timer &) = delete;
     Timer &operator=(const Timer &) = delete;
-    ~Timer() { cbindgen_private::sixtyfps_timer_stop(id); }
+    ~Timer() { cbindgen_private::sixtyfps_timer_destroy(id); }
 
     /// Starts the timer with the given \a mode and \a interval, in order for the \a callback to
     /// called when the timer fires. If the timer has been started previously and not fired yet,
@@ -388,12 +388,12 @@ struct Timer
     }
     /// Stops the previously started timer. Does nothing if the timer has never been started. A
     /// stopped timer cannot be restarted with restart() -- instead you need to call start().
-    void stop()
-    {
-        cbindgen_private::sixtyfps_timer_stop(id);
-        id = -1;
-    }
-    /// Restarts the timer, if it was previously started.
+    void stop() { cbindgen_private::sixtyfps_timer_stop(id); }
+    /// Restarts the timer. If the timer was previously started by calling [`Self::start()`]
+    /// with a duration and callback, then the time when the callback will be next invoked
+    /// is re-calculated to be in the specified duration relative to when this function is called.
+    ///
+    /// Does nothing if the timer was never started.
     void restart() { cbindgen_private::sixtyfps_timer_restart(id); }
     /// Returns true if the timer is running; false otherwise.
     bool running() const { return cbindgen_private::sixtyfps_timer_running(id); }

--- a/api/sixtyfps-cpp/tests/eventloop.cpp
+++ b/api/sixtyfps-cpp/tests/eventloop.cpp
@@ -77,6 +77,57 @@ TEST_CASE("C++ Restart Singleshot Timer")
     REQUIRE(timer_was_running);
 }
 
+TEST_CASE("C++ Restart Repeated Timer")
+{
+    int timer_triggered = 0;
+    sixtyfps::Timer timer;
+
+    timer.start(sixtyfps::TimerMode::Repeated, std::chrono::milliseconds(30),
+                [&]() { timer_triggered++; });
+
+    REQUIRE(timer_triggered == 0);
+
+    bool timer_was_running = false;
+
+    sixtyfps::Timer::single_shot(std::chrono::milliseconds(500), [&]() {
+        timer_was_running = timer.running();
+        sixtyfps::quit_event_loop();
+    });
+
+    sixtyfps::run_event_loop();
+
+    REQUIRE(timer_triggered > 1);
+    REQUIRE(timer_was_running);
+
+    timer_was_running = false;
+    timer_triggered = 0;
+    timer.stop();
+    sixtyfps::Timer::single_shot(std::chrono::milliseconds(500), [&]() {
+        timer_was_running = timer.running();
+        sixtyfps::quit_event_loop();
+    });
+
+    sixtyfps::run_event_loop();
+
+    REQUIRE(timer_triggered == 0);
+    REQUIRE(!timer_was_running);
+
+    timer_was_running = false;
+    timer_triggered = 0;
+
+    timer.restart();
+
+    sixtyfps::Timer::single_shot(std::chrono::milliseconds(500), [&]() {
+        timer_was_running = timer.running();
+        sixtyfps::quit_event_loop();
+    });
+
+    sixtyfps::run_event_loop();
+
+    REQUIRE(timer_triggered > 1);
+    REQUIRE(timer_was_running);
+}
+
 TEST_CASE("Quit from event")
 {
     int called = 0;


### PR DESCRIPTION
Allow calling restart() on a repeated timer if it has been previously stopped.