### PR TITLE
Start a migration guide for C++ API for 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+This version changes some APIs in incompatible ways. For details how to migrate your application code, see the [C++ migration guide](api/sixtyfps-cpp/docs/cpp_migration.md).
+
 ### Changed
 
  - Minimum rust version is now 1.56

--- a/api/sixtyfps-cpp/docs/cpp_migration.md
+++ b/api/sixtyfps-cpp/docs/cpp_migration.md
@@ -6,7 +6,9 @@ This guide lists all API incompatible changes between major versions and describ
 
 ## Migrating from Version 0.1.x to 0.2.0
 
-In the 0.2.x series we have increased the minimum version of C++ and Rust that we require. You need to have Rust >= 1.56 installed and a C++ compiler that supports C++ 20 or newer. If you have installed Rust using `rustup`, then you can upgrade to the latest Version of Rust by running `rustup update`.
+In the 0.2.x series we have increased the minimum version of C++. You need to have a C++ compiler installed that supports C++ 20 or newer.
+
+If you are building SixtyFPS from source, you need to make sure that your Rust installation is up-to-date. If you have installed Rust using `rustup`, then you can upgrade to the latest Version of Rust by running `rustup update`.
 
 ### C++ Interpreter API
 

--- a/api/sixtyfps-cpp/docs/cpp_migration.md
+++ b/api/sixtyfps-cpp/docs/cpp_migration.md
@@ -1,0 +1,29 @@
+# Migrating from Older Versions
+
+The C++ library is versioned according to the principles of [Semantic Versioning](https://semver.org). We define that the left-most non-zero component of the version is the major version, followed by the minor and optionally patch version. That means releases in the "0.y.z" series treat changes in "y" as a major release, which can contain incompatible API changes, while changes in just "z" are minor. For example the release 0.1.6 is fully backwards compatible to 0.1.5, but it contains new functionality. The release 0.2.0 however is a new major version compared to 0.1.x and may contain API incompatible changes.
+
+This guide lists all API incompatible changes between major versions and describes how you can migrate your application's source code.
+
+## Migrating from Version 0.1.x to 0.2.0
+
+In the 0.2.x series we have increased the minimum version of C++ and Rust that we require. You need to have Rust >= 1.56 installed and a C++ compiler that supports C++ 20 or newer. If you have installed Rust using `rustup`, then you can upgrade to the latest Version of Rust by running `rustup update`.
+
+### C++ Interpreter API
+
+#### Callbacks
+
+Callbacks declared in `.60` markup can be invoked from C++ using  {cpp:func}`sixtyfps::interpreter::ComponentInstance::invoke_callback()` or {cpp:func}`sixtyfps::interpreter::ComponentInstance::invoke_global_callback()`. The arguments to the callback at invocation time used to require the use of `sixtyfps::Slice` type. This was changed to use the C++ 20 [`std::span`](https://en.cppreference.com/w/cpp/container/span) type, for easier passing.
+
+Old code:
+
+```cpp
+sixtyfps::Value args[] = { SharedString("Hello"), 42. };
+instance->invoke_callback("foo", sixtyfps::Slice{ args, 2 });
+```
+
+New code:
+
+```cpp
+sixtyfps::Value args[] = { SharedString("Hello"), 42. };
+instance->invoke_callback("foo", args);
+```

--- a/api/sixtyfps-cpp/docs/index.rst
+++ b/api/sixtyfps-cpp/docs/index.rst
@@ -39,6 +39,8 @@ Welcome to SixtyFPS C++'s documentation!
 
    markdown/debugging_techniques.md
 
+   cpp_migration.md
+
 .. image:: https://github.com/sixtyfpsui/sixtyfps/workflows/CI/badge.svg
    :target: https://github.com/sixtyfpsui/sixtyfps/actions
    :alt: GitHub CI Build Status


### PR DESCRIPTION
Once we have a Rust incompatible change we can change the sentencen in the ChangeLog to link to the Rust guide, too.