### PR TITLE
Semi-automatic clippy fixes

### DIFF
--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -77,7 +77,7 @@ impl sixtyfps_corelib::backend::Backend for TestingBackend {
             )
             .map(|img| img.dimensions().into())
             .unwrap_or_default(),
-            ImageInner::StaticTextures { size, .. } => size.clone(),
+            ImageInner::StaticTextures { size, .. } => *size,
         }
     }
 }

--- a/internal/compiler/generator.rs
+++ b/internal/compiler/generator.rs
@@ -188,7 +188,7 @@ pub fn build_item_tree<T: ItemTreeBuilder>(
 
     fn visit_children<T: ItemTreeBuilder>(
         state: &T::SubComponentState,
-        children: &Vec<ElementRc>,
+        children: &[ElementRc],
         component: &Rc<Component>,
         parent_item: &ElementRc,
         parent_index: u32,

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -30,7 +30,7 @@ fn access_item_rc(pr: &llr::PropertyReference, ctx: &EvaluationContext) -> Strin
             }
             parent_reference
         }
-        other @ _ => other,
+        other => other,
     };
 
     match pr {

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1236,7 +1236,7 @@ fn access_item_rc(pr: &llr::PropertyReference, ctx: &EvaluationContext) -> Token
             }
             parent_reference
         }
-        other @ _ => other,
+        other => other,
     };
 
     match pr {

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -291,11 +291,12 @@ impl Expression {
             Expression::BoolLiteral(_) => {}
             Expression::PropertyReference(_) => {}
             Expression::FunctionParameterReference { .. } => {}
-            Expression::StoreLocalVariable { value, .. } => visitor(&value),
+            Expression::StoreLocalVariable { value, .. } => visitor(value),
             Expression::ReadLocalVariable { .. } => {}
-            Expression::StructFieldAccess { base, .. } => visitor(&base),
+            Expression::StructFieldAccess { base, .. } => visitor(base),
             Expression::ArrayIndex { array, index } => {
-                (visitor(array), visitor(index));
+                visitor(array);
+                visitor(index);
             }
             Expression::Cast { from, .. } => visitor(from),
             Expression::CodeBlock(b) => b.iter().for_each(visitor),
@@ -304,28 +305,31 @@ impl Expression {
             Expression::ExtraBuiltinFunctionCall { arguments, .. } => {
                 arguments.iter().for_each(visitor)
             }
-            Expression::PropertyAssignment { value, .. } => visitor(&value),
-            Expression::ModelDataAssignment { value, .. } => visitor(&value),
+            Expression::PropertyAssignment { value, .. } => visitor(value),
+            Expression::ModelDataAssignment { value, .. } => visitor(value),
             Expression::ArrayIndexAssignment { array, index, value } => {
-                (visitor(array), visitor(index), visitor(value));
+                visitor(array);
+                visitor(index);
+                visitor(value);
             }
             Expression::BinaryExpression { lhs, rhs, .. } => {
-                (visitor(lhs), visitor(rhs));
+                visitor(lhs);
+                visitor(rhs);
             }
             Expression::UnaryOp { sub, .. } => {
                 visitor(sub);
             }
             Expression::ImageReference { .. } => {}
             Expression::Condition { condition, true_expr, false_expr } => {
-                visitor(&condition);
-                visitor(&true_expr);
-                visitor(&false_expr);
+                visitor(condition);
+                visitor(true_expr);
+                visitor(false_expr);
             }
             Expression::Array { values, .. } => values.iter().for_each(visitor),
             Expression::Struct { values, .. } => values.values().for_each(visitor),
             Expression::EasingCurve(_) => {}
             Expression::LinearGradient { angle, stops } => {
-                visitor(&angle);
+                visitor(angle);
                 for (a, b) in stops {
                     visitor(a);
                     visitor(b);
@@ -335,16 +339,16 @@ impl Expression {
             Expression::ReturnStatement(_) => {}
             Expression::LayoutCacheAccess { repeater_index, .. } => {
                 if let Some(repeater_index) = repeater_index {
-                    visitor(&repeater_index);
+                    visitor(repeater_index);
                 }
             }
             Expression::BoxLayoutFunction { elements, sub_expression, .. } => {
-                visitor(&sub_expression);
+                visitor(sub_expression);
                 elements.iter().filter_map(|x| x.as_ref().left()).for_each(visitor);
             }
             Expression::ComputeDialogLayoutCells { roles, unsorted_cells, .. } => {
-                visitor(&roles);
-                visitor(&unsorted_cells);
+                visitor(roles);
+                visitor(unsorted_cells);
             }
         }
     }

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -31,7 +31,7 @@ impl ExpressionContext<'_> {
         if !enclosing.is_global() {
             let mut map = self;
             let mut level = 0;
-            while !Rc::ptr_eq(&enclosing, map.component) {
+            while !Rc::ptr_eq(enclosing, map.component) {
                 map = map.parent.unwrap();
                 level += 1;
             }
@@ -222,7 +222,7 @@ fn lower_assignment(
             let mut values = HashMap::new();
             match &ty {
                 Type::Struct { fields, .. } => {
-                    for (field, _) in fields {
+                    for field in fields.keys() {
                         let e = if field != name {
                             tree_Expression::StructFieldAccess {
                                 base: lower_base.clone().into(),
@@ -917,15 +917,13 @@ fn compile_path(path: &crate::expression_tree::Path, ctx: &ExpressionContext) ->
                 return llr_path_elements(vec![]);
             }
 
-            let events: Vec<_> =
-                events.into_iter().map(|event| lower_expression(&event, &ctx)).collect();
+            let events: Vec<_> = events.iter().map(|event| lower_expression(event, ctx)).collect();
 
-            let event_type = events.first().unwrap().ty(ctx).clone();
+            let event_type = events.first().unwrap().ty(ctx);
 
-            let points: Vec<_> =
-                points.into_iter().map(|point| lower_expression(&point, &ctx)).collect();
+            let points: Vec<_> = points.iter().map(|point| lower_expression(point, ctx)).collect();
 
-            let point_type = points.first().unwrap().ty(ctx).clone();
+            let point_type = points.first().unwrap().ty(ctx);
 
             llr_Expression::Cast {
                 from: llr_Expression::Struct {
@@ -950,7 +948,7 @@ fn compile_path(path: &crate::expression_tree::Path, ctx: &ExpressionContext) ->
                         (
                             "points".to_owned(),
                             llr_Expression::Array {
-                                element_ty: point_type.clone(),
+                                element_ty: point_type,
                                 values: points,
                                 as_model: false,
                             },
@@ -963,7 +961,7 @@ fn compile_path(path: &crate::expression_tree::Path, ctx: &ExpressionContext) ->
             }
         }
         crate::expression_tree::Path::Commands(commands) => llr_Expression::Cast {
-            from: lower_expression(&commands, &ctx).into(),
+            from: lower_expression(commands, ctx).into(),
             to: Type::PathData,
         },
     }

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -168,7 +168,7 @@ fn analyse_binding(
         return depends_on_external;
     }
 
-    if context.currently_analyzing.contains(&current) {
+    if context.currently_analyzing.contains(current) {
         for it in context.currently_analyzing.iter().rev() {
             let p = &it.prop;
             let elem = p.element();
@@ -249,7 +249,7 @@ fn analyse_binding(
     let o = context.currently_analyzing.pop_back();
     assert_eq!(&o.unwrap(), current);
 
-    return depends_on_external;
+    depends_on_external
 }
 
 /// Process the property `prop`
@@ -300,7 +300,7 @@ fn process_property(
         prop.elements.push(element.into());
         prop.prop = NamedReference::new(&next, prop.prop.name());
     }
-    return depends_on_external;
+    depends_on_external
 }
 
 // Same as in crate::visit_all_named_references_in_element, but not mut

--- a/internal/compiler/passes/compile_paths.rs
+++ b/internal/compiler/passes/compile_paths.rs
@@ -69,7 +69,7 @@ pub fn compile_paths(
                         return;
                     }
                 }
-                expr @ _ if expr.ty() == Type::String => Expression::PathData(
+                expr if expr.ty() == Type::String => Expression::PathData(
                     crate::expression_tree::Path::Commands(Box::new(commands_expr.expression)),
                 )
                 .into(),

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -393,7 +393,7 @@ impl Image {
                 }
             },
             ImageInner::EmbeddedImage(buffer) => buffer.size(),
-            ImageInner::StaticTextures{size, ..} => size.clone(),
+            ImageInner::StaticTextures{size, ..} => *size,
 
         }
     }

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -735,8 +735,8 @@ fn eval_assignment(lhs: &Expression, op: char, rhs: Value, local_context: &mut E
             )
         }
         Expression::ArrayIndex { array, index } => {
-            let array = eval_expression(&array, local_context);
-            let index = eval_expression(&index, local_context);
+            let array = eval_expression(array, local_context);
+            let index = eval_expression(index, local_context);
             match (array, index) {
                 (Value::Model(model), Value::Number(index)) => {
                     let index = index as usize;


### PR DESCRIPTION
Nothing interesting, I mostly want to let CI run over it.

Afterwards we have some more warnings about functions with too many arguments, the cpp transmute thing that I should fix upstream, some complex types. But apart from those we are almost clippy clean after this set of patches and #794.