### PR TITLE
Add `delay` property to `PropertyAnimation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to this project will be documented in this file.
    special keys are handled
  - `start()`, `stop()`, `running()` and a default constructor for C++ `sixtyfps::Timer`
  - Math functions `log`, and `pow`
+ - Property animations now have a `delay` property, which will delay the start
+   of the animation.
 
 ### Fixed
 

--- a/docs/langref.md
+++ b/docs/langref.md
@@ -675,6 +675,7 @@ This will animate the color property for 100ms when it changes.
 
 Animation can be configured with the following parameter:
 
+* `delay`: the amount of time to wait before starting the animation
 * `duration`: the amount of time it takes for the animation to complete
 * `loop-count`: FIXME
 * `easing`: can be `linear`, `ease`, `ease-in`, `ease-out`, `ease-in-out`, `cubic-bezier(a, b, c, d)` as in CSS

--- a/sixtyfps_compiler/builtins.60
+++ b/sixtyfps_compiler/builtins.60
@@ -406,6 +406,7 @@ export PopupWindow := _ {
 export Dialog := WindowItem {}
 
 PropertyAnimation := _ {
+    property <duration> delay;
     property <duration> duration;
     property <easing> easing;
     property <int> loop-count;

--- a/sixtyfps_runtime/corelib/items.rs
+++ b/sixtyfps_runtime/corelib/items.rs
@@ -984,6 +984,8 @@ pub unsafe extern "C" fn sixtyfps_flickable_data_free(data: *mut FlickableDataBo
 #[pin]
 pub struct PropertyAnimation {
     #[rtti_field]
+    pub delay: i32,
+    #[rtti_field]
     pub duration: i32,
     #[rtti_field]
     pub loop_count: i32,

--- a/sixtyfps_runtime/corelib/properties.rs
+++ b/sixtyfps_runtime/corelib/properties.rs
@@ -1127,8 +1127,19 @@ impl<T: InterpolatedPropertyValue + Clone> PropertyValueAnimationData<T> {
 
     fn compute_interpolated_value(&mut self) -> (T, bool) {
         let duration = self.details.duration as u128;
+        let delay = self.details.delay as u128;
+
         let new_tick = crate::animations::current_tick();
+
         let mut time_progress = new_tick.duration_since(self.start_time).as_millis();
+        if self.loop_iteration == 0 {
+            if time_progress >= delay {
+                time_progress -= delay;
+            } else {
+                return (self.from_value.clone(), false);
+            }
+        }
+
         if time_progress >= duration {
             if self.loop_iteration < self.details.loop_count || self.details.loop_count < 0 {
                 self.loop_iteration += (time_progress / duration) as i32;

--- a/tests/cases/properties/delayed_transitions.60
+++ b/tests/cases/properties/delayed_transitions.60
@@ -1,0 +1,268 @@
+// Copyright © SixtyFPS GmbH <info@sixtyfps.io>
+// SPDX-License-Identifier: (GPL-3.0-only OR LicenseRef-SixtyFPS-commercial)
+
+ TestCase := Rectangle {
+    property<int> top_level: 4;
+    property<int> active_index: 0;
+    property<int> some_prop: 5;
+    property<int> other_prop: 5000;
+    text1 := Text {
+        property<int> foo: 85 + top_level;
+    }
+
+    states [
+        xxx when active_index == 1 : {
+            text1.foo: 3 + 2 * top_level;
+            some_prop: 2000;
+            other_prop: 0;
+        }
+    ]
+
+    transitions [
+        in xxx: {
+            animate some_prop { delay: 5000ms; duration: 100ms; }
+            animate other_prop { delay: 100ms; duration: 1000ms; }
+        }
+        out xxx: {
+            animate text1.foo { delay: 200ms; duration: 300ms; }
+        }
+    ]
+
+    property<int> text1_foo: text1.foo;
+
+}
+
+
+/*
+
+```rust
+let instance = TestCase::new();
+assert_eq!(instance.get_text1_foo(), 89);
+assert_eq!(instance.get_some_prop(), 5);
+assert_eq!(instance.get_other_prop(), 5000);
+
+instance.set_active_index(1);
+assert_eq!(instance.get_text1_foo(), 11);
+assert_eq!(instance.get_some_prop(), 5);
+assert_eq!(instance.get_other_prop(), 5000);
+
+sixtyfps::testing::mock_elapsed_time(50); // In delay
+assert_eq!(instance.get_text1_foo(), 11);
+assert_eq!(instance.get_some_prop(), 5);
+assert_eq!(instance.get_other_prop(), 5000);
+
+sixtyfps::testing::mock_elapsed_time(50); // some: in delay, other: end of delay
+assert_eq!(instance.get_text1_foo(), 11);
+assert_eq!(instance.get_some_prop(), 5);
+assert_eq!(instance.get_other_prop(), 5000);
+
+sixtyfps::testing::mock_elapsed_time(50); // some: in delay, other: in play for 50ms [150ms]
+assert_eq!(instance.get_text1_foo(), 11);
+assert_eq!(instance.get_some_prop(), 5);
+assert!(instance.get_other_prop() < 4760); // should be 4750
+assert!(instance.get_other_prop() > 4740);
+
+sixtyfps::testing::mock_elapsed_time(800); // some: in delay, other: in play for 850ms [950ms]
+assert_eq!(instance.get_text1_foo(), 11);
+assert_eq!(instance.get_some_prop(), 5);
+assert!(instance.get_other_prop() < 760); // should be 750
+assert!(instance.get_other_prop() > 740);
+
+sixtyfps::testing::mock_elapsed_time(160); // some: in delay, other: ended [111ßms]
+assert_eq!(instance.get_text1_foo(), 11);
+assert_eq!(instance.get_some_prop(), 5);
+assert_eq!(instance.get_other_prop(), 0);
+
+sixtyfps::testing::mock_elapsed_time(3840); // some: in delay, other: ended [4950ms]
+assert_eq!(instance.get_text1_foo(), 11);
+assert_eq!(instance.get_some_prop(), 5);
+assert_eq!(instance.get_other_prop(), 0);
+
+sixtyfps::testing::mock_elapsed_time(60); // some: in play for 10ms, other: ended [5010ms]
+assert_eq!(instance.get_text1_foo(), 11);
+assert!(instance.get_some_prop() > 202); // should be 204,5
+assert!(instance.get_some_prop() < 207);
+assert_eq!(instance.get_other_prop(), 0);
+
+sixtyfps::testing::mock_elapsed_time(100); // some: ended, other: ended [5110ms]
+assert_eq!(instance.get_text1_foo(), 11);
+assert_eq!(instance.get_some_prop(), 2000);
+assert_eq!(instance.get_other_prop(), 0);
+
+instance.set_active_index(2);
+assert_eq!(instance.get_text1_foo(), 11);
+assert_eq!(instance.get_some_prop(), 5);
+assert_eq!(instance.get_other_prop(), 5000);
+
+sixtyfps::testing::mock_elapsed_time(50); // In delay
+assert_eq!(instance.get_text1_foo(), 11);
+assert_eq!(instance.get_some_prop(), 5);
+assert_eq!(instance.get_other_prop(), 5000);
+
+sixtyfps::testing::mock_elapsed_time(440);
+assert!(instance.get_text1_foo() > 70);
+assert!(instance.get_text1_foo() < 87);
+assert_eq!(instance.get_some_prop(), 5);
+assert_eq!(instance.get_other_prop(), 5000);
+
+sixtyfps::testing::mock_elapsed_time(30);
+assert_eq!(instance.get_text1_foo(), 85 + 4);
+assert_eq!(instance.get_some_prop(), 5);
+assert_eq!(instance.get_other_prop(), 5000);
+```
+
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_text1_foo(), 85 + 4);
+assert_eq(instance.get_some_prop(), 5);
+assert_eq(instance.get_other_prop(), 5000);
+
+instance.set_active_index(1);
+assert_eq(instance.get_text1_foo(), 11);
+assert_eq(instance.get_some_prop(), 5);
+assert_eq(instance.get_other_prop(), 5000);
+
+sixtyfps::testing::mock_elapsed_time(50); // In delay
+assert_eq(instance.get_text1_foo(), 11);
+assert_eq(instance.get_some_prop(), 5);
+assert_eq(instance.get_other_prop(), 5000);
+
+sixtyfps::testing::mock_elapsed_time(50); // some: in delay, other: end of delay
+assert_eq(instance.get_text1_foo(), 11);
+assert_eq(instance.get_some_prop(), 5);
+assert_eq(instance.get_other_prop(), 5000);
+
+sixtyfps::testing::mock_elapsed_time(50); // some: in delay, other: in play for 50ms [150ms]
+assert_eq(instance.get_text1_foo(), 11);
+assert_eq(instance.get_some_prop(), 5);
+assert(instance.get_other_prop() < 4760); // should be 4750
+assert(instance.get_other_prop() > 4740);
+
+sixtyfps::testing::mock_elapsed_time(800); // some: in delay, other: in play for 850ms [950ms]
+assert_eq(instance.get_text1_foo(), 11);
+assert_eq(instance.get_some_prop(), 5);
+assert(instance.get_other_prop() < 760); // should be 750
+assert(instance.get_other_prop() > 740);
+
+sixtyfps::testing::mock_elapsed_time(160); // some: in delay, other: ended [111ßms]
+assert_eq(instance.get_text1_foo(), 11);
+assert_eq(instance.get_some_prop(), 5);
+assert_eq(instance.get_other_prop(), 0);
+
+sixtyfps::testing::mock_elapsed_time(3840); // some: in delay, other: ended [4950ms]
+assert_eq(instance.get_text1_foo(), 11);
+assert_eq(instance.get_some_prop(), 5);
+assert_eq(instance.get_other_prop(), 0);
+
+sixtyfps::testing::mock_elapsed_time(60); // some: in play for 10ms, other: ended [5010ms]
+assert_eq(instance.get_text1_foo(), 11);
+assert(instance.get_some_prop() > 202); // should be 204,5
+assert(instance.get_some_prop() < 207);
+assert_eq(instance.get_other_prop(), 0);
+
+sixtyfps::testing::mock_elapsed_time(100); // some: ended, other: ended [5110ms]
+assert_eq(instance.get_text1_foo(), 11);
+assert_eq(instance.get_some_prop(), 2000);
+assert_eq(instance.get_other_prop(), 0);
+
+instance.set_active_index(2);
+assert_eq(instance.get_text1_foo(), 11);
+assert_eq(instance.get_some_prop(), 5);
+assert_eq(instance.get_other_prop(), 5000);
+
+sixtyfps::testing::mock_elapsed_time(50); // In delay
+assert_eq(instance.get_text1_foo(), 11);
+assert_eq(instance.get_some_prop(), 5);
+assert_eq(instance.get_other_prop(), 5000);
+
+sixtyfps::testing::mock_elapsed_time(440);
+assert(instance.get_text1_foo() > 70);
+assert(instance.get_text1_foo() < 87);
+assert_eq(instance.get_some_prop(), 5);
+assert_eq(instance.get_other_prop(), 5000);
+
+sixtyfps::testing::mock_elapsed_time(30);
+assert_eq(instance.get_text1_foo(), 85 + 4);
+assert_eq(instance.get_some_prop(), 5);
+assert_eq(instance.get_other_prop(), 5000);
+```
+
+```js
+var instance = new sixtyfps.TestCase({});
+assert.equal(instance.text1_foo, 85 + 4);
+assert.equal(instance.some_prop, 5);
+assert.equal(instance.other_prop, 5000);
+
+instance.active_index = 1;
+assert.equal(instance.text1_foo, 11);
+assert.equal(instance.some_prop, 5);
+assert.equal(instance.other_prop, 5000);
+
+sixtyfpslib.private_api.mock_elapsed_time(50); // In delay
+assert.equal(instance.text1_foo, 11);
+assert.equal(instance.some_prop, 5);
+assert.equal(instance.other_prop, 5000);
+
+sixtyfpslib.private_api.mock_elapsed_time(50); // some: in delay, other: end of delay
+assert.equal(instance.text1_foo, 11);
+assert.equal(instance.some_prop, 5);
+assert.equal(instance.other_prop, 5000);
+
+sixtyfpslib.private_api.mock_elapsed_time(50); // some: in delay, other: in play for 50ms [150ms]
+assert.equal(instance.text1_foo, 11);
+assert.equal(instance.some_prop, 5);
+assert(instance.other_prop < 4760); // should be 4750
+assert(instance.other_prop > 4740);
+
+sixtyfpslib.private_api.mock_elapsed_time(800); // some: in delay, other: in play for 850ms [950ms]
+assert.equal(instance.text1_foo, 11);
+assert.equal(instance.some_prop, 5);
+assert(instance.other_prop < 760); // should be 750
+assert(instance.other_prop > 740);
+
+sixtyfpslib.private_api.mock_elapsed_time(160); // some: in delay, other: ended [111ßms]
+assert.equal(instance.text1_foo, 11);
+assert.equal(instance.some_prop, 5);
+assert.equal(instance.other_prop, 0);
+
+sixtyfpslib.private_api.mock_elapsed_time(3840); // some: in delay, other: ended [4950ms]
+assert.equal(instance.text1_foo, 11);
+assert.equal(instance.some_prop, 5);
+assert.equal(instance.other_prop, 0);
+
+sixtyfpslib.private_api.mock_elapsed_time(60); // some: in play for 10ms, other: ended [5010ms]
+assert.equal(instance.text1_foo, 11);
+assert(instance.some_prop > 202); // should be 204,5
+assert(instance.some_prop < 207);
+assert.equal(instance.other_prop, 0);
+
+sixtyfpslib.private_api.mock_elapsed_time(100); // some: ended, other: ended [5110ms]
+assert.equal(instance.text1_foo, 11);
+assert.equal(instance.some_prop, 2000);
+assert.equal(instance.other_prop, 0);
+
+instance.active_index = 2;
+assert.equal(instance.text1_foo, 11);
+assert.equal(instance.some_prop, 5);
+assert.equal(instance.other_prop, 5000);
+
+sixtyfpslib.private_api.mock_elapsed_time(50); // In delay
+assert.equal(instance.text1_foo, 11);
+assert.equal(instance.some_prop, 5);
+assert.equal(instance.other_prop, 5000);
+
+sixtyfpslib.private_api.mock_elapsed_time(440);
+assert(instance.text1_foo > 70);
+assert(instance.text1_foo < 87);
+assert.equal(instance.some_prop, 5);
+assert.equal(instance.other_prop, 5000);
+
+sixtyfpslib.private_api.mock_elapsed_time(30);
+assert.equal(instance.text1_foo, 85 + 4);
+assert.equal(instance.some_prop, 5);
+assert.equal(instance.other_prop, 5000);
+```
+
+*/


### PR DESCRIPTION
This is a very non-intrusive implementation of a `delay` property on `PropertyAnimation`.

This version will only add a `delay` before the first animation. In the presence of `loop-count`, these other animations will not be delayed.