### PR TITLE
Verify the existence of imported custom fonts

### DIFF
--- a/docs/langref.md
+++ b/docs/langref.md
@@ -1016,7 +1016,7 @@ instructions the SixtyFPS compiler to include the font and makes the font famili
 
 For example:
 
-```60
+```60,notest
 import "./NotoSans-Regular.ttf";
 
 Example := Window {

--- a/sixtyfps_compiler/object_tree.rs
+++ b/sixtyfps_compiler/object_tree.rs
@@ -132,7 +132,15 @@ impl Document {
                     || import.file.ends_with(".ttf")
                     || import.file.ends_with(".otf")
                 {
-                    Some(import.file)
+                    if crate::fileaccess::load_file(std::path::Path::new(&import.file)).is_some() {
+                        Some(import.file)
+                    } else {
+                        diag.push_error(
+                            format!("File \"{}\" not found", import.file),
+                            &import.import_token,
+                        );
+                        None
+                    }
                 } else {
                     diag.push_error(
                         format!("Unsupported foreign import \"{}\"", import.file),

--- a/sixtyfps_compiler/tests/syntax/imports/font.60
+++ b/sixtyfps_compiler/tests/syntax/imports/font.60
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: (GPL-3.0-only OR LicenseRef-SixtyFPS-commercial)
 
 import "myfont.ttf";
+//     ^error{File "myfont.ttf" not found}
 import "myfontcollection.ttc";
+//     ^error{File "myfontcollection.ttc" not found}
 import "myimage.png";
 //     ^error{Unsupported foreign import "myimage.png"}
 


### PR DESCRIPTION
... and produce diagnostics.

That way in later phases we don't need to check again.