### PR TITLE
Speed up C++ builds

### DIFF
--- a/examples/iot-dashboard/CMakeLists.txt
+++ b/examples/iot-dashboard/CMakeLists.txt
@@ -4,18 +4,20 @@
 cmake_minimum_required(VERSION 3.14)
 project(sixtyfps_cpp_iot_dashboard LANGUAGES CXX)
 
+if (NOT "cxx_std_20" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+    message(STATUS "The C++ iot dashboard demo requires C++ >= 20. The compiler you're using does not support that, so the build of this example is skipped.")
+    return()
+endif()
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 if (NOT TARGET SixtyFPS::SixtyFPS)
     find_package(SixtyFPS REQUIRED)
 endif()
-
-FetchContent_Declare(fmt
-  GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-  GIT_TAG 7.1.3
-)
-FetchContent_MakeAvailable(fmt)
 
 add_executable(iot_dashboard main.cpp dashboard.cpp)
 target_compile_definitions(iot_dashboard PRIVATE
    SOURCE_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\"
 )
-target_link_libraries(iot_dashboard PRIVATE SixtyFPS::SixtyFPS fmt::fmt )
+target_link_libraries(iot_dashboard PRIVATE SixtyFPS::SixtyFPS)

--- a/examples/iot-dashboard/dashboard.cpp
+++ b/examples/iot-dashboard/dashboard.cpp
@@ -3,7 +3,7 @@
 
 #include "dashboard.h"
 
-#include <fmt/core.h>
+#include <format>
 
 void Widget::set_property(std::string_view name, const sixtyfps::interpreter::Value &value)
 {
@@ -37,13 +37,13 @@ std::string WidgetLocation::location_bindings() const
 {
     auto maybe_binding = [](std::string_view name, const auto &opt_value) -> std::string {
         if (opt_value.has_value()) {
-            return fmt::format("               {}: {};\n", name, opt_value.value());
+            return std::format("               {}: {};\n", name, opt_value.value());
         } else {
             return "";
         }
     };
 
-    return fmt::format(
+    return std::format(
             R"60(row: {};
                col: {};
 {}{})60",
@@ -68,7 +68,7 @@ int DashboardBuilder::register_widget(WidgetPtr widget)
     widgets_used.insert(widget_type_name);
 
     auto widget_id = int(widgets.size());
-    auto widget_name = fmt::format("widget_{}", widget_id);
+    auto widget_name = std::format("widget_{}", widget_id);
     widgets.push_back({ widget_name, widget });
     return widget_id;
 }
@@ -86,7 +86,7 @@ DashboardBuilder::build(sixtyfps::interpreter::ComponentCompiler &compiler) cons
     }
 
     if (widget_imports.size() > 0) {
-        widget_imports = fmt::format("import {{ {} }} from \"iot-dashboard.60\";", widget_imports);
+        widget_imports = std::format("import {{ {} }} from \"iot-dashboard.60\";", widget_imports);
     }
 
     // Vector of name/type_name of properties forwarded through the MainContent {} element.
@@ -98,7 +98,7 @@ DashboardBuilder::build(sixtyfps::interpreter::ComponentCompiler &compiler) cons
     for (const auto &[widget_id, location] : grid_widgets) {
         const auto &[widget_name, widget_ptr] = widgets[widget_id];
 
-        main_grid.append(fmt::format(
+        main_grid.append(std::format(
                 R"60(
             {0} := {1} {{
                 {2}
@@ -113,11 +113,11 @@ DashboardBuilder::build(sixtyfps::interpreter::ComponentCompiler &compiler) cons
             std::string forwarded_property_name = properties_prefix;
             forwarded_property_name.append(property.name);
 
-            main_content_properties.append(fmt::format("    property <{0}> {1} <=> {2}.{3};\n",
+            main_content_properties.append(std::format("    property <{0}> {1} <=> {2}.{3};\n",
                                                        property.type_name, forwarded_property_name,
                                                        widget_name, property.name));
 
-            exposed_properties.append(fmt::format("    property <{0}> {1} <=> main_content.{1};\n",
+            exposed_properties.append(std::format("    property <{0}> {1} <=> main_content.{1};\n",
                                                   property.type_name, forwarded_property_name));
         }
     }
@@ -125,7 +125,7 @@ DashboardBuilder::build(sixtyfps::interpreter::ComponentCompiler &compiler) cons
     for (const auto widget_id : top_bar_widgets) {
         const auto &[widget_name, widget_ptr] = widgets[widget_id];
 
-        top_bar.append(fmt::format(
+        top_bar.append(std::format(
                 R"60(
             {0} := {1} {{
             }}
@@ -139,13 +139,13 @@ DashboardBuilder::build(sixtyfps::interpreter::ComponentCompiler &compiler) cons
             std::string forwarded_property_name = properties_prefix;
             forwarded_property_name.append(property.name);
 
-            exposed_properties.append(fmt::format("    property <{0}> {1} <=> {2}.{3};\n",
+            exposed_properties.append(std::format("    property <{0}> {1} <=> {2}.{3};\n",
                                                   property.type_name, forwarded_property_name,
                                                   widget_name, property.name));
         }
     }
 
-    auto source_code = fmt::format(
+    auto source_code = std::format(
             R"60(
 
 {0}

--- a/examples/iot-dashboard/main.cpp
+++ b/examples/iot-dashboard/main.cpp
@@ -5,8 +5,7 @@
 #include <chrono>
 #include <sixtyfps_interpreter.h>
 
-#include <fmt/core.h>
-#include <fmt/chrono.h>
+#include <format>
 #include <random>
 #include <time.h>
 
@@ -44,7 +43,7 @@ ClockWidget::ClockWidget() : clock_update_timer(std::chrono::seconds(1), [this] 
 
 void ClockWidget::update_clock()
 {
-    std::string current_time = fmt::format("{:%H:%M:%S}", fmt::localtime(std::time(nullptr)));
+    std::string current_time = std::format("{:%H:%M:%S}", std::localtime(std::time(nullptr)));
     set_property("time", sixtyfps::SharedString(current_time));
 }
 


### PR DESCRIPTION
Replace the use of the external fmtlib with C++20 std::format. This avoids extra cloning.