### PR TITLE
cpp generator: reduce surface of public C++ API

### DIFF
--- a/sixtyfps_compiler/generator/cpp.rs
+++ b/sixtyfps_compiler/generator/cpp.rs
@@ -636,7 +636,7 @@ fn generate_public_component(file: &mut File, component: &llr::PublicComponent) 
         &component,
         None,
         component_id.clone(),
-        Access::Private, // Hid eproperties and other fields from the C++ API
+        Access::Private, // Hide properties and other fields from the C++ API
         file,
     );
 


### PR DESCRIPTION
After generating the root component's item tree, with all public fields,
hide all variables and functions, with three exceptions.

All meanwhile added declarations for sub-components (such as popups, child repeaters)
still get access through friendship.