### PR TITLE
Remove a doxygen #ifdef

### DIFF
--- a/api/sixtyfps-cpp/cbindgen.rs
+++ b/api/sixtyfps-cpp/cbindgen.rs
@@ -158,6 +158,7 @@ fn gen_corelib(
         "sixtyfps_image_size",
         "sixtyfps_image_path",
         "TimerMode", // included in generated_public.h
+        "IntSize",   // included in generated_public.h
     ]
     .iter()
     .map(|x| x.to_string())
@@ -215,7 +216,6 @@ fn gen_corelib(
                 "ImageInner",
                 "Image",
                 "Size",
-                "IntSize",
                 "sixtyfps_image_size",
                 "sixtyfps_image_path",
                 "SharedPixelBuffer",
@@ -267,6 +267,7 @@ fn gen_corelib(
             "sixtyfps_color_darker",
             "sixtyfps_image_size",
             "sixtyfps_image_path",
+            "IntSize",
         ]
         .iter()
         .filter(|exclusion| !rust_types.iter().any(|inclusion| inclusion == *exclusion))
@@ -307,13 +308,22 @@ fn gen_corelib(
     // Generate a header file with some public API (enums, etc.)
     let mut public_config = config.clone();
     public_config.namespaces = Some(vec!["sixtyfps".into()]);
-    public_config.export.item_types = vec![cbindgen::ItemType::Enums];
-    public_config.export.include = vec!["TimerMode".into()];
+    public_config.export.item_types = vec![cbindgen::ItemType::Enums, cbindgen::ItemType::Structs];
+    public_config.export.include = vec!["TimerMode".into(), "IntSize".into()];
     public_config.export.exclude.clear();
+
+    public_config.export.body.insert(
+        "IntSize".to_owned(),
+        r#"
+    /// Compares this IntSize with \a other and returns true if they are equal; false otherwise.
+    bool operator==(const IntSize &other) const = default;"#
+            .to_owned(),
+    );
 
     cbindgen::Builder::new()
         .with_config(public_config)
         .with_src(crate_dir.join("timers.rs"))
+        .with_src(crate_dir.join("graphics.rs"))
         .with_after_include(format!(
             r"
 /// This macro expands to the to the numeric value of the major version of SixtyFPS you're

--- a/api/sixtyfps-cpp/include/sixtyfps_image.h
+++ b/api/sixtyfps-cpp/include/sixtyfps_image.h
@@ -3,25 +3,12 @@
 
 #pragma once
 #include <string_view>
+#include "sixtyfps_generated_public.h"
 #include "sixtyfps_image_internal.h"
 #include "sixtyfps_string.h"
 #include "sixtyfps_sharedvector.h"
 
 namespace sixtyfps {
-
-#if !defined(DOXYGEN)
-using cbindgen_private::types::IntSize;
-#else
-/// The Size structure is used to represent a two-dimensional size
-/// with width and height.
-struct IntSize
-{
-    /// The width of the size
-    uint32_t width;
-    /// The height of the size
-    uint32_t height;
-};
-#endif
 
 /// An image type that can be displayed by the Image element
 struct Image

--- a/internal/core/graphics.rs
+++ b/internal/core/graphics.rs
@@ -193,11 +193,15 @@ pub(crate) mod ffi {
         height: f32,
     }
 
-    /// Expand Size so that cbindgen can see it. ( is in fact euclid::default::Size2D<u32>)
+    // Expand Size so that cbindgen can see it. ( is in fact euclid::default::Size2D<u32>)
+    /// The Size structure is used to represent a two-dimensional size
+    /// with width and height.
     #[cfg(cbindgen)]
     #[repr(C)]
     struct IntSize {
+        /// The width of the size
         width: u32,
+        /// The height of the size
         height: u32,
     }
 


### PR DESCRIPTION
Remove the duplicated definition of the IntSize struct and instead
generate it via cbindgen into the public API.