### PR TITLE
Prospective fix for the printer demo not loading in the online editor

### DIFF
--- a/sixtyfps_compiler/object_tree.rs
+++ b/sixtyfps_compiler/object_tree.rs
@@ -132,7 +132,13 @@ impl Document {
                     || import.file.ends_with(".ttf")
                     || import.file.ends_with(".otf")
                 {
-                    if crate::fileaccess::load_file(std::path::Path::new(&import.file)).is_some() {
+                    // Assume remote urls are valid, we need to load them at run-time (which we currently don't). For
+                    // local paths we should try to verify the existence and let the developer know ASAP.
+                    if import.file.starts_with("http://")
+                        || import.file.starts_with("https://")
+                        || crate::fileaccess::load_file(std::path::Path::new(&import.file))
+                            .is_some()
+                    {
                         Some(import.file)
                     } else {
                         diag.push_error(


### PR DESCRIPTION
Commit fa1ac9884d0fdc20acc1ed39f20ea010de8b069d introduced an early check for the existence
of the specified font files. However we should only do that for local files for now.