### PR TITLE
Don't panic in the compiler when encountering a Path element with for-in

### DIFF
--- a/sixtyfps_compiler/passes/compile_paths.rs
+++ b/sixtyfps_compiler/passes/compile_paths.rs
@@ -98,8 +98,16 @@ pub fn compile_paths(
                             element_name
                         ),
                     };
-                    let bindings = std::mem::take(&mut child.borrow_mut().bindings);
-                    path_data.push(PathElement { element_type, bindings });
+
+                    if child.borrow().repeated.is_some() {
+                        diag.push_error(
+                            "Path elements are not supported with `for`-`in` syntax, yet (https://github.com/sixtyfpsui/sixtyfps/issues/754)".into(),
+                            &*child.borrow(),
+                        );
+                    } else {
+                        let bindings = std::mem::take(&mut child.borrow_mut().bindings);
+                        path_data.push(PathElement { element_type, bindings });
+                    }
                 } else {
                     elem.children.push(child);
                 }

--- a/sixtyfps_compiler/tests/syntax/basic/path_for.60
+++ b/sixtyfps_compiler/tests/syntax/basic/path_for.60
@@ -1,0 +1,18 @@
+// Copyright © SixtyFPS GmbH <info@sixtyfps.io>
+// SPDX-License-Identifier: (GPL-3.0-only OR LicenseRef-SixtyFPS-commercial)
+
+
+TestCase := Rectangle {
+    Path {
+        MoveTo {
+        x: 0;
+        y: 0;
+        }
+        for sample[i] in [ 0, 1, 2, 3 ] : LineTo {
+//                                        ^error{Path elements are not supported with `for`-`in` syntax, yet \(https://github.com/sixtyfpsui/sixtyfps/issues/754\)}
+            x: i;
+            y: sample;
+        }
+        Close {}
+    }
+}


### PR DESCRIPTION
Instead, produce a diagnostic message.

cc #754