### PR TITLE
Change what is accepted by ModelRc::new and ModelRc::from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ as well as the [Rust migration guide for the `sixtyfps` crate](api/sixtyfps-rs/m
  - `Model::model_tracker` no longer has a default implementation.
  - The deprecated methods `Model::attach_peer` and `ModelNotify::attach` were removed.
  - The interpreter does not differentiate anymore between `Value::Array` and `Value::Model`
-   everything is a `Value::Model`, which now contains a `ModelHandle`
+   everything is a `Value::Model`, which now contains a `ModelRc`
  - In Rust, `sixtyfps::SharedPixelBuffer` and `sixtyfps::SharedImageBuffer` now use a `u32` instead of `usize` for `width`, `height` and `stride`.
  - In Rust and C++, `sixtyfps::Image::size()` now returns an integer size type.
  - `sixtyfps::interpreter::CallCallbackError` was renamed to `sixtyfps::interpreter::InvokeCallbackError`

--- a/api/sixtyfps-node/native/lib.rs
+++ b/api/sixtyfps-node/native/lib.rs
@@ -9,7 +9,6 @@ use sixtyfps_corelib::model::{Model, ModelRc};
 use sixtyfps_corelib::window::WindowHandleAccess;
 use sixtyfps_corelib::{ImageInner, SharedVector};
 use sixtyfps_interpreter::ComponentHandle;
-use std::rc::Rc;
 
 mod js_model;
 mod persistent_context;
@@ -183,12 +182,10 @@ fn to_eval_value<'cx>(
         Type::Array(a) => match val.downcast::<JsArray>() {
             Ok(arr) => {
                 let vec = arr.to_vec(cx)?;
-                Ok(Value::Model(ModelRc::new(Rc::new(
-                    sixtyfps_corelib::model::SharedVectorModel::from(
-                        vec.into_iter()
-                            .map(|i| to_eval_value(i, (*a).clone(), cx, persistent_context))
-                            .collect::<Result<SharedVector<_>, _>>()?,
-                    ),
+                Ok(Value::Model(ModelRc::new(sixtyfps_corelib::model::SharedVectorModel::from(
+                    vec.into_iter()
+                        .map(|i| to_eval_value(i, (*a).clone(), cx, persistent_context))
+                        .collect::<Result<SharedVector<_>, _>>()?,
                 ))))
             }
             Err(_) => {
@@ -196,7 +193,7 @@ fn to_eval_value<'cx>(
                 obj.get(cx, "rowCount")?.downcast_or_throw::<JsFunction, _>(cx)?;
                 obj.get(cx, "rowData")?.downcast_or_throw::<JsFunction, _>(cx)?;
                 let m = js_model::JsModel::new(obj, *a, cx, persistent_context)?;
-                Ok(Value::Model(ModelRc::new(m)))
+                Ok(Value::Model(m.into()))
             }
         },
         Type::Image => {

--- a/api/sixtyfps-rs/migration.md
+++ b/api/sixtyfps-rs/migration.md
@@ -62,6 +62,10 @@ fn model_tracker(&self) -> &dyn ModelTracker {
 }
 ```
 
-#### Minor changes to `Model`
+#### ModelHandle
 
 `ModelHandle` was renamed [`ModelRc`].
+
+[`ModelRc::new`]  no longer takes a `Rc`, but takes the structure that implements the [`Model`] trait directly.
+To construct a `ModelRc` from a Rc for your model, use the `From` trait. [`ModelRc::from`] is doing what
+`ModelHandle::new` was doing.

--- a/docs/tutorial/rust/src/main_game_logic_in_rust.rs
+++ b/docs/tutorial/rust/src/main_game_logic_in_rust.rs
@@ -20,7 +20,7 @@ fn main() {
     // ANCHOR: game_logic
     // Assign the shuffled Vec to the model property
     let tiles_model = std::rc::Rc::new(sixtyfps::VecModel::from(tiles));
-    main_window.set_memory_tiles(sixtyfps::ModelRc::new(tiles_model.clone()));
+    main_window.set_memory_tiles(tiles_model.clone().into());
 
     let main_window_weak = main_window.as_weak();
     main_window.on_check_if_pair_solved(move || {

--- a/docs/tutorial/rust/src/main_tiles_from_rust.rs
+++ b/docs/tutorial/rust/src/main_tiles_from_rust.rs
@@ -20,7 +20,7 @@ fn main() {
 
     // Assign the shuffled Vec to the model property
     let tiles_model = std::rc::Rc::new(sixtyfps::VecModel::from(tiles));
-    main_window.set_memory_tiles(sixtyfps::ModelRc::new(tiles_model));
+    main_window.set_memory_tiles(tiles_model.into());
 
     main_window.run();
 }

--- a/examples/imagefilter/main.rs
+++ b/examples/imagefilter/main.rs
@@ -140,7 +140,7 @@ pub fn main() {
     ]);
     let filters = Rc::new(filters);
 
-    main_window.set_filters(sixtyfps::ModelRc::new(filters.clone()));
+    main_window.set_filters(sixtyfps::ModelRc::from(filters.clone()));
 
     main_window.on_filter_image(move |filter_index| {
         let filter_fn = filters.0[filter_index as usize].apply_function;

--- a/examples/memory/main.rs
+++ b/examples/memory/main.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@sixtyfps.io>
 // SPDX-License-Identifier: (GPL-3.0-only OR LicenseRef-SixtyFPS-commercial)
 
-use sixtyfps::{Model, ModelRc, Timer, VecModel};
+use sixtyfps::{Model, Timer, VecModel};
 use std::rc::Rc;
 use std::time::Duration;
 
@@ -30,7 +30,7 @@ pub fn main() {
 
     let tiles_model = Rc::new(VecModel::from(tiles));
 
-    main_window.set_memory_tiles(ModelRc::new(tiles_model.clone()));
+    main_window.set_memory_tiles(tiles_model.clone().into());
 
     let main_window_weak = main_window.as_weak();
 

--- a/examples/printerdemo/rust/main.rs
+++ b/examples/printerdemo/rust/main.rs
@@ -57,9 +57,7 @@ pub fn main() {
         data: Rc::new(sixtyfps::VecModel::from(default_queue)),
         print_progress_timer: Default::default(),
     });
-    main_window
-        .global::<PrinterQueue>()
-        .set_printer_queue(sixtyfps::ModelRc::new(printer_queue.data.clone()));
+    main_window.global::<PrinterQueue>().set_printer_queue(printer_queue.data.clone().into());
 
     main_window.on_quit(move || {
         #[cfg(not(target_arch = "wasm32"))]

--- a/examples/slide_puzzle/main.rs
+++ b/examples/slide_puzzle/main.rs
@@ -180,7 +180,7 @@ pub fn main() {
         finished: false,
     }));
     state.borrow_mut().randomize();
-    main_window.set_pieces(sixtyfps::ModelRc::new(state.borrow().pieces.clone()));
+    main_window.set_pieces(state.borrow().pieces.clone().into());
 
     let state_copy = state.clone();
     main_window.on_piece_clicked(move |p| {

--- a/examples/todo/rust/main.rs
+++ b/examples/todo/rust/main.rs
@@ -45,7 +45,7 @@ pub fn main() {
         }
     });
 
-    main_window.set_todo_model(sixtyfps::ModelRc::new(todo_model));
+    main_window.set_todo_model(todo_model.into());
 
     main_window.run();
 }

--- a/sixtyfps_compiler/generator/rust.rs
+++ b/sixtyfps_compiler/generator/rust.rs
@@ -536,7 +536,7 @@ fn generate_sub_component(
 
         let mut model = compile_expression(&repeated.model, &ctx);
         if repeated.model.ty(&ctx) == Type::Bool {
-            model = quote!(sixtyfps::re_exports::ModelRc::new(sixtyfps::re_exports::Rc::<bool>::new(#model)))
+            model = quote!(sixtyfps::re_exports::ModelRc::new(#model as bool))
         }
 
         init.push(quote! {
@@ -1273,7 +1273,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
                     ))
                 }
                 (Type::Float32, Type::Model) | (Type::Int32, Type::Model) => {
-                    quote!(sixtyfps::re_exports::ModelRc::new(sixtyfps::re_exports::Rc::<usize>::new(#f as usize)))
+                    quote!(sixtyfps::re_exports::ModelRc::new(#f as usize))
                 }
                 (Type::Float32, Type::Color) => {
                     quote!(sixtyfps::re_exports::Color::from_argb_encoded(#f as u32))
@@ -1537,9 +1537,9 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
             if *as_model {
                 let rust_element_ty = rust_type(element_ty).unwrap();
                 quote!(sixtyfps::re_exports::ModelRc::new(
-                    sixtyfps::re_exports::Rc::new(sixtyfps::re_exports::VecModel::<#rust_element_ty>::from(
+                    sixtyfps::re_exports::VecModel::<#rust_element_ty>::from(
                         sixtyfps::re_exports::vec![#(#val as _),*]
-                    ))
+                    )
                 ))
             } else {
                 quote!(Slice::from_slice(&[#(#val),*]))

--- a/sixtyfps_runtime/interpreter/api.rs
+++ b/sixtyfps_runtime/interpreter/api.rs
@@ -1353,17 +1353,17 @@ fn component_definition_model_properties() {
 
     let instance = comp_def.create();
 
-    let int_model = Value::Model(ModelRc::new(Rc::new(VecModel::from_slice(&[
+    let int_model = Value::Model(VecModel::from_slice(&[
         Value::Number(14.),
         Value::Number(15.),
         Value::Number(16.),
-    ]))));
-    let empty_model = Value::Model(ModelRc::new(Rc::new(VecModel::<Value>::default())));
-    let model_with_string = Value::Model(ModelRc::new(Rc::new(VecModel::from_slice(&[
+    ]));
+    let empty_model = Value::Model(ModelRc::new(VecModel::<Value>::default()));
+    let model_with_string = Value::Model(VecModel::from_slice(&[
         Value::Number(1000.),
         Value::String("foo".into()),
         Value::Number(1111.),
-    ]))));
+    ]));
 
     #[track_caller]
     fn check_model(val: Value, r: &[f64]) {

--- a/sixtyfps_runtime/interpreter/dynamic_component.rs
+++ b/sixtyfps_runtime/interpreter/dynamic_component.rs
@@ -1356,7 +1356,7 @@ pub fn instantiate(
                     InstanceRef::from_pin_ref(c, guard)
                 }),
             );
-            sixtyfps_corelib::model::ModelRc::new(Rc::new(crate::value_model::ValueModel::new(m)))
+            sixtyfps_corelib::model::ModelRc::new(crate::value_model::ValueModel::new(m))
         });
     }
 

--- a/sixtyfps_runtime/interpreter/eval.rs
+++ b/sixtyfps_runtime/interpreter/eval.rs
@@ -568,10 +568,10 @@ pub fn eval_expression(expression: &Expression, local_context: &mut EvalLocalCon
             }
         }
         Expression::Array { values, .. } => Value::Model(
-            ModelRc::new(Rc::new(corelib::model::SharedVectorModel::from(
+            ModelRc::new(corelib::model::SharedVectorModel::from(
                 values.iter().map(|e| eval_expression(e, local_context)).collect::<SharedVector<_>>()
             )
-        ))),
+        )),
         Expression::Struct { values, .. } => Value::Struct(
             values
                 .iter()

--- a/sixtyfps_runtime/interpreter/ffi.rs
+++ b/sixtyfps_runtime/interpreter/ffi.rs
@@ -85,7 +85,7 @@ pub unsafe extern "C" fn sixtyfps_interpreter_value_new_array_model(
     let vec = std::mem::transmute::<SharedVector<ValueOpaque>, SharedVector<Value>>(a.clone());
     std::ptr::write(
         val as *mut Value,
-        Value::Model(ModelRc::new(Rc::new(SharedVectorModel::<Value>::from(vec)))),
+        Value::Model(ModelRc::new(SharedVectorModel::<Value>::from(vec))),
     )
 }
 
@@ -119,10 +119,7 @@ pub unsafe extern "C" fn sixtyfps_interpreter_value_new_model(
     model: vtable::VBox<ModelAdaptorVTable>,
     val: *mut ValueOpaque,
 ) {
-    std::ptr::write(
-        val as *mut Value,
-        Value::Model(ModelRc::new(Rc::new(ModelAdaptorWrapper(model)))),
-    )
+    std::ptr::write(val as *mut Value, Value::Model(ModelRc::new(ModelAdaptorWrapper(model))))
 }
 
 #[no_mangle]

--- a/tests/cases/crashes/layout_deleted_item.60
+++ b/tests/cases/crashes/layout_deleted_item.60
@@ -52,7 +52,7 @@ assert(!instance.get_hover());
 use sixtyfps::Model;
 let instance = TestCase::new();
 let vec_model = std::rc::Rc::new(sixtyfps::VecModel::from(vec![1i32, 2i32]));
-instance.set_model(sixtyfps::ModelRc::new(vec_model.clone() as std::rc::Rc<dyn Model<Data = i32>>));
+instance.set_model(vec_model.clone().into());
 instance.on_clicked(move || dbg!(vec_model.remove(vec_model.row_count() - 1)));
 sixtyfps::testing::send_mouse_click(&instance, 95., 5.);
 assert_eq!(instance.get_model().row_count(), 1);

--- a/tests/cases/models/array.60
+++ b/tests/cases/models/array.60
@@ -43,7 +43,7 @@ assert_eq!(instance.get_n(), 4);
 assert_eq!(instance.get_third_int(), 3);
 
 let model: std::rc::Rc<sixtyfps::VecModel<i32>> = std::rc::Rc::new(vec![1, 2, 3, 4, 5, 6, 7].into());
-instance.set_ints(sixtyfps::ModelRc::new(model.clone()));
+instance.set_ints(sixtyfps::ModelRc::from(model.clone()));
 assert_eq!(instance.get_num_ints(), 7);
 assert_eq!(instance.get_third_int(), 3);
 model.push(8);

--- a/tests/cases/models/model.60
+++ b/tests/cases/models/model.60
@@ -62,7 +62,7 @@ let another_model = std::rc::Rc::new(sixtyfps::VecModel::<ModelData>::from(
         ("a3".into(), "world".into(), 333.),
     ]));
 
-instance.set_model(sixtyfps::ModelRc::new(another_model.clone()));
+instance.set_model(sixtyfps::ModelRc::from(another_model.clone()));
 
 sixtyfps::testing::send_mouse_click(&instance, 25., 5.);
 assert_eq!(instance.get_clicked_score(), 333000);

--- a/tests/cases/models/write_to_model.60
+++ b/tests/cases/models/write_to_model.60
@@ -61,7 +61,7 @@ let another_model = std::rc::Rc::new(sixtyfps::VecModel::<ModelData>::from(
         ("a3".into(), "world".into(), 333.),
     ]));
 
-instance.set_model(sixtyfps::ModelRc::new(another_model.clone()));
+instance.set_model(sixtyfps::ModelRc::from(another_model.clone()));
 
 sixtyfps::testing::send_mouse_click(&instance, 25., 5.);
 assert_eq!(instance.get_clicked_score(), 336);

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -8,7 +8,6 @@ use sixtyfps_corelib::SharedVector;
 use sixtyfps_interpreter::{ComponentHandle, ComponentInstance, SharedString, Value};
 use std::future::Future;
 use std::pin::Pin;
-use std::rc::Rc;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 use std::task::Wake;
@@ -268,9 +267,9 @@ fn load_data(instance: &ComponentInstance, data_path: &std::path::Path) -> Resul
                 }
                 serde_json::Value::String(s) => SharedString::from(s.as_str()).into(),
                 serde_json::Value::Array(array) => sixtyfps_interpreter::Value::Model(
-                    ModelRc::new(Rc::new(sixtyfps_corelib::model::SharedVectorModel::from(
+                    ModelRc::new(sixtyfps_corelib::model::SharedVectorModel::from(
                         array.iter().map(from_json).collect::<SharedVector<Value>>(),
-                    ))),
+                    )),
                 ),
                 serde_json::Value::Object(obj) => obj
                     .iter()


### PR DESCRIPTION
 - ModelRc::new constructs a ModelRc from a impl Model
 - ModelRc::form constructs a ModelRc from a `Rc<dyn Model>` or `Rc<impl Model>`