### PR TITLE
Add support tracked array data access by index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
    of the animation.
  - Rust: Added `sixtyfps::VecModel::insert(&self, index, value)`.
  - C++: Added `sixtyfps::VecModel::insert(index, value)`.
+ - Added ability to access elements of a model with the `[index]` syntax.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ All notable changes to this project will be documented in this file.
  - Math functions `log`, and `pow`
  - Property animations now have a `delay` property, which will delay the start
    of the animation.
- - `sixtyfps::VecModel` in Rust now has an `insert(index, value)` function.
+ - Rust: Added `sixtyfps::VecModel::insert(&self, index, value)`.
+ - C++: Added `sixtyfps::VecModel::insert(index, value)`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
  - Math functions `log`, and `pow`
  - Property animations now have a `delay` property, which will delay the start
    of the animation.
+ - `sixtyfps::VecModel` in Rust now has an `insert(index, value)` function.
 
 ### Fixed
 

--- a/api/sixtyfps-cpp/include/sixtyfps.h
+++ b/api/sixtyfps-cpp/include/sixtyfps.h
@@ -595,6 +595,13 @@ public:
         data.erase(data.begin() + index);
         this->row_removed(index, 1);
     }
+
+    /// Inserts the given value as a new row at the specified index
+    void insert(size_t index, const ModelData &value)
+    {
+        data.insert(data.begin() + index, value);
+        this->row_added(int(index), 1);
+    }
 };
 
 namespace private_api {
@@ -700,7 +707,8 @@ public:
         for (std::size_t i = 0; i < inner->data.size(); ++i) {
             int index = order == TraversalOrder::BackToFront ? i : inner->data.size() - 1 - i;
             auto ref = item_at(index);
-            if (ref.vtable->visit_children_item(ref, -1, order, visitor) != std::numeric_limits<uint64_t>::max()) {
+            if (ref.vtable->visit_children_item(ref, -1, order, visitor)
+                != std::numeric_limits<uint64_t>::max()) {
                 return index;
             }
         }

--- a/docs/langref.md
+++ b/docs/langref.md
@@ -262,6 +262,7 @@ Example := Window {
 ```
 
 * **`length`**: One can query the length of an array and model using the builtin `.length` property.
+* **`array[index]`**: Individual elements of an array can be retrieved using the `array[index]` syntax.
 
 ### Conversions
 

--- a/sixtyfps_compiler/expression_tree.rs
+++ b/sixtyfps_compiler/expression_tree.rs
@@ -1081,6 +1081,7 @@ impl Expression {
             }
             Expression::StructFieldAccess { base, .. } => base.try_set_rw(),
             Expression::RepeaterModelReference { .. } => true,
+            Expression::ArrayIndex { .. } => true,
             _ => false,
         }
     }

--- a/sixtyfps_compiler/generator/cpp.rs
+++ b/sixtyfps_compiler/generator/cpp.rs
@@ -2520,6 +2520,22 @@ fn compile_assignment(
                 )
             }
         }
+        Expression::ArrayIndex { array, index } => {
+            let array = compile_expression(array, component);
+            let index = compile_expression(index, component);
+            if op == '=' {
+                format!("{}->set_row_data({}, {})", array, index, rhs)
+            } else {
+                format!(
+                    "{array}->set_row_data({index}, {array}->row_data({index}) {op} {rhs})",
+                    array = array,
+                    index = index,
+                    op = op,
+                    rhs = rhs,
+                )
+            }
+        }
+
         _ => panic!("typechecking should make sure this was a PropertyReference"),
     }
 }

--- a/sixtyfps_compiler/generator/cpp.rs
+++ b/sixtyfps_compiler/generator/cpp.rs
@@ -2079,7 +2079,7 @@ fn compile_expression(
         },
         Expression::ArrayIndex { array, index } => match array.ty() {
             Type::Array(_) => {
-                format!("({})->row_data({})", compile_expression(array, component), compile_expression(index, component))
+                format!("[&](const auto &model, const auto &index){{ model->track_row_data_changes(index); return model->row_data(index); }}({}, {})", compile_expression(array, component), compile_expression(index, component))
             }
             _ => panic!("Expression::ArrayIndex's base expression is not an Array type"),
         },

--- a/sixtyfps_compiler/generator/cpp.rs
+++ b/sixtyfps_compiler/generator/cpp.rs
@@ -2077,6 +2077,12 @@ fn compile_expression(
             }
             _ => panic!("Expression::ObjectAccess's base expression is not an Object type"),
         },
+        Expression::ArrayIndex { array, index } => match array.ty() {
+            Type::Array(_) => {
+                format!("({})->row_data({})", compile_expression(array, component), compile_expression(index, component))
+            }
+            _ => panic!("Expression::ArrayIndex's base expression is not an Array type"),
+        },
         Expression::Cast { from, to } => {
             let f = compile_expression(&*from, component);
             match (from.ty(), to) {

--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -1381,7 +1381,11 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
             debug_assert!(matches!(array.ty(ctx), Type::Array(_)));
             let base_e = compile_expression(array, ctx);
             let index_e = compile_expression(index, ctx);
-            quote!((#base_e).row_data((#index_e) as usize))
+            quote!(match &#base_e { x => {
+                let index = (#index_e) as usize;
+                x.model_tracker().track_row_data_changes(index);
+                x.row_data(index)
+            }})
         }
         Expression::CodeBlock(sub) => {
             let map = sub.iter().map(|e| compile_expression(e, ctx));

--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -1377,10 +1377,10 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
             }
             _ => panic!("Expression::StructFieldAccess's base expression is not an Object type"),
         },
-        Expression::ArrayIndex { array, index } => match array.ty() {
+        Expression::ArrayIndex { array, index } => match array.ty(ctx) {
             Type::Array(_) => {
-                let base_e = compile_expression(array, component);
-                let index_e = compile_expression(index, component);
+                let base_e = compile_expression(array, ctx);
+                let index_e = compile_expression(index, ctx);
                 quote!((#base_e).row_data((#index_e) as usize))
             }
             _ => panic!("Expression::ArrayIndex's base expression is not an Array type"),

--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -1377,6 +1377,14 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
             }
             _ => panic!("Expression::StructFieldAccess's base expression is not an Object type"),
         },
+        Expression::ArrayIndex { array, index } => match array.ty() {
+            Type::Array(_) => {
+                let base_e = compile_expression(array, component);
+                let index_e = compile_expression(index, component);
+                quote!((#base_e).row_data((#index_e) as usize))
+            }
+            _ => panic!("Expression::ArrayIndex's base expression is not an Array type"),
+        },
         Expression::CodeBlock(sub) => {
             let map = sub.iter().map(|e| compile_expression(e, ctx));
             quote!({ #(#map);* })

--- a/sixtyfps_compiler/langtype.rs
+++ b/sixtyfps_compiler/langtype.rs
@@ -407,7 +407,6 @@ impl Type {
             }
             true
         };
-
         match (self, other) {
             (a, b) if a == b => true,
             (_, Type::Invalid)

--- a/sixtyfps_compiler/llr/lower_expression.rs
+++ b/sixtyfps_compiler/llr/lower_expression.rs
@@ -269,6 +269,25 @@ fn lower_assignment(
 
             llr_Expression::ModelDataAssignment { level, value }
         }
+        tree_Expression::ArrayIndex { array, index } => {
+            let rhs = lower_expression(rhs, ctx);
+            let array = Box::new(lower_expression(array, ctx));
+            let index = Box::new(lower_expression(index, ctx));
+            let value = Box::new(if op == '=' {
+                rhs
+            } else {
+                // FIXME: this will compute the index and the array twice:
+                // Ideally we should store the index and the array in local variable
+                llr_Expression::BinaryExpression {
+                    lhs: llr_Expression::ArrayIndex { array: array.clone(), index: index.clone() }
+                        .into(),
+                    rhs: rhs.into(),
+                    op,
+                }
+            });
+
+            llr_Expression::ArrayIndexAssignment { array, index, value }
+        }
         _ => panic!("not a rvalue"),
     }
 }

--- a/sixtyfps_compiler/llr/lower_expression.rs
+++ b/sixtyfps_compiler/llr/lower_expression.rs
@@ -103,6 +103,10 @@ pub fn lower_expression(
             base: Box::new(lower_expression(base, ctx)),
             name: name.clone(),
         },
+        tree_Expression::ArrayIndex { array, index } => llr_Expression::ArrayIndex {
+            array: Box::new(lower_expression(array, ctx)),
+            index: Box::new(lower_expression(index, ctx)),
+        },
         tree_Expression::Cast { from, to } => {
             llr_Expression::Cast { from: Box::new(lower_expression(from, ctx)), to: to.clone() }
         }

--- a/sixtyfps_compiler/parser.rs
+++ b/sixtyfps_compiler/parser.rs
@@ -357,7 +357,7 @@ declare_syntax! {
         CodeBlock-> [ *Expression, *ReturnStatement ],
         ReturnStatement -> [ ?Expression ],
         // FIXME: the test should test that as alternative rather than several of them (but it can also be a literal)
-        Expression-> [ ?Expression, ?FunctionCallExpression, ?SelfAssignment,
+        Expression-> [ ?Expression, ?FunctionCallExpression, ?IndexExpression, ?SelfAssignment,
                        ?ConditionalExpression, ?QualifiedName, ?BinaryExpression, ?Array, ?ObjectLiteral,
                        ?UnaryOpExpression, ?CodeBlock, ?StringTemplate, ?AtImageUrl, ?AtLinearGradient,
                        ?MemberAccess ],
@@ -369,6 +369,8 @@ declare_syntax! {
         AtLinearGradient -> [*Expression],
         /// expression()
         FunctionCallExpression -> [*Expression],
+        /// expression[index]
+        IndexExpression -> [2 Expression],
         /// `expression += expression`
         SelfAssignment -> [2 Expression],
         /// `condition ? first : second`

--- a/sixtyfps_compiler/parser/expressions.rs
+++ b/sixtyfps_compiler/parser/expressions.rs
@@ -27,6 +27,7 @@ use super::prelude::*;
 /// -0.3px + 0.3px - 3.pt+3pt
 /// aa == cc && bb && (xxx || fff) && 3 + aaa == bbb
 /// [array]
+/// array[index]
 /// {object:42}
 /// "foo".bar.something().something.xx({a: 1.foo}.a)
 /// ```
@@ -105,6 +106,15 @@ fn parse_expression_helper(p: &mut impl Parser, precedence: OperatorPrecedence) 
                 }
                 let mut p = p.start_node_at(checkpoint.clone(), SyntaxKind::FunctionCallExpression);
                 parse_function_arguments(&mut *p);
+            }
+            SyntaxKind::LBracket => {
+                {
+                    let _ = p.start_node_at(checkpoint.clone(), SyntaxKind::Expression);
+                }
+                let mut p = p.start_node_at(checkpoint.clone(), SyntaxKind::IndexExpression);
+                p.expect(SyntaxKind::LBracket);
+                parse_expression(&mut *p);
+                p.expect(SyntaxKind::RBracket);
             }
             _ => break,
         }

--- a/sixtyfps_compiler/passes/resolving.rs
+++ b/sixtyfps_compiler/passes/resolving.rs
@@ -866,8 +866,7 @@ impl Expression {
         );
 
         let ty = array_expr.ty();
-        if let Type::Array(_) = ty {
-        } else {
+        if !matches!(ty, Type::Array(_) | Type::Invalid) {
             ctx.diag.push_error(format!("{} is not an indexable type", ty), &node);
         }
         Expression::ArrayIndex { array: Box::new(array_expr), index: Box::new(index_expr) }

--- a/sixtyfps_compiler/tests/syntax/lookup/array_index.60
+++ b/sixtyfps_compiler/tests/syntax/lookup/array_index.60
@@ -1,0 +1,22 @@
+// Copyright © SixtyFPS GmbH <info@sixtyfps.io>
+// SPDX-License-Identifier: (GPL-3.0-only OR LicenseRef-SixtyFPS-commercial)
+
+Hello := Rectangle {
+
+    property <int> aa: 45;
+    property <{o:[int], c:string}> bb;
+    property <int> xx: aa[2];
+    //                 ^error{int is not an indexable type}
+    property <int> yy: dontexist[2];
+    //                 ^error{Unknown unqualified identifier 'dontexist'}
+    //property <int> zz: bb.o[2].aa;
+    property <int> ww: bb.c[2];
+    //                 ^error{string is not an indexable type}
+
+    property <int> uu: bb.o[bb.c];
+    //                      ^error{Cannot convert string to int}
+
+
+
+}
+

--- a/sixtyfps_runtime/corelib/model.rs
+++ b/sixtyfps_runtime/corelib/model.rs
@@ -300,6 +300,13 @@ impl<T: 'static> VecModel<T> {
         self.notify.row_added(self.array.borrow().len() - 1, 1)
     }
 
+    /// Inserts a row at position index. All rows after that are shifted.
+    /// This function panics if index is > row_count().
+    pub fn insert(&self, index: usize, value: T) {
+        self.array.borrow_mut().insert(index, value);
+        self.notify.row_added(index, 1)
+    }
+
     /// Remove the row at the given index from the model
     pub fn remove(&self, index: usize) {
         self.array.borrow_mut().remove(index);

--- a/sixtyfps_runtime/interpreter/eval.rs
+++ b/sixtyfps_runtime/interpreter/eval.rs
@@ -170,6 +170,25 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
                 Value::Void
             }
         }
+        Expression::ArrayIndex { array, index } => {
+            let array = eval_expression(array, local_context);
+            let index = eval_expression(index, local_context);
+            match (array, index) {
+                (Value::Array(vec), Value::Number(index)) => {
+                    vec.as_slice().get(index as usize).cloned().unwrap_or(Value::Void)
+                }
+                (Value::Model(model), Value::Number(index)) => {
+                    if (index as usize) < model.row_count() {
+                        model.row_data(index as usize)
+                    } else {
+                        Value::Void
+                    }
+                }
+                _ => {
+                    Value::Void
+                }
+            }
+        }
         Expression::Cast { from, to } => {
             let v = eval_expression(&*from, local_context);
             match (v, to) {

--- a/sixtyfps_runtime/interpreter/eval.rs
+++ b/sixtyfps_runtime/interpreter/eval.rs
@@ -736,6 +736,25 @@ fn eval_assignment(lhs: &Expression, op: char, rhs: Value, local_context: &mut E
                 },
             )
         }
+        Expression::ArrayIndex { array, index } => {
+            let array = eval_expression(&array, local_context);
+            let index = eval_expression(&index, local_context);
+            match (array, index) {
+                (Value::Model(model), Value::Number(index)) => {
+                    let index = index as usize;
+                    if (index) < model.row_count() {
+                        if op == '=' {
+                            model.set_row_data(index, rhs);
+                        } else {
+                            model.set_row_data(index, eval(model.row_data(index)));
+                        }
+                    }
+                }
+                _ => {
+                    eprintln!("Attempting to write into an array that cannot be written");
+                }
+            }
+        }
         _ => panic!("typechecking should make sure this was a PropertyReference"),
     }
 }

--- a/sixtyfps_runtime/interpreter/eval.rs
+++ b/sixtyfps_runtime/interpreter/eval.rs
@@ -179,6 +179,7 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
                 }
                 (Value::Model(model), Value::Number(index)) => {
                     if (index as usize) < model.row_count() {
+                        model.model_tracker().track_row_data_changes(index as usize);
                         model.row_data(index as usize)
                     } else {
                         Value::Void

--- a/sixtyfps_runtime/interpreter/value_model.rs
+++ b/sixtyfps_runtime/interpreter/value_model.rs
@@ -32,6 +32,14 @@ impl ModelTracker for ValueModel {
             self.notify.track_row_count_changes()
         }
     }
+
+    fn track_row_data_changes(&self, row: usize) {
+        if let Value::Model(ref model_ptr) = *self.value.borrow() {
+            model_ptr.model_tracker().track_row_data_changes(row)
+        } else {
+            self.notify.track_row_data_changes(row)
+        }
+    }
 }
 
 impl Model for ValueModel {

--- a/tests/cases/models/array.60
+++ b/tests/cases/models/array.60
@@ -7,6 +7,7 @@ export TestCase := Rectangle {
     property<int> n: ints[ints[4] - ints[1]];
     property<int> operations: ints.length < 1 ? ints.length : ints.length + ints.length;
     property<bool> test: num_ints == 5 && operations == 10;
+    property<int> third_int: ints[2];
 }
 
 /*
@@ -16,26 +17,35 @@ const TestCase &instance = *handle;
 
 assert_eq(instance.get_num_ints(), 5);
 assert_eq(instance.get_n(), 4);
+assert_eq(instance.get_third_int(), 3);
 
 auto model = std::make_shared<sixtyfps::VectorModel<int>>(std::vector<int>{1, 2, 3, 4, 5, 6, 7});
 instance.set_ints(model);
 assert_eq(instance.get_num_ints(), 7);
+assert_eq(instance.get_third_int(), 3);
 model->push_back(8);
 assert_eq(instance.get_num_ints(), 8);
+model->set_row_data(2, 100);
+assert_eq(instance.get_third_int(), 100);
 ```
 
 
 ```rust
+use sixtyfps::Model;
 let instance = TestCase::new();
 
 assert_eq!(instance.get_num_ints(), 5);
 assert_eq!(instance.get_n(), 4);
+assert_eq!(instance.get_third_int(), 3);
 
 let model: std::rc::Rc<sixtyfps::VecModel<i32>> = std::rc::Rc::new(vec![1, 2, 3, 4, 5, 6, 7].into());
 instance.set_ints(sixtyfps::ModelHandle::new(model.clone()));
 assert_eq!(instance.get_num_ints(), 7);
+assert_eq!(instance.get_third_int(), 3);
 model.push(8);
 assert_eq!(instance.get_num_ints(), 8);
+model.set_row_data(2, 100);
+assert_eq!(instance.get_third_int(), 100);
 ```
 
 ```js
@@ -43,11 +53,15 @@ var instance = new sixtyfps.TestCase();
 
 assert.equal(instance.num_ints, 5);
 assert.equal(instance.n, 4);
+assert.equal(instance.third_int, 3);
 
 let model = new sixtyfpslib.ArrayModel([1, 2, 3, 4, 5, 6, 7]);
 instance.ints = model;
 assert.equal(instance.num_ints, 7);
+assert.equal(instance.third_int, 3);
 model.push(8);
 assert.equal(instance.num_ints, 8);
+model.setRowData(2, 100);
+assert.equal(instance.third_int, 100);
 ```
 */

--- a/tests/cases/models/array.60
+++ b/tests/cases/models/array.60
@@ -4,6 +4,7 @@
 export TestCase := Rectangle {
     property<[int]> ints: [1, 2, 3, 4, 5];
     property<int> num_ints: ints.length;
+    property<int> n: ints[ints[4] - ints[1]];
     property<int> operations: ints.length < 1 ? ints.length : ints.length + ints.length;
     property<bool> test: num_ints == 5 && operations == 10;
 }
@@ -14,6 +15,7 @@ auto handle = TestCase::create();
 const TestCase &instance = *handle;
 
 assert_eq(instance.get_num_ints(), 5);
+assert_eq(instance.get_n(), 4);
 
 auto model = std::make_shared<sixtyfps::VectorModel<int>>(std::vector<int>{1, 2, 3, 4, 5, 6, 7});
 instance.set_ints(model);
@@ -27,6 +29,7 @@ assert_eq(instance.get_num_ints(), 8);
 let instance = TestCase::new();
 
 assert_eq!(instance.get_num_ints(), 5);
+assert_eq!(instance.get_n(), 4);
 
 let model: std::rc::Rc<sixtyfps::VecModel<i32>> = std::rc::Rc::new(vec![1, 2, 3, 4, 5, 6, 7].into());
 instance.set_ints(sixtyfps::ModelHandle::new(model.clone()));
@@ -39,6 +42,7 @@ assert_eq!(instance.get_num_ints(), 8);
 var instance = new sixtyfps.TestCase();
 
 assert.equal(instance.num_ints, 5);
+assert.equal(instance.n, 4);
 
 let model = new sixtyfpslib.ArrayModel([1, 2, 3, 4, 5, 6, 7]);
 instance.ints = model;

--- a/tests/cases/models/write_to_model.60
+++ b/tests/cases/models/write_to_model.60
@@ -30,9 +30,15 @@ TestCase := Rectangle {
             person.score = person.score + 1;
             person.score += 1;
             clicked_score = score;
-
         }
     }
+
+    callback manual_score_update(int, int);
+    manual_score_update(i, val) => {
+        model[i].score += val;
+    }
+
+
 }
 
 /*
@@ -56,9 +62,11 @@ instance.set_model(sixtyfps::ModelHandle::new(another_model.clone()));
 sixtyfps::testing::send_mouse_click(&instance, 25., 5.);
 assert_eq!(instance.get_clicked_score(), 336);
 assert_eq!(another_model.row_data(2).2, 336.);
+
+instance.invoke_manual_score_update(2, 100);
 sixtyfps::testing::send_mouse_click(&instance, 25., 5.);
-assert_eq!(instance.get_clicked_score(), 339);
-assert_eq!(another_model.row_data(2).2, 339.);
+assert_eq!(instance.get_clicked_score(), 439);
+assert_eq!(another_model.row_data(2).2, 439.);
 assert_eq!(another_model.row_data(2).1, sixtyfps::SharedString::from("world"));
 ```
 
@@ -79,9 +87,11 @@ instance.set_model(another_model);
 sixtyfps::testing::send_mouse_click(&instance, 25., 5.);
 assert_eq(instance.get_clicked_score(), 336);
 assert_eq(std::get<2>(another_model->row_data(2)), 336.);
+
+instance.invoke_manual_score_update(2, 100);
 sixtyfps::testing::send_mouse_click(&instance, 25., 5.);
-assert_eq(instance.get_clicked_score(), 339);
-assert_eq(std::get<2>(another_model->row_data(2)), 339.);
+assert_eq(instance.get_clicked_score(), 439);
+assert_eq(std::get<2>(another_model->row_data(2)), 439.);
 assert_eq(std::get<1>(another_model->row_data(2)), "world");
 ```
 
@@ -101,9 +111,11 @@ instance.model = another_model;
 instance.send_mouse_click(25., 5.);
 assert.equal(instance.clicked_score, 336);
 assert.equal(another_model.rowData(2).score, 336.);
+
+instance.manual_score_update(2, 100);
 instance.send_mouse_click(25., 5.);
-assert.equal(instance.clicked_score, 339);
-assert.equal(another_model.rowData(2).score, 339.);
+assert.equal(instance.clicked_score, 439);
+assert.equal(another_model.rowData(2).score, 439.);
 assert.equal(another_model.rowData(2).name, "world");
 ```
 


### PR DESCRIPTION
This is based on #605 and adds support for array index expressions for writing as well as change tracking for property bindings.