### PR TITLE
CMake: Require C++ 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ cmake_minimum_required(VERSION 3.19)
 
 project(SixtyFPS LANGUAGES CXX)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 include(FeatureSummary)
 
 option(BUILD_TESTING "Build tests" OFF)


### PR DESCRIPTION
Our code uses some C++ 17 extensions, so document that in the
CMakeLists.txt file.