### PR TITLE
Fix wasm build when fontdb has file system features enabled

### DIFF
--- a/sixtyfps_runtime/rendering_backends/gl/fonts.rs
+++ b/sixtyfps_runtime/rendering_backends/gl/fonts.rs
@@ -295,6 +295,9 @@ impl FontCache {
                 (
                     match source {
                         fontdb::Source::Binary(data) => data.clone(),
+                        // We feed only Source::Binary into fontdb on wasm
+                        #[allow(unreachable_patterns)]
+                        _ => unreachable!(),
                     },
                     face_index,
                 )


### PR DESCRIPTION
That adds visibility to additional fontdb::Source variants,
which however are not reachable for us.

cc #826