### PR TITLE
Parser: allow `.` to access member after any expression

### DIFF
--- a/sixtyfps_compiler/parser.rs
+++ b/sixtyfps_compiler/parser.rs
@@ -359,7 +359,8 @@ declare_syntax! {
         // FIXME: the test should test that as alternative rather than several of them (but it can also be a literal)
         Expression-> [ ?Expression, ?FunctionCallExpression, ?SelfAssignment,
                        ?ConditionalExpression, ?QualifiedName, ?BinaryExpression, ?Array, ?ObjectLiteral,
-                       ?UnaryOpExpression, ?CodeBlock, ?StringTemplate, ?AtImageUrl, ?AtLinearGradient],
+                       ?UnaryOpExpression, ?CodeBlock, ?StringTemplate, ?AtImageUrl, ?AtLinearGradient,
+                       ?MemberAccess ],
         /// Concatenate the Expressions to make a string (usually expended from a template string)
         StringTemplate -> [*Expression],
         /// `@image-url("foo.png")`
@@ -376,6 +377,8 @@ declare_syntax! {
         BinaryExpression -> [2 Expression],
         /// `- expr`
         UnaryOpExpression -> [Expression],
+        /// `(foo).bar`, where `foo` is the base expression, and `bar` is a Identifier.
+        MemberAccess -> [Expression],
         /// `[ ... ]`
         Array -> [ *Expression ],
         /// `{ foo: bar }`

--- a/tests/cases/types/object.60
+++ b/tests/cases/types/object.60
@@ -17,6 +17,11 @@ TestCase := Rectangle {
         foo.a = obj_conversion2.a;
         foo.b += 8 + obj_conversion2.b;
     }
+
+    callback return_object() -> { aa: { bb: int } };
+    return_object => { return { aa: { bb: { cc: 42 }.cc } }; }
+    property <bool> test: return_object().aa.bb == 42 && obj_binop_merge;
+
 }
 
 
@@ -30,6 +35,7 @@ assert_eq!(instance.get_foo_a(), sixtyfps::SharedString::from("hello"));
 assert_eq!(instance.get_foo_b(), 20);
 assert_eq!(instance.get_obj_cond_merge_b(), 0);
 assert!(instance.get_obj_binop_merge());
+assert!(instance.get_test());
 
 // This API to set with a tuple should maybe not be accessible?
 instance.set_foo(("yo".into(), 33));
@@ -48,6 +54,7 @@ assert_eq(instance.get_foo_a(), sixtyfps::SharedString("hello"));
 assert_eq(instance.get_foo_b(), 20);
 assert_eq(instance.get_obj_cond_merge_b(), 0);
 assert_eq(instance.get_obj_binop_merge(), true);
+assert(instance.get_test());
 
 // This API to set with a tuple should maybe not be accessible?
 instance.set_foo(std::make_tuple(sixtyfps::SharedString("yo"), 33));
@@ -65,6 +72,7 @@ assert.equal(instance.foo_a, "hello");
 assert.equal(instance.foo_b, 20);
 assert.equal(instance.obj_cond_merge_b, 0);
 assert(instance.obj_binop_merge);
+assert(instance.test);
 
 instance.foo = { a: "yo", b: 33 };
 assert.equal(instance.foo_a, "yo");

--- a/tests/cases/types/string_to_float.60
+++ b/tests/cases/types/string_to_float.60
@@ -12,7 +12,7 @@ TestCase := Rectangle {
     property<bool> test_is_float: !hello.is_float() && number.is_float() &&
          !invalid.is_float() && negative.is_float();
 
-    property<bool> test: test_is_float &&  42.56001 - number_as_float  < 0.001;
+    property<bool> test: test_is_float &&  42.56001 - number_as_float  < 0.001 && "123".to-float() == 123;
 }
 
 


### PR DESCRIPTION
Before we would only allow `foo.bar` where `foo` was an identifier.
Now we also allow more complex expression such as `"foo".bar` or `(123 + foo).bar`
(in the parser)
In particular, this will allow to get the member of objects returned by functions
or, in the future, part of arrays