### PR TITLE
Add compatibility feature to our public crates

### DIFF
--- a/api/sixtyfps-cpp/Cargo.toml
+++ b/api/sixtyfps-cpp/Cargo.toml
@@ -33,7 +33,7 @@ default = ["backend-gl", "x11", "backend-qt"]
 
 [dependencies]
 sixtyfps-corelib = { version = "=0.2.0", path="../../internal/core", features = ["ffi"] }
-sixtyfps-interpreter = { version = "=0.2.0", path="../../internal/interpreter", default-features = false, features = ["ffi"], optional = true }
+sixtyfps-interpreter = { version = "=0.2.0", path="../../internal/interpreter", default-features = false, features = ["ffi", "compat-0-2-0"], optional = true }
 sixtyfps-rendering-backend-selector = { version = "=0.2.0", path="../../internal/backends/selector" }
 sixtyfps-rendering-backend-testing = { version = "=0.2.0", path="../../internal/backends/testing", optional = true }
 

--- a/api/sixtyfps-rs/Cargo.toml
+++ b/api/sixtyfps-rs/Cargo.toml
@@ -18,7 +18,13 @@ path = "lib.rs"
 
 [features]
 
-default = ["backend-gl", "x11", "backend-qt"]
+default = ["std", "backend-gl", "x11", "backend-qt", "compat-0-2-0"]
+
+## Mandatory feature:
+## This feature is required to keep the compatibility with SixtyFPS 0.2.0
+## Newer patch version may put current functionality behind a new feature
+## that would be enabled by default only if this feature was added
+compat-0-2-0 = []
 
 ## Enable use of the Rust standard library.
 std = ["sixtyfps-corelib/std"]

--- a/api/sixtyfps-rs/lib.rs
+++ b/api/sixtyfps-rs/lib.rs
@@ -226,7 +226,15 @@ See the [documentation of the `Global` trait](Global) for an example.
 #![deny(unsafe_code)]
 #![doc(html_logo_url = "https://sixtyfps.io/resources/logo.drawio.svg")]
 #![cfg_attr(not(feature = "std"), no_std)]
+
 extern crate alloc;
+
+#[cfg(not(feature = "compat-0-2-0"))]
+compile_error!(
+    "The feature `compat-0-2-0` must be enabled to ensure \
+    forward compatibility with future version of this crate"
+);
+
 pub use sixtyfps_macros::sixtyfps;
 
 pub use sixtyfps_corelib::api::*;

--- a/api/sixtyfps-rs/sixtyfps-build/Cargo.toml
+++ b/api/sixtyfps-rs/sixtyfps-build/Cargo.toml
@@ -15,6 +15,9 @@ homepage = "https://sixtyfps.io"
 [lib]
 path = "lib.rs"
 
+[features]
+default = []
+
 [dependencies]
 sixtyfps-compilerlib = { version = "=0.2.0", path = "../../../internal/compiler", features = ["rust", "display-diagnostics"] }
 

--- a/api/sixtyfps-rs/sixtyfps-build/lib.rs
+++ b/api/sixtyfps-rs/sixtyfps-build/lib.rs
@@ -44,6 +44,12 @@ fn main() {
 #![doc(html_logo_url = "https://sixtyfps.io/resources/logo.drawio.svg")]
 #![warn(missing_docs)]
 
+#[cfg(not(feature = "default"))]
+compile_error!(
+    "The feature `default` must be enabled to ensure \
+    forward compatibility with future version of this crate"
+);
+
 use std::env;
 use std::io::Write;
 use std::path::Path;

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -18,7 +18,13 @@ path = "lib.rs"
 
 [features]
 
-default = ["backend-gl", "x11", "backend-qt"]
+default = ["std", "backend-gl", "x11", "backend-qt", "compat-0-2-0"]
+
+## Mandatory feature:
+## This feature is required to keep the compatibility with SixtyFPS 0.2.0
+## Newer patch version may put current functionality behind a new feature
+## that would be enabled by default only if this feature was added
+compat-0-2-0 = []
 
 ## enable the [`print_diagnostics`] function to show diagnostic in the console output
 display-diagnostics = ["sixtyfps-compilerlib/display-diagnostics"]

--- a/internal/interpreter/lib.rs
+++ b/internal/interpreter/lib.rs
@@ -66,6 +66,12 @@ instance.run();
 #![warn(missing_docs)]
 #![doc(html_logo_url = "https://sixtyfps.io/resources/logo.drawio.svg")]
 
+#[cfg(not(feature = "compat-0-2-0"))]
+compile_error!(
+    "The feature `compat-0-2-0` must be enabled to ensure \
+    forward compatibility with future version of this crate"
+);
+
 mod api;
 mod dynamic_component;
 mod dynamic_type;

--- a/tests/driver/interpreter/Cargo.toml
+++ b/tests/driver/interpreter/Cargo.toml
@@ -14,7 +14,7 @@ path = "main.rs"
 name = "test-driver-interpreter"
 
 [dev-dependencies]
-sixtyfps-interpreter = { path = "../../../internal/interpreter", default-features = false, features = ["display-diagnostics"] }
+sixtyfps-interpreter = { path = "../../../internal/interpreter", default-features = false, features = ["display-diagnostics", "compat-0-2-0"] }
 sixtyfps-rendering-backend-testing = { path = "../../../internal/backends/testing" }
 
 itertools = "0.10"

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -32,7 +32,7 @@ default = ["sixtyfps-backend-qt", "sixtyfps-backend-gl", "x11"]
 [dependencies]
 sixtyfps-compilerlib = { version = "=0.2.0", path = "../../internal/compiler"}
 sixtyfps-corelib = { version = "=0.2.0", path = "../../internal/core"}
-sixtyfps-interpreter = { version = "=0.2.0", path = "../../internal/interpreter", default-features = false }
+sixtyfps-interpreter = { version = "=0.2.0", path = "../../internal/interpreter", default-features = false, features = ["compat-0-2-0"] }
 sixtyfps-rendering-backend-selector = { version = "=0.2.0", path="../../internal/backends/selector" }
 
 clap = { version = "3.0.5", features=["derive", "wrap_help"] }

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -23,7 +23,7 @@ default = ["sixtyfps-backend-qt", "sixtyfps-backend-gl", "x11"]
 
 [dependencies]
 sixtyfps-corelib = { version = "=0.2.0", path="../../internal/core" }
-sixtyfps-interpreter = { version = "=0.2.0", path = "../../internal/interpreter", default-features = false, features = ["display-diagnostics"] }
+sixtyfps-interpreter = { version = "=0.2.0", path = "../../internal/interpreter", default-features = false, features = ["display-diagnostics", "compat-0-2-0"] }
 sixtyfps-rendering-backend-selector = { version = "=0.2.0", path="../../internal/backends/selector" }
 
 vtable = { version = "0.1", path="../../helper_crates/vtable" }


### PR DESCRIPTION
We want to be able to put existing functionality behind a feature flag while keeping
the semver compatibility.
This is only possible if that new feature flag is enabled by default, but this is not
working if the users have done `default-features = false` in their Cargo.toml.
So we add new `compat-x-y-z` feature that is mandatory to have and which is
enforced with a `compile_error!`

Now, users that whishes to not have the default features must enable it explicitly.
Say we want only x11 but not qt and wayland, the user will do
```toml
sixtyfps = { version = "0.2", default-features = false, features = ["x11", "compat-0-2-0"] }
```

Now, imagine that in the version 0.2.3, we put the SVG support behind a feature flag.
we will do this in out Cargo.toml:

```toml
[features]
default = ["compat-0-2-0", "x11", "wayland"]
compat-0-2-0 = ["compat-0-2-3", "svg"]
compat-0-2-3 = []

svg = [...]
...
```

That way, the svg feature will be enabled by default for all the users who used previous version
of SixtyFPS, and people that want to disable "svg" can just change from compat-0-2-0 to
compat-0-2-3 in their Cargo.toml