### PR TITLE
Mark some enums that end up in the public Rust API as non_exhaustive

### DIFF
--- a/api/sixtyfps-rs/sixtyfps-build/lib.rs
+++ b/api/sixtyfps-rs/sixtyfps-build/lib.rs
@@ -91,6 +91,7 @@ impl CompilerConfiguration {
 
 /// Error returned by the `compile` function
 #[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
 pub enum CompileError {
     /// Cannot read environment variable CARGO_MANIFEST_DIR or OUT_DIR. The build script need to be run via cargo.
     #[error("Cannot read environment variable CARGO_MANIFEST_DIR or OUT_DIR. The build script need to be run via cargo.")]

--- a/sixtyfps_compiler/diagnostics.rs
+++ b/sixtyfps_compiler/diagnostics.rs
@@ -155,9 +155,13 @@ impl Spanned for Option<SourceLocation> {
     }
 }
 
+/// This enum describes the level or severity of a diagnostic message produced by the compiler.
 #[derive(Debug, PartialEq, Copy, Clone)]
+#[non_exhaustive]
 pub enum DiagnosticLevel {
+    /// The diagnostic found is an error that prevents successful compilation.
     Error,
+    /// The diagnostic found is a warning.
     Warning,
 }
 

--- a/sixtyfps_compiler/diagnostics.rs
+++ b/sixtyfps_compiler/diagnostics.rs
@@ -155,7 +155,6 @@ impl Spanned for Option<SourceLocation> {
     }
 }
 
-/// Diagnostics level (error or warning)
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum DiagnosticLevel {
     Error,

--- a/sixtyfps_runtime/corelib/timers.rs
+++ b/sixtyfps_runtime/corelib/timers.rs
@@ -22,6 +22,7 @@ type SingleShotTimerCallback = Box<dyn FnOnce()>;
 /// Used by the [`Timer::start`] function.
 #[derive(Copy, Clone)]
 #[repr(C)]
+#[non_exhaustive]
 pub enum TimerMode {
     /// A SingleShot timer is fired only once.
     SingleShot,

--- a/sixtyfps_runtime/interpreter/api.rs
+++ b/sixtyfps_runtime/interpreter/api.rs
@@ -21,6 +21,7 @@ pub use sixtyfps_corelib::window::api::Window;
 /// the contained values.
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[repr(i8)]
+#[non_exhaustive]
 pub enum ValueType {
     /// The variant that expresses the non-type. This is the default.
     Void,
@@ -1032,6 +1033,7 @@ impl WeakComponentInstance {
 
 /// Error returned by [`ComponentInstance::get_property`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
 pub enum GetPropertyError {
     /// There is no property with the given name
     #[error("no such property")]
@@ -1040,6 +1042,7 @@ pub enum GetPropertyError {
 
 /// Error returned by [`ComponentInstance::set_property`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
 pub enum SetPropertyError {
     /// There is no property with the given name
     #[error("no such property")]
@@ -1051,6 +1054,7 @@ pub enum SetPropertyError {
 
 /// Error returned by [`ComponentInstance::set_callback`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
 pub enum SetCallbackError {
     /// There is no callback with the given name
     #[error("no such callback")]
@@ -1059,6 +1063,7 @@ pub enum SetCallbackError {
 
 /// Error returned by [`ComponentInstance::invoke_callback`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
 pub enum InvokeCallbackError {
     /// There is no callback with the given name
     #[error("no such callback")]

--- a/sixtyfps_runtime/interpreter/api.rs
+++ b/sixtyfps_runtime/interpreter/api.rs
@@ -40,6 +40,7 @@ pub enum ValueType {
     /// Correspond to `image` type in .60.
     Image,
     /// The type is not a public type but something internal.
+    #[doc(hidden)]
     Other = -1,
 }
 

--- a/sixtyfps_runtime/interpreter/ffi.rs
+++ b/sixtyfps_runtime/interpreter/ffi.rs
@@ -797,6 +797,7 @@ pub unsafe extern "C" fn sixtyfps_interpreter_component_compiler_get_diagnostics
                 sixtyfps_compilerlib::diagnostics::DiagnosticLevel::Warning => {
                     DiagnosticLevel::Warning
                 }
+                _ => DiagnosticLevel::Warning,
             },
         }
     }));

--- a/tools/lsp/util.rs
+++ b/tools/lsp/util.rs
@@ -152,5 +152,6 @@ fn to_lsp_diag_level(
     match level {
         sixtyfps_interpreter::DiagnosticLevel::Error => lsp_types::DiagnosticSeverity::ERROR,
         sixtyfps_interpreter::DiagnosticLevel::Warning => lsp_types::DiagnosticSeverity::WARNING,
+        _ => lsp_types::DiagnosticSeverity::INFORMATION,
     }
 }


### PR DESCRIPTION
This allows adding new variants in minor releases without breaking
source compatibility.

cc #431