### PR TITLE
Enable write access to models initialized from arrays in the interpreter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This version changes some APIs in incompatible ways. For details how to migrate 
 
 ### Fixed
 
+ - Models initialized from arrays are now also mutable when run in the interpreter.
+
 ## [0.1.6] - 2022-01-21
 
 ### Changed

--- a/api/sixtyfps-cpp/include/sixtyfps_interpreter.h
+++ b/api/sixtyfps-cpp/include/sixtyfps_interpreter.h
@@ -419,8 +419,10 @@ inline Value::Value(const sixtyfps::SharedVector<Value> &array)
 
 inline std::optional<sixtyfps::SharedVector<Value>> Value::to_array() const
 {
-    if (auto *array = cbindgen_private::sixtyfps_interpreter_value_to_array(&inner)) {
-        return *reinterpret_cast<const sixtyfps::SharedVector<Value> *>(array);
+    sixtyfps::SharedVector<Value> array;
+    if (cbindgen_private::sixtyfps_interpreter_value_to_array(
+                &inner, &reinterpret_cast<sixtyfps::SharedVector<ValueOpaque> &>(array))) {
+        return array;
     } else {
         return {};
     }

--- a/api/sixtyfps-node/native/js_model.rs
+++ b/api/sixtyfps-node/native/js_model.rs
@@ -37,7 +37,7 @@ impl JsModel {
         Ok(model)
     }
 
-    fn get_object<'cx>(
+    pub fn get_object<'cx>(
         &self,
         cx: &mut impl Context<'cx>,
         persistent_context: &crate::persistent_context::PersistentContext<'cx>,
@@ -94,7 +94,7 @@ impl Model for JsModel {
     fn set_row_data(&self, row: usize, data: Self::Data) {
         crate::run_with_global_context(&|cx, persistent_context| {
             let row = JsNumber::new(cx, row as f64).as_value(cx);
-            let data = crate::to_js_value(data.clone(), cx).unwrap();
+            let data = crate::to_js_value(data.clone(), cx, persistent_context).unwrap();
             let obj = self.get_object(cx, persistent_context).unwrap();
             let _ = obj
                 .get(cx, "setRowData")

--- a/sixtyfps_runtime/interpreter/eval.rs
+++ b/sixtyfps_runtime/interpreter/eval.rs
@@ -572,8 +572,10 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
                 _ => local_context.return_value.clone().expect("conditional expression did not evaluate to boolean"),
             }
         }
-        Expression::Array { values, .. } => Value::Array(
-            values.iter().map(|e| eval_expression(e, local_context)).collect(),
+        Expression::Array { values, .. } => Value::Model(
+            Rc::new(corelib::model::VecModel::from(
+                values.iter().map(|e| eval_expression(e, local_context)).collect::<Vec<_>>()
+            )) as Rc<dyn corelib::model::Model<Data = Value>>
         ),
         Expression::Struct { values, .. } => Value::Struct(
             values

--- a/sixtyfps_runtime/interpreter/eval.rs
+++ b/sixtyfps_runtime/interpreter/eval.rs
@@ -573,8 +573,8 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
             }
         }
         Expression::Array { values, .. } => Value::Model(
-            Rc::new(corelib::model::VecModel::from(
-                values.iter().map(|e| eval_expression(e, local_context)).collect::<Vec<_>>()
+            Rc::new(corelib::model::SharedVectorModel::from(
+                values.iter().map(|e| eval_expression(e, local_context)).collect::<SharedVector<_>>()
             )) as Rc<dyn corelib::model::Model<Data = Value>>
         ),
         Expression::Struct { values, .. } => Value::Struct(

--- a/tests/cases/models/model.60
+++ b/tests/cases/models/model.60
@@ -168,6 +168,9 @@ let another_model = new sixtyfpslib.ArrayModel([
 ]);
 instance.model = another_model;
 
+let roundtripped_model = instance.model;
+assert.equal(another_model, roundtripped_model);
+
 instance.send_mouse_click(25., 5.);
 assert.equal(instance.clicked_score, 333000);
 assert.equal(instance.clicked_internal_state, 1);

--- a/tests/cases/models/write_to_model.60
+++ b/tests/cases/models/write_to_model.60
@@ -49,6 +49,10 @@ let instance = TestCase::new();
 sixtyfps::testing::send_mouse_click(&instance, 15., 5.);
 assert_eq!(instance.get_clicked_score(), 792);
 
+assert_eq!(instance.get_model().row_data(1).unwrap().2, 792.);
+instance.invoke_manual_score_update(1, 100);
+assert_eq!(instance.get_model().row_data(1).unwrap().2, 892.);
+
 type ModelData = (sixtyfps::SharedString, sixtyfps::SharedString, f32);
 let another_model = std::rc::Rc::new(sixtyfps::VecModel::<ModelData>::from(
     vec![
@@ -79,6 +83,10 @@ const TestCase &instance = *handle;
 sixtyfps::testing::send_mouse_click(&instance, 15., 5.);
 assert_eq(instance.get_clicked_score(), 792);
 
+assert_eq(std::get<2>(instance.get_model()->row_data(1)), 792.);
+instance.invoke_manual_score_update(1, 100);
+assert_eq(std::get<2>(instance.get_model()->row_data(1)), 892.);
+
 using ModelData = std::tuple<sixtyfps::SharedString, sixtyfps::SharedString, float>;
 std::vector<ModelData> array;
 array.push_back(ModelData{"a1", "hello", 111.});
@@ -106,6 +114,10 @@ assert_eq(another_model->row_count(), 3);
 var instance = new sixtyfps.TestCase({});
 instance.send_mouse_click(15., 5.);
 assert.equal(instance.clicked_score, 792);
+
+assert.equal(instance.model[1].score, 792.);
+instance.manual_score_update(1, 100);
+assert.equal(instance.model[1].score, 892.);
 
 let another_model = new sixtyfpslib.ArrayModel([
     {account: "a1", name: "hello", score: 111.},

--- a/tests/cases/models/write_to_model.60
+++ b/tests/cases/models/write_to_model.60
@@ -83,9 +83,9 @@ const TestCase &instance = *handle;
 sixtyfps::testing::send_mouse_click(&instance, 15., 5.);
 assert_eq(instance.get_clicked_score(), 792);
 
-assert_eq(std::get<2>(instance.get_model()->row_data(1)), 792.);
+assert_eq(std::get<2>(*instance.get_model()->row_data(1)), 792.);
 instance.invoke_manual_score_update(1, 100);
-assert_eq(std::get<2>(instance.get_model()->row_data(1)), 892.);
+assert_eq(std::get<2>(*instance.get_model()->row_data(1)), 892.);
 
 using ModelData = std::tuple<sixtyfps::SharedString, sixtyfps::SharedString, float>;
 std::vector<ModelData> array;


### PR DESCRIPTION
A model property such as

    property <[Foo]> model: [ ... ];

would create a VecModel in Rust and C++, which in turn can be written to
with an array index expression in .60. If the same .60 code was running
in the interpreter, a Value::Array would be created instead. We don't
support writing into Value::Array by index because we don't have
tracking in place for that, to update dependent bindings.

To fix this inconsistency, this patch changes the interpreter to
allocate a mutable VecModel as well.