### PR TITLE
PropertyAnimation: Make `loop-count: n` run animations n times

### DIFF
--- a/docs/langref.md
+++ b/docs/langref.md
@@ -678,7 +678,8 @@ Animation can be configured with the following parameter:
 
 * `delay`: the amount of time to wait before starting the animation
 * `duration`: the amount of time it takes for the animation to complete
-* `loop-count`: FIXME
+* `iteration-count`: The number of times a animation should run. A negative value specifies
+    infinite reruns. Fractual values are possible.
 * `easing`: can be `linear`, `ease`, `ease-in`, `ease-out`, `ease-in-out`, `cubic-bezier(a, b, c, d)` as in CSS
 
 It is also possible to animate several properties with the same animation:

--- a/internal/compiler/builtins.60
+++ b/internal/compiler/builtins.60
@@ -408,7 +408,7 @@ PropertyAnimation := _ {
     property <duration> delay;
     property <duration> duration;
     property <easing> easing;
-    property <int> loop-count;
+    property <float> iteration-count: 1.0;
     //-is_non_item_type
 }
 

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -370,7 +370,7 @@ pub fn lower_animation(a: &PropertyAnimation, ctx: &ExpressionContext<'_>) -> An
     fn animation_fields() -> impl Iterator<Item = (String, Type)> {
         IntoIterator::into_iter([
             ("duration".to_string(), Type::Int32),
-            ("loop-count".to_string(), Type::Int32),
+            ("iteration-count".to_string(), Type::Float32),
             ("easing".to_string(), Type::Easing),
             ("delay".to_string(), Type::Int32),
         ])

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -749,15 +749,7 @@ impl Element {
             diag,
         );
 
-        if let Type::Builtin(builtin_base) = &r.base_type {
-            for (prop, info) in &builtin_base.properties {
-                if let Some(expr) = &info.default_value {
-                    r.bindings
-                        .entry(prop.clone())
-                        .or_insert_with(|| RefCell::new(expr.clone().into()));
-                }
-            }
-        }
+        apply_default_type_properties(&mut r);
 
         for sig_decl in node.CallbackDeclaration() {
             let name =
@@ -1233,6 +1225,21 @@ impl Element {
     }
 }
 
+/// Apply default property values defined in `builtins.60` to the element.
+fn apply_default_type_properties(element: &mut Element) {
+    // Apply default property values on top:
+    if let Type::Builtin(builtin_base) = &element.base_type {
+        for (prop, info) in &builtin_base.properties {
+            if let Some(expr) = &info.default_value {
+                element
+                    .bindings
+                    .entry(prop.clone())
+                    .or_insert_with(|| RefCell::new(expr.clone().into()));
+            }
+        }
+    }
+}
+
 /// Create a Type for this node
 pub fn type_from_node(
     node: syntax_nodes::Type,
@@ -1302,6 +1309,9 @@ fn animation_element_from_node(
             }),
             diag,
         );
+
+        apply_default_type_properties(&mut anim_element);
+
         Some(Rc::new(RefCell::new(anim_element)))
     }
 }

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -988,7 +988,7 @@ pub struct PropertyAnimation {
     #[rtti_field]
     pub duration: i32,
     #[rtti_field]
-    pub loop_count: i32,
+    pub iteration_count: f32,
     #[rtti_field]
     pub easing: crate::animations::EasingCurve,
 }

--- a/tests/cases/layout/path_offset.60
+++ b/tests/cases/layout/path_offset.60
@@ -19,7 +19,7 @@ TestCase := Rectangle {
 
         animate offset {
             duration: 1000ms;
-            loop_count: 4;
+            iteration-count: 4;
         }
 
         Text {

--- a/tools/syntax_updater/from_0_1_0.rs
+++ b/tools/syntax_updater/from_0_1_0.rs
@@ -1,0 +1,36 @@
+// Copyright © SixtyFPS GmbH <info@sixtyfps.io>
+// SPDX-License-Identifier: (GPL-3.0-only OR LicenseRef-SixtyFPS-commercial)
+
+use std::io::Write;
+
+use sixtyfps_compilerlib::parser::{syntax_nodes, SyntaxNode};
+
+/// Rename `loop-count` to `iteration-count` in `PropertyAnimation`s
+pub(crate) fn fold_node(
+    node: &SyntaxNode,
+    file: &mut impl Write,
+    state: &mut crate::State,
+) -> std::io::Result<bool> {
+    if let Some(binding) = syntax_nodes::Binding::new(node.clone()) {
+        let property_name = state.property_name.as_deref().unwrap_or_default();
+        if (property_name == "loop-count" || property_name == "loop_count")
+            && has_parent_anim(&binding.clone().into())
+        {
+            let text = node.text().to_string();
+            let text = text.replace("loop-count", "iteration-count");
+            let text = text.replace("loop_count", "iteration-count");
+            file.write_all(text.as_bytes())?;
+            return Ok(true);
+        }
+    };
+    Ok(false)
+}
+
+fn has_parent_anim(node: &SyntaxNode) -> bool {
+    let node = node.parent();
+    if let Some(node) = node {
+        syntax_nodes::PropertyAnimation::new(node).is_some()
+    } else {
+        false
+    }
+}

--- a/tools/syntax_updater/main.rs
+++ b/tools/syntax_updater/main.rs
@@ -24,6 +24,7 @@ use clap::Parser;
 
 mod from_0_0_5;
 mod from_0_0_6;
+mod from_0_1_0;
 
 #[derive(clap::Parser)]
 struct Cli {
@@ -219,11 +220,14 @@ fn fold_node(
     if args.from == "0.0.5" && from_0_0_5::fold_node(node, file, state)? {
         return Ok(true);
     }
-    if args.from.as_str() <= "0.0.6" {
-        from_0_0_6::fold_node(node, file, state)
-    } else {
-        Ok(false)
+    if args.from.as_str() <= "0.0.6" && from_0_0_6::fold_node(node, file, state)? {
+        return Ok(true);
     }
+    if args.from.as_str() <= "0.1.0" && from_0_1_0::fold_node(node, file, state)? {
+        return Ok(true);
+    }
+
+    Ok(false)
 }
 
 fn fold_token(


### PR DESCRIPTION
We used to run `n+1` times instead, which seems wrong to me. It is also
not how the similar property in CSS is documented to work.

As a side-effect of this change, the animation will no longer play when
overshooting the playback interval.