### PR TITLE
Fixes loop detection involving sub components and two ways binding

### DIFF
--- a/sixtyfps_compiler/expression_tree.rs
+++ b/sixtyfps_compiler/expression_tree.rs
@@ -1200,6 +1200,10 @@ pub struct BindingAnalysis {
 
     /// true if the binding is a constant value that can be set without creating a binding at runtime
     pub is_const: bool,
+
+    /// true if this binding does not depends on the value of property that are set externally.
+    /// When true, this binding cannot be part of a binding loop involving external components
+    pub no_external_dependencies: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/sixtyfps_compiler/tests/syntax/analysis/binding_loop2.60
+++ b/sixtyfps_compiler/tests/syntax/analysis/binding_loop2.60
@@ -1,0 +1,44 @@
+// Copyright © SixtyFPS GmbH <info@sixtyfps.io>
+// SPDX-License-Identifier: (GPL-3.0-only OR LicenseRef-SixtyFPS-commercial)
+
+
+T1 := Rectangle {
+    property <int> foo;
+    property <int> bar: foo;
+//                     ^error{The binding for the property 'bar' is part of a binding loop}
+    Text { text: bar; }
+}
+
+T2 := Rectangle {
+    property <string> t2_text;
+    t:= Text { text: t2_text; }
+//                  ^error{The binding for the property 'text' is part of a binding loop}
+//                  ^^error{The binding for the property 'text' is part of a binding loop}
+    property t_alias <=> t.text;
+//                   ^error{The binding for the property 't-alias' is part of a binding loop}
+//                   ^^error{The binding for the property 't-alias' is part of a binding loop}
+}
+
+T3 := Rectangle {
+    property <string> hello;
+    property <string> al <=> a.t_alias;
+//                       ^error{The binding for the property 'al' is part of a binding loop}
+    HorizontalLayout {
+        a := T2 { t2_text: b.t_alias; }
+//                        ^error{The binding for the property 't2-text' is part of a binding loop}
+        b := T2 { t2_text: root.hello;  }
+//                        ^error{The binding for the property 't2-text' is part of a binding loop}
+    }
+}
+
+App := Rectangle {
+
+
+    VerticalLayout {
+        T1 { foo: 44; }
+        T1 { foo: bar; }
+//               ^error{The binding for the property 'foo' is part of a binding loop}
+        T3 { hello: al; }
+//                 ^error{The binding for the property 'hello' is part of a binding loop}
+    }
+}

--- a/sixtyfps_compiler/tests/syntax/analysis/binding_loop_issue_772.60
+++ b/sixtyfps_compiler/tests/syntax/analysis/binding_loop_issue_772.60
@@ -1,0 +1,19 @@
+// Copyright © SixtyFPS GmbH <info@sixtyfps.io>
+// SPDX-License-Identifier: (GPL-3.0-only OR LicenseRef-SixtyFPS-commercial)
+
+Alias := Rectangle {
+    property <int> viewport_width ;
+    property <int> ps_width <=> viewport_width;
+}
+
+Foo := Rectangle {
+    property <int> base-prop: alias.viewport_width;
+    //                       ^error{The binding for the property 'base-prop' is part of a binding loop}
+
+    alias := Alias { ps_width: base-prop; }
+    //                        ^error{The binding for the property 'ps-width' is part of a binding loop}
+
+    Text {
+        text: base-prop;
+    }
+}


### PR DESCRIPTION
The original binding analysis code was considering that all the sub components
were inlined. But when this is not the case, we need to re-analyze each
sub component within their parent.

We also need to take care of reverse aliases

Will cause a .60 compile time binding loop error instead of a
runtime recursion panic in code like issue #772