### PR TITLE
Custom rendering API

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -279,7 +279,7 @@ jobs:
             rm -rf snapshots/$target_branch/demos
             mkdir -p snapshots/$target_branch/demos
 
-            for demo_subdir in gallery, printerdemo,rust printerdemo_old,rust todo,rust slide_puzzle, memory, imagefilter, plotter,; do
+            for demo_subdir in gallery, printerdemo,rust printerdemo_old,rust todo,rust slide_puzzle, memory, imagefilter, plotter, opengl_underlay,; do
                 IFS=',' read demo subdir <<< "${demo_subdir}"
 
                 mkdir -p snapshots/$target_branch/demos/$demo

--- a/.github/workflows/wasm_demos.yaml
+++ b/.github/workflows/wasm_demos.yaml
@@ -64,6 +64,11 @@ jobs:
         sed -i "s/#wasm# //" Cargo.toml
         wasm-pack build --release --target web
       working-directory: examples/plotter
+    - name: OpenGL underlay example WASM build
+      run: |
+        sed -i "s/#wasm# //" Cargo.toml
+        wasm-pack build --release --target web
+      working-directory: examples/opengl_underlay
     - name: "Upload Demo Artifacts"
       uses: actions/upload-artifact@v2
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ as well as the [Rust migration guide for the `sixtyfps` crate](api/sixtyfps-rs/m
 
  - `TextEdit::font-size` and `LineEdit::font-size` have been added to control the size of these widgets.
  - Added `sixtyfps::Window::set_rendering_notifier` to get a callback before and after a new frame is being rendered.
+ - Added `sixtyfps::Window::request_redraw()` to schedule redrawing of the window contents.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ as well as the [Rust migration guide for the `sixtyfps` crate](api/sixtyfps-rs/m
 ### Added
 
  - `TextEdit::font-size` and `LineEdit::font-size` have been added to control the size of these widgets.
+ - Added `sixtyfps::Window::set_rendering_notifier` to get a callback before and after a new frame is being rendered.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     'examples/gallery',
     'examples/imagefilter',
     'examples/memory',
+    'examples/opengl_underlay',
     'examples/plotter',
     'examples/printerdemo_old/rust',
     'examples/printerdemo/rust',

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -268,6 +268,7 @@ fn gen_corelib(
             "sixtyfps_windowrc_set_component",
             "sixtyfps_windowrc_show_popup",
             "sixtyfps_windowrc_set_rendering_notifier",
+            "sixtyfps_windowrc_request_redraw",
             "sixtyfps_new_path_elements",
             "sixtyfps_new_path_events",
             "sixtyfps_color_brighter",

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -128,6 +128,9 @@ fn gen_corelib(
     .map(|x| x.to_string())
     .collect();
 
+    let mut private_exported_types: std::collections::HashSet<String> =
+        config.export.include.iter().cloned().collect();
+
     config.export.exclude = [
         "SharedString",
         "SharedVector",
@@ -157,8 +160,10 @@ fn gen_corelib(
         "sixtyfps_color_darker",
         "sixtyfps_image_size",
         "sixtyfps_image_path",
-        "TimerMode", // included in generated_public.h
-        "IntSize",   // included in generated_public.h
+        "TimerMode",                 // included in generated_public.h
+        "IntSize",                   // included in generated_public.h
+        "RenderingState",            // included in generated_public.h
+        "SetRenderingNotifierError", // included in generated_public.h
     ]
     .iter()
     .map(|x| x.to_string())
@@ -201,6 +206,7 @@ fn gen_corelib(
         .insert("StateInfo".to_owned(), "    using Instant = uint64_t;".into());
     properties_config.structure.derive_eq = true;
     properties_config.structure.derive_neq = true;
+    private_exported_types.extend(properties_config.export.include.iter().cloned());
     cbindgen::Builder::new()
         .with_config(properties_config)
         .with_src(crate_dir.join("properties.rs"))
@@ -261,6 +267,7 @@ fn gen_corelib(
             "sixtyfps_windowrc_set_focus_item",
             "sixtyfps_windowrc_set_component",
             "sixtyfps_windowrc_show_popup",
+            "sixtyfps_windowrc_set_rendering_notifier",
             "sixtyfps_new_path_elements",
             "sixtyfps_new_path_events",
             "sixtyfps_color_brighter",
@@ -289,6 +296,9 @@ fn gen_corelib(
         // Property<> fields uses the public `sixtyfps::Blah` type
         special_config.namespaces =
             Some(vec!["sixtyfps".into(), "cbindgen_private".into(), "types".into()]);
+
+        private_exported_types.extend(special_config.export.include.iter().cloned());
+
         cbindgen::Builder::new()
             .with_config(special_config)
             .with_src(crate_dir.join("graphics.rs"))
@@ -309,8 +319,15 @@ fn gen_corelib(
     let mut public_config = config.clone();
     public_config.namespaces = Some(vec!["sixtyfps".into()]);
     public_config.export.item_types = vec![cbindgen::ItemType::Enums, cbindgen::ItemType::Structs];
-    public_config.export.include = vec!["TimerMode".into(), "IntSize".into()];
-    public_config.export.exclude.clear();
+    // Previously included types are now excluded (to avoid duplicates)
+    public_config.export.exclude = private_exported_types.into_iter().collect();
+    public_config.export.exclude.push("Point".into());
+    public_config.export.include = vec![
+        "TimerMode".into(),
+        "IntSize".into(),
+        "RenderingState".into(),
+        "SetRenderingNotifierError".into(),
+    ];
 
     public_config.export.body.insert(
         "IntSize".to_owned(),
@@ -324,6 +341,8 @@ fn gen_corelib(
         .with_config(public_config)
         .with_src(crate_dir.join("timers.rs"))
         .with_src(crate_dir.join("graphics.rs"))
+        .with_src(crate_dir.join("window.rs"))
+        .with_src(crate_dir.join("api.rs"))
         .with_after_include(format!(
             r"
 /// This macro expands to the to the numeric value of the major version of SixtyFPS you're

--- a/api/cpp/include/sixtyfps.h
+++ b/api/cpp/include/sixtyfps.h
@@ -158,6 +158,8 @@ public:
         }
     }
 
+    void request_redraw() const { cbindgen_private::sixtyfps_windowrc_request_redraw(&inner); }
+
 private:
     cbindgen_private::WindowRcOpaque inner;
 };
@@ -177,7 +179,8 @@ constexpr inline ItemTreeNode make_dyn_node(std::uintptr_t offset, std::uint32_t
                                                            parent_index } };
 }
 
-inline ItemRef get_item_ref(ComponentRef component, cbindgen_private::Slice<ItemTreeNode> item_tree, int index)
+inline ItemRef get_item_ref(ComponentRef component, cbindgen_private::Slice<ItemTreeNode> item_tree,
+                            int index)
 {
     const auto &item = item_tree.ptr[index].item.item;
     return ItemRef { item.vtable, reinterpret_cast<char *>(component.instance) + item.offset };
@@ -341,6 +344,9 @@ public:
         return inner.set_rendering_notifier(std::forward<F>(callback));
     }
 
+    /// This function issues a request to the windowing system to redraw the contents of the window.
+    void request_redraw() const { inner.request_redraw(); }
+
     /// \private
     private_api::WindowRc &window_handle() { return inner; }
     /// \private
@@ -429,7 +435,8 @@ inline SharedVector<float> solve_box_layout(const cbindgen_private::BoxLayoutDat
                                             cbindgen_private::Slice<int> repeater_indexes)
 {
     SharedVector<float> result;
-    cbindgen_private::Slice<uint32_t> ri { reinterpret_cast<uint32_t *>(repeater_indexes.ptr), repeater_indexes.len };
+    cbindgen_private::Slice<uint32_t> ri { reinterpret_cast<uint32_t *>(repeater_indexes.ptr),
+                                           repeater_indexes.len };
     cbindgen_private::sixtyfps_solve_box_layout(&data, ri, &result);
     return result;
 }
@@ -467,7 +474,8 @@ inline SharedVector<float> solve_path_layout(const cbindgen_private::PathLayoutD
                                              cbindgen_private::Slice<int> repeater_indexes)
 {
     SharedVector<float> result;
-    cbindgen_private::Slice<uint32_t> ri { reinterpret_cast<uint32_t *>(repeater_indexes.ptr), repeater_indexes.len };
+    cbindgen_private::Slice<uint32_t> ri { reinterpret_cast<uint32_t *>(repeater_indexes.ptr),
+                                           repeater_indexes.len };
     cbindgen_private::sixtyfps_solve_path_layout(&data, ri, &result);
     return result;
 }
@@ -490,7 +498,8 @@ struct AbstractRepeaterView
 using ModelPeer = std::weak_ptr<AbstractRepeaterView>;
 
 template<typename M>
-auto access_array_index(const M &model, int index) {
+auto access_array_index(const M &model, int index)
+{
     model->track_row_data_changes(index);
     if (const auto v = model->row_data(index)) {
         return *v;

--- a/api/cpp/include/sixtyfps.h
+++ b/api/cpp/include/sixtyfps.h
@@ -141,6 +141,23 @@ public:
         cbindgen_private::sixtyfps_windowrc_show_popup(&inner, &popup, p, &parent_item);
     }
 
+    template<typename F>
+    std::optional<SetRenderingNotifierError> set_rendering_notifier(F callback) const
+    {
+        auto actual_cb = [](RenderingState state, void *data) {
+            (*reinterpret_cast<F *>(data))(state);
+        };
+        SetRenderingNotifierError err;
+        if (cbindgen_private::sixtyfps_windowrc_set_rendering_notifier(
+                    &inner, actual_cb,
+                    [](void *user_data) { delete reinterpret_cast<F *>(user_data); },
+                    new F(std::move(callback)), &err)) {
+            return {};
+        } else {
+            return err;
+        }
+    }
+
 private:
     cbindgen_private::WindowRcOpaque inner;
 };
@@ -313,6 +330,16 @@ public:
     void show() { inner.show(); }
     /// De-registers the window from the windowing system, therefore hiding it.
     void hide() { inner.hide(); }
+
+    /// This function allows registering a callback that's invoked during the different phases of
+    /// rendering. This allows custom rendering on top or below of the scene.
+    /// On success, the function returns a std::optional without value. On error, the function
+    /// returns the error code as value in the std::optional.
+    template<typename F>
+    std::optional<SetRenderingNotifierError> set_rendering_notifier(F &&callback) const
+    {
+        return inner.set_rendering_notifier(std::forward<F>(callback));
+    }
 
     /// \private
     private_api::WindowRc &window_handle() { return inner; }

--- a/cmake/FindOpenGLES2.cmake
+++ b/cmake/FindOpenGLES2.cmake
@@ -1,0 +1,52 @@
+# Copyright © SixtyFPS GmbH <info@sixtyfps.io>
+# SPDX-License-Identifier: (GPL-3.0-only OR LicenseRef-SixtyFPS-commercial)
+
+include(CheckCXXSourceCompiles)
+
+find_path(OPENGLES2_INCLUDE_DIR NAMES "GLES2/gl2.h" "OpenGLES/ES2/gl.h" DOC "The path where the OpenGL ES 2.0 headers are located")
+find_library(OPENGLES2_LIBRARY NAMES GLESv2 OpenGLES)
+
+# Sometimes EGL linkage is required, so look it up and always use if available.
+find_package(OpenGL COMPONENTS EGL)
+
+# See if we can compile some example code with what we've found.
+set(saved_libraries "${CMAKE_REQUIRED_LIBRARIES}")
+set(saved_includes "${CMAKE_REQUIRED_INCLUDES}")
+
+if (OPENGLES2_LIBRARY)
+    list(APPEND CMAKE_REQUIRED_INCLUDES "${OPENGLES2_INCLUDE_DIR}")
+    list(APPEND CMAKE_REQUIRED_LIBRARIES "${OPENGLES2_LIBRARY}")
+endif()
+
+if(OPENGL_egl_LIBRARY)
+    list(APPEND CMAKE_REQUIRED_INCLUDES "${OPENGL_EGL_INCLUDE_DIRS}")
+    list(APPEND CMAKE_REQUIRED_LIBRARIES "${OPENGL_egl_LIBRARY}")
+endif()
+
+check_cxx_source_compiles("
+#include <GLES2/gl2.h>
+#include <GLES2/gl2platform.h>
+
+int main(int argc, char *argv[]) {
+    glClear(GL_STENCIL_BUFFER_BIT);
+    glUseProgram(0);
+}" HAVE_OPENGLES2)
+
+set(CMAKE_REQUIRED_INCLUDES "${saved_includes}")
+set(CMAKE_REQUIRED_LIBRARIES "${saved_libraries}")
+
+# Standard CMake package dance
+set(package_args OPENGLES2_INCLUDE_DIR OPENGLES2_LIBRARY HAVE_OPENGLES2)
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(OpenGLES2 DEFAULT_MSG ${package_args})
+mark_as_advanced(${package_args})
+
+# Create a convenience target for linkage
+if (OPENGLES2_FOUND AND NOT TARGET OpenGLES2::OpenGLES2)
+    add_library(OpenGLES2::OpenGLES2 UNKNOWN IMPORTED)
+    set_property(TARGET OpenGLES2::OpenGLES2 PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${OPENGLES2_INCLUDE_DIR}")
+    set_property(TARGET OpenGLES2::OpenGLES2 PROPERTY IMPORTED_LOCATION "${OPENGLES2_LIBRARY}")
+    if (TARGET OpenGL::EGL)
+        target_link_libraries(OpenGLES2::OpenGLES2 INTERFACE OpenGL::EGL)
+    endif()
+endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,6 +3,10 @@
 cmake_minimum_required(VERSION 3.19)
 project(SixtyFPSExamples LANGUAGES CXX)
 
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
+
+find_package(OpenGLES2 QUIET)
+
 if (NOT TARGET SixtyFPS::SixtyFPS)
     find_package(SixtyFPS REQUIRED)
     include(FetchContent)
@@ -21,4 +25,7 @@ if (SIXTYFPS_FEATURE_INTERPRETER AND SIXTYFPS_FEATURE_BACKEND_QT)
 endif()
 if (SIXTYFPS_FEATURE_INTERPRETER)
     add_subdirectory(iot-dashboard/)
+endif()
+if (OpenGLES2_FOUND AND SIXTYFPS_FEATURE_BACKEND_GL)
+    add_subdirectory(opengl_underlay)
 endif()

--- a/examples/README.md
+++ b/examples/README.md
@@ -91,6 +91,16 @@ graph and integrate the result into SixtyFPS.
 
 Some examples of how to use the `sixtyfps-viewer` to add a GUI to shell scripts.
 
+### [`opengl_underlay`](./opengl_underlay)
+
+A Rust and C++ example that shows how render SixtyFPS on top of graphical effect rendered using custom OpenGL code. For more details check out the [Readme](./opengl_underlay).
+
+| `.60` Design | Rust Source | C++ Source | Online wasm Preview |
+| --- | --- | --- | --- |
+| [`scene.60`](./opengl_underlay/scene.60) | [`main.rs`](./opengl_underlay/main.rs) | [`main.cpp`](./opengl_underlay/main.cpp) | [Online simulation](https://sixtyfps.io/snapshots/master/demos/opengl_underlay/) |
+
+![Screenshot of the OpenGL Underlay Example on Windows](https://sixtyfps.io/resources/opengl_underlay_screenshot.png "OpenGL Underlay")
+
 ### External examples
 
 * [Cargo UI](https://github.com/sixtyfpsui/cargo-ui): A rust application that makes use of threads in the background.

--- a/examples/opengl_underlay/CMakeLists.txt
+++ b/examples/opengl_underlay/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright © SixtyFPS GmbH <info@sixtyfps.io>
+# SPDX-License-Identifier: (GPL-3.0-only OR LicenseRef-SixtyFPS-commercial)
+
+cmake_minimum_required(VERSION 3.14)
+project(opengl_cpp_underlay LANGUAGES CXX)
+
+if (NOT TARGET SixtyFPS::SixtyFPS)
+    find_package(SixtyFPS REQUIRED)
+endif()
+
+add_executable(opengl_underlay main.cpp)
+target_link_libraries(opengl_underlay PRIVATE SixtyFPS::SixtyFPS OpenGLES2::OpenGLES2)
+sixtyfps_target_60_sources(opengl_underlay scene.60)

--- a/examples/opengl_underlay/Cargo.toml
+++ b/examples/opengl_underlay/Cargo.toml
@@ -1,0 +1,38 @@
+# Copyright © SixtyFPS GmbH <info@sixtyfps.io>
+# SPDX-License-Identifier: (GPL-3.0-only OR LicenseRef-SixtyFPS-commercial)
+
+[package]
+name = "opengl_underlay"
+version = "0.1.6"
+authors = ["SixtyFPS <info@sixtyfps.io>"]
+edition = "2021"
+build = "build.rs"
+license = "(GPL-3.0-only OR LicenseRef-SixtyFPS-commercial)"
+publish = false
+
+[[bin]]
+path = "main.rs"
+name = "opengl_underlay"
+
+[dependencies]
+sixtyfps = { path = "../../api/sixtyfps-rs" }
+glow = { version = "0.11" }
+instant = { version = "0.1", features = [ "now" ] }
+
+[build-dependencies]
+sixtyfps-build = { path = "../../api/rs/build" }
+
+# Remove the `#wasm#` to uncomment the wasm build.
+# This is commented out by default because we don't want to build it as a library by default
+# The CI has a script that does sed "s/#wasm# //" to generate the wasm build.
+
+#wasm# [lib]
+#wasm# crate-type = ["cdylib"]
+#wasm# path = "main.rs"
+#wasm#
+#wasm# [target.'cfg(target_arch = "wasm32")'.dependencies]
+#wasm# wasm-bindgen = { version = "0.2" }
+#wasm# web-sys = { version = "0.3", features=["console"] }
+#wasm# console_error_panic_hook = "0.1.5"
+#wasm# instant = { version = "0.1", features = [ "wasm-bindgen" ] }
+

--- a/examples/opengl_underlay/README.md
+++ b/examples/opengl_underlay/README.md
@@ -1,0 +1,10 @@
+# OpenGL Underlay Example
+
+This example application demonstrates how layer two scenes together in a window:
+
+1. First a graphical effect is rendered using low-level OpenGL code (underlay).
+2. A scene of SixtyFPS elements is rendered above.
+
+This is implemented using the `set_rendering_notifier` function on the `sixtyfps::Window` type. It takes a callback as a parameter and that is invoked during different phases of the rendering. In this example the invocation during the setup phase is used to prepare the pipeline for OpenGL rendering later. Then the `BeforeRendering` phase is used to render the graphical effect with OpenGL. Afterwards, SixtyFPS will render the scene of elements into the same back-buffer as the previous OpenGL code rendered into.
+
+Since the graphical effect is continuous, the code in the callback requests a redraw of the contents by calling `sixtyfps::Window::request_redraw()`.

--- a/examples/opengl_underlay/build.rs
+++ b/examples/opengl_underlay/build.rs
@@ -1,0 +1,6 @@
+// Copyright © SixtyFPS GmbH <info@sixtyfps.io>
+// SPDX-License-Identifier: (GPL-3.0-only OR LicenseRef-SixtyFPS-commercial)
+
+fn main() {
+    sixtyfps_build::compile("scene.60").unwrap();
+}

--- a/examples/opengl_underlay/index.html
+++ b/examples/opengl_underlay/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+
+<!-- Copyright © SixtyFPS GmbH <info@sixtyfps.io> -->
+<!-- SPDX-License-Identifier: (GPL-3.0-only OR LicenseRef-SixtyFPS-commercial) -->
+
+<html>
+<!--
+    This is a static html file used to display the wasm build.
+    In order to generate the build
+     - uncomment the #wasm# lines in Cargo.toml
+     - Run `wasm-pack build --release --target web` in this directory.
+  -->
+
+<head>
+  <meta charset="UTF-8">
+  <title>SixtyFPS OpenGL Underlay Example (Web Assembly version)</title>
+</head>
+<style>
+  canvas:focus {
+    outline: none;
+    touch-action: none;
+  }
+
+  /* beautify ignore:start */
+  .spinner:before {
+    content: ''; box-sizing: border-box; position: absolute;
+    top: 50%; left: 50%; width: 100px; height: 100px;
+    margin-top: -10px; margin-left: -10px;
+    border-radius: 50%;  border: 2px solid transparent;
+    border-top-color: #07d; border-bottom-color: #07d;
+    animation: spinner 1s ease infinite;
+  }
+  @keyframes spinner { to { transform: rotate(360deg); } }
+  /* beautify ignore:end */
+</style>
+
+<body>
+  <p>This is the <a href="https://sixtyfps.io">SixtyFPS</a> OpenGL Underlay example compiled to WebAssembly. It demonstrates an OpenGL rendered scene under a SixtyFPS scene.</p>
+  <div id="spinner" style="position: relative;">
+    <div class="spinner">Loading...</div>
+  </div>
+  <canvas id="canvas" width="640" height="480"></canvas>
+  <p>
+    <a href="https://github.com/sixtyfpsui/sixtyfps/blob/master/examples/opengl_underlay/scene.60">
+      View Source Code on GitHub</a> -
+    <a
+      href="https://sixtyfps.io/editor?load_url=https://raw.githubusercontent.com/sixtyfpsui/sixtyfps/master/examples/opengl_underlay/scene.60">
+      Edit in the online code editor
+    </a>
+  </p>
+  <script type="module">
+    import init from './pkg/opengl_underlay.js';
+    init().finally(() => {
+      document.getElementById("spinner").remove();
+    });
+  </script>
+</body>
+
+</html>

--- a/examples/opengl_underlay/main.cpp
+++ b/examples/opengl_underlay/main.cpp
@@ -1,0 +1,181 @@
+// Copyright © SixtyFPS GmbH <info@sixtyfps.io>
+// SPDX-License-Identifier: (GPL-3.0-only OR LicenseRef-SixtyFPS-commercial)
+
+#include "scene.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <stdlib.h>
+#include <stdio.h>
+#include <chrono>
+
+#include <GLES2/gl2.h>
+#include <GLES2/gl2platform.h>
+
+static GLint compile_shader(GLuint program, GLuint shader_type, const GLchar *const *source)
+{
+    auto shader_id = glCreateShader(shader_type);
+    glShaderSource(shader_id, 1, source, nullptr);
+    glCompileShader(shader_id);
+
+    GLint compiled = 0;
+    glGetShaderiv(shader_id, GL_COMPILE_STATUS, &compiled);
+    if (!compiled) {
+        GLint infoLen = 0;
+        glGetShaderiv(shader_id, GL_INFO_LOG_LENGTH, &infoLen);
+        if (infoLen > 1) {
+            char *infoLog = reinterpret_cast<char *>(malloc(sizeof(char) * infoLen));
+            glGetShaderInfoLog(shader_id, infoLen, NULL, infoLog);
+            fprintf(stderr, "Error compiling %s shader:\n%s\n",
+                    shader_type == GL_FRAGMENT_SHADER ? "fragment shader" : "vertex shader",
+                    infoLog);
+            free(infoLog);
+        }
+        glDeleteShader(shader_id);
+        exit(1);
+    }
+    glAttachShader(program, shader_id);
+
+    return shader_id;
+}
+
+class OpenGLUnderlay
+{
+public:
+    OpenGLUnderlay(sixtyfps::ComponentWeakHandle<App> app) : app_weak(app) { }
+
+    void operator()(sixtyfps::RenderingState state)
+    {
+        switch (state) {
+        case sixtyfps::RenderingState::RenderingSetup:
+            setup();
+            break;
+        case sixtyfps::RenderingState::BeforeRendering:
+            if (auto app = app_weak.lock()) {
+                render((*app)->get_rotation_enabled());
+                (*app)->window().request_redraw();
+            }
+            break;
+        case sixtyfps::RenderingState::AfterRendering:
+            break;
+        case sixtyfps::RenderingState::RenderingTeardown:
+            teardown();
+            break;
+        }
+    }
+
+private:
+    void setup()
+    {
+        program = glCreateProgram();
+
+        const GLchar *const fragment_shader =
+                "#version 100\n"
+                "precision mediump float;\n"
+                "varying vec2 frag_position;\n"
+                "uniform float effect_time;\n"
+                "uniform float rotation_time;\n"
+                "float roundRectDistance(vec2 pos, vec2 rect_size, float radius)\n"
+                "{\n"
+                "    vec2 q = abs(pos) - rect_size + radius;\n"
+                "    return min(max(q.x, q.y), 0.0) + length(max(q, 0.0)) - radius;\n"
+                "}\n"
+                "void main() {\n"
+                "    vec2 size = vec2(0.4, 0.5) + 0.2 * cos(effect_time / 500. + vec2(0.3, 0.2));\n"
+                "    float radius = 0.5 * sin(effect_time / 300.);\n"
+                "    float a = rotation_time / 800.0;\n"
+                "    float d = roundRectDistance(mat2(cos(a), -sin(a), sin(a), cos(a)) * "
+                "frag_position, size, radius);\n"
+                "    vec3 col = (d > 0.0) ? vec3(sin(d * 0.2), 0.4 * cos(effect_time / 1000.0 + d "
+                "* 0.8), "
+                "sin(d * 1.2)) : vec3(0.2 * cos(d * 0.1), 0.17 * sin(d * 0.4), 0.96 * "
+                "abs(sin(effect_time "
+                "/ 500. - d * 0.9)));\n"
+                "    col *= 0.8 + 0.5 * sin(50.0 * d);\n"
+                "    col = mix(col, vec3(0.9), 1.0 - smoothstep(0.0, 0.03, abs(d) ));\n"
+                "    gl_FragColor = vec4(col, 1.0);\n"
+                "}\n";
+
+        const GLchar *const vertex_shader = "#version 100\n"
+                                            "attribute vec2 position;\n"
+                                            "varying vec2 frag_position;\n"
+                                            "void main() {\n"
+                                            "    frag_position = position;\n"
+                                            "    gl_Position = vec4(position, 0.0, 1.0);\n"
+                                            "}\n";
+
+        auto fragment_shader_id = compile_shader(program, GL_FRAGMENT_SHADER, &fragment_shader);
+        auto vertex_shader_id = compile_shader(program, GL_VERTEX_SHADER, &vertex_shader);
+
+        GLint linked = 0;
+        glLinkProgram(program);
+        glGetProgramiv(program, GL_LINK_STATUS, &linked);
+
+        if (!linked) {
+            GLint infoLen = 0;
+            glGetProgramiv(program, GL_INFO_LOG_LENGTH, &infoLen);
+            if (infoLen > 1) {
+                char *infoLog = reinterpret_cast<char *>(malloc(sizeof(char) * infoLen));
+                glGetProgramInfoLog(program, infoLen, NULL, infoLog);
+                fprintf(stderr, "Error linking shader:\n%s\n", infoLog);
+                free(infoLog);
+            }
+            glDeleteProgram(program);
+            exit(1);
+        }
+        glDetachShader(program, fragment_shader_id);
+        glDetachShader(program, vertex_shader_id);
+
+        position_location = glGetAttribLocation(program, "position");
+        effect_time_location = glGetUniformLocation(program, "effect_time");
+        rotation_time_location = glGetUniformLocation(program, "rotation_time");
+    }
+
+    void render(bool enable_rotation)
+    {
+        glUseProgram(program);
+        const float vertices[] = { -1.0, 1.0, -1.0, -1.0, 1.0, 1.0, 1.0, -1.0 };
+        glVertexAttribPointer(position_location, 2, GL_FLOAT, GL_FALSE, 0, vertices);
+        glEnableVertexAttribArray(position_location);
+
+        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - start_time);
+        glUniform1f(effect_time_location, elapsed.count());
+        if (enable_rotation) {
+            glUniform1f(rotation_time_location, elapsed.count());
+        } else {
+            glUniform1f(rotation_time_location, 0.0);
+        }
+
+        glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+        glUseProgram(0);
+    }
+
+    void teardown() { glDeleteProgram(program); }
+
+    sixtyfps::ComponentWeakHandle<App> app_weak;
+    GLuint program = 0;
+    GLuint position_location = 0;
+    GLuint effect_time_location = 0;
+    GLuint rotation_time_location = 0;
+    std::chrono::time_point<std::chrono::steady_clock> start_time =
+            std::chrono::steady_clock::now();
+};
+
+int main()
+{
+    auto app = App::create();
+
+    if (auto error = app->window().set_rendering_notifier(OpenGLUnderlay(app))) {
+        if (*error == sixtyfps::SetRenderingNotifierError::Unsupported) {
+            fprintf(stderr,
+                    "This example requires the use of the GL backend. Please run with the "
+                    "environment variable SIXTYFPS_BACKEND=GL set.\n");
+        } else {
+            fprintf(stderr, "Unknown error calling set_rendering_notifier\n");
+        }
+        exit(EXIT_FAILURE);
+    }
+
+    app->run();
+}

--- a/examples/opengl_underlay/main.rs
+++ b/examples/opengl_underlay/main.rs
@@ -1,0 +1,225 @@
+// Copyright © SixtyFPS GmbH <info@sixtyfps.io>
+// SPDX-License-Identifier: (GPL-3.0-only OR LicenseRef-SixtyFPS-commercial)
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
+sixtyfps::include_modules!();
+
+use glow::HasContext;
+
+struct EGLUnderlay {
+    gl: glow::Context,
+    program: glow::Program,
+    effect_time_location: glow::UniformLocation,
+    rotation_time_location: glow::UniformLocation,
+    vbo: glow::Buffer,
+    vao: glow::VertexArray,
+    start_time: instant::Instant,
+}
+
+impl EGLUnderlay {
+    fn new(gl: glow::Context) -> Self {
+        unsafe {
+            let program = gl.create_program().expect("Cannot create program");
+
+            let (vertex_shader_source, fragment_shader_source) = (
+                r#"#version 100
+            attribute vec2 position;
+            varying vec2 frag_position;
+            void main() {
+                frag_position = position;
+                gl_Position = vec4(position, 0.0, 1.0);
+            }"#,
+                r#"#version 100
+            precision mediump float;
+            varying vec2 frag_position;
+            uniform float effect_time;
+            uniform float rotation_time;
+
+            float roundRectDistance(vec2 pos, vec2 rect_size, float radius)
+            {
+                vec2 q = abs(pos) - rect_size + radius;
+                return min(max(q.x, q.y), 0.0) + length(max(q, 0.0)) - radius;
+            }
+
+            void main() {
+                vec2 size = vec2(0.4, 0.5) + 0.2 * cos(effect_time / 500. + vec2(0.3, 0.2));
+                float radius = 0.5 * sin(effect_time / 300.);
+                float a = rotation_time / 800.0;
+                float d = roundRectDistance(mat2(cos(a), -sin(a), sin(a), cos(a)) * frag_position, size, radius);
+                vec3 col = (d > 0.0) ? vec3(sin(d * 0.2), 0.4 * cos(effect_time / 1000.0 + d * 0.8), sin(d * 1.2)) : vec3(0.2 * cos(d * 0.1), 0.17 * sin(d * 0.4), 0.96 * abs(sin(effect_time / 500. - d * 0.9)));
+                col *= 0.8 + 0.5 * sin(50.0 * d);
+                col = mix(col, vec3(0.9), 1.0 - smoothstep(0.0, 0.03, abs(d) ));
+                gl_FragColor = vec4(col, 1.0);
+            }"#,
+            );
+
+            let shader_sources = [
+                (glow::VERTEX_SHADER, vertex_shader_source),
+                (glow::FRAGMENT_SHADER, fragment_shader_source),
+            ];
+
+            let mut shaders = Vec::with_capacity(shader_sources.len());
+
+            for (shader_type, shader_source) in shader_sources.iter() {
+                let shader = gl.create_shader(*shader_type).expect("Cannot create shader");
+                gl.shader_source(shader, shader_source);
+                gl.compile_shader(shader);
+                if !gl.get_shader_compile_status(shader) {
+                    panic!("{}", gl.get_shader_info_log(shader));
+                }
+                gl.attach_shader(program, shader);
+                shaders.push(shader);
+            }
+
+            gl.link_program(program);
+            if !gl.get_program_link_status(program) {
+                panic!("{}", gl.get_program_info_log(program));
+            }
+
+            for shader in shaders {
+                gl.detach_shader(program, shader);
+                gl.delete_shader(shader);
+            }
+
+            let effect_time_location = gl.get_uniform_location(program, "effect_time").unwrap();
+            let rotation_time_location = gl.get_uniform_location(program, "rotation_time").unwrap();
+            let position_location = gl.get_attrib_location(program, "position").unwrap();
+
+            let vbo = gl.create_buffer().expect("Cannot create buffer");
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(vbo));
+
+            let vertices = [-1.0f32, 1.0f32, -1.0f32, -1.0f32, 1.0f32, 1.0f32, 1.0f32, -1.0f32];
+
+            gl.buffer_data_u8_slice(glow::ARRAY_BUFFER, vertices.align_to().1, glow::STATIC_DRAW);
+
+            let vao = gl.create_vertex_array().expect("Cannot create vertex array");
+            gl.bind_vertex_array(Some(vao));
+            gl.enable_vertex_attrib_array(position_location);
+            gl.vertex_attrib_pointer_f32(position_location, 2, glow::FLOAT, false, 8, 0);
+
+            gl.bind_buffer(glow::ARRAY_BUFFER, None);
+            gl.bind_vertex_array(None);
+
+            Self {
+                gl,
+                program,
+                effect_time_location,
+                rotation_time_location,
+                vbo,
+                vao,
+                start_time: instant::Instant::now(),
+            }
+        }
+    }
+}
+
+impl Drop for EGLUnderlay {
+    fn drop(&mut self) {
+        unsafe {
+            self.gl.delete_program(self.program);
+            self.gl.delete_vertex_array(self.vao);
+            self.gl.delete_buffer(self.vbo);
+        }
+    }
+}
+
+impl EGLUnderlay {
+    fn render(&mut self, rotation_enabled: bool) {
+        unsafe {
+            let gl = &self.gl;
+
+            gl.use_program(Some(self.program));
+
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(self.vbo));
+
+            gl.bind_vertex_array(Some(self.vao));
+
+            let elapsed = self.start_time.elapsed().as_millis() as f32;
+            gl.uniform_1_f32(Some(&self.effect_time_location), elapsed);
+            gl.uniform_1_f32(
+                Some(&self.rotation_time_location),
+                if rotation_enabled { elapsed } else { 0.0 },
+            );
+
+            gl.draw_arrays(glow::TRIANGLE_STRIP, 0, 4);
+
+            gl.bind_buffer(glow::ARRAY_BUFFER, None);
+            gl.bind_vertex_array(None);
+            gl.use_program(None);
+        }
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
+pub fn main() {
+    // This provides better error messages in debug mode.
+    // It's disabled in release mode so it doesn't bloat up the file size.
+    #[cfg(all(debug_assertions, target_arch = "wasm32"))]
+    console_error_panic_hook::set_once();
+
+    let app = App::new();
+
+    let mut underlay = None;
+
+    let app_weak = app.as_weak();
+
+    if let Err(error) = app.window().set_rendering_notifier(move |state, graphics_api| {
+        // eprintln!("rendering state {:#?}", state);
+
+        match state {
+            sixtyfps::RenderingState::RenderingSetup => {
+                let context = match graphics_api {
+                    #[cfg(not(target_arch = "wasm32"))]
+                    sixtyfps::GraphicsAPI::NativeOpenGL { get_proc_address } => unsafe {
+                        glow::Context::from_loader_function(|s| get_proc_address(s))
+                    },
+                    #[cfg(target_arch = "wasm32")]
+                    sixtyfps::GraphicsAPI::WebGL { canvas_element_id, context_type } => {
+                        use wasm_bindgen::JsCast;
+
+                        let canvas = web_sys::window()
+                            .unwrap()
+                            .document()
+                            .unwrap()
+                            .get_element_by_id(canvas_element_id)
+                            .unwrap()
+                            .dyn_into::<web_sys::HtmlCanvasElement>()
+                            .unwrap();
+
+                        let webgl1_context = canvas
+                            .get_context(context_type)
+                            .unwrap()
+                            .unwrap()
+                            .dyn_into::<web_sys::WebGlRenderingContext>()
+                            .unwrap();
+
+                        glow::Context::from_webgl1_context(webgl1_context)
+                    }
+                    _ => return,
+                };
+                underlay = Some(EGLUnderlay::new(context))
+            }
+            sixtyfps::RenderingState::BeforeRendering => {
+                if let (Some(underlay), Some(app)) = (underlay.as_mut(), app_weak.upgrade()) {
+                    underlay.render(app.get_rotation_enabled());
+                    app.window().request_redraw();
+                }
+            }
+            sixtyfps::RenderingState::AfterRendering => {}
+            sixtyfps::RenderingState::RenderingTeardown => {
+                drop(underlay.take());
+            }
+            _ => {}
+        }
+    }) {
+        match error {
+            sixtyfps::SetRenderingNotifierError::Unsupported => eprintln!("This example requires the use of the GL backend. Please run with the environment variable SIXTYFPS_BACKEND=GL set."),
+            _ => unreachable!()
+        }
+        std::process::exit(1);
+    }
+
+    app.run();
+}

--- a/examples/opengl_underlay/scene.60
+++ b/examples/opengl_underlay/scene.60
@@ -1,0 +1,36 @@
+// Copyright © SixtyFPS GmbH <info@sixtyfps.io>
+// SPDX-License-Identifier: (GPL-3.0-only OR LicenseRef-SixtyFPS-commercial)
+
+import { ScrollView, Button, CheckBox, SpinBox, Slider, GroupBox, LineEdit, StandardListView,
+    ComboBox, HorizontalBox, VerticalBox, GridBox, TabWidget, TextEdit, AboutSixtyFPS } from "sixtyfps_widgets.60";
+
+App := Window {
+    preferred-width: 500px;
+    preferred-height: 600px;
+    title: "SixtyFPS OpenGL Underlay Example";
+    icon: @image-url("../../vscode_extension/extension-logo.png");
+
+    property <bool> rotation-enabled <=> apply-rotation.checked;
+
+    VerticalBox {
+        Rectangle {
+            background: #ffffff92;
+            HorizontalBox {
+                Text {
+                    text: "This text is rendered using SixtyFPS. The animation below is rendered using OpenGL code.";
+                    wrap: word-wrap;
+                }
+
+                VerticalLayout {
+                    alignment: start;
+                    apply-rotation := CheckBox {
+                        checked: true;
+                        text: "Rotate the OpenGL underlay";
+                    }
+                }
+            }
+        }
+
+        Rectangle {}
+    }
+}

--- a/internal/backends/gl/glcontext.rs
+++ b/internal/backends/gl/glcontext.rs
@@ -16,7 +16,7 @@ enum OpenGLContextState {
     #[cfg(not(target_arch = "wasm32"))]
     Current(glutin::WindowedContext<glutin::PossiblyCurrent>),
     #[cfg(target_arch = "wasm32")]
-    Current(Rc<winit::window::Window>),
+    Current { window: Rc<winit::window::Window>, canvas: web_sys::HtmlCanvasElement },
 }
 
 pub struct OpenGLContext(RefCell<Option<OpenGLContextState>>);
@@ -29,7 +29,14 @@ impl OpenGLContext {
             #[cfg(not(target_arch = "wasm32"))]
             OpenGLContextState::Current(context) => context.window(),
             #[cfg(target_arch = "wasm32")]
-            OpenGLContextState::Current(window) => window.as_ref(),
+            OpenGLContextState::Current { window, .. } => window.as_ref(),
+        })
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn html_canvas_element(&self) -> std::cell::Ref<web_sys::HtmlCanvasElement> {
+        std::cell::Ref::map(self.0.borrow(), |state| match state.as_ref().unwrap() {
+            OpenGLContextState::Current { canvas, .. } => canvas,
         })
     }
 
@@ -41,7 +48,7 @@ impl OpenGLContext {
                 let current_ctx = unsafe { not_current_ctx.make_current().unwrap() };
                 OpenGLContextState::Current(current_ctx)
             }
-            state @ OpenGLContextState::Current(_) => state,
+            state @ OpenGLContextState::Current { .. } => state,
         });
     }
 
@@ -60,12 +67,12 @@ impl OpenGLContext {
         }
     }
 
-    pub fn with_current_context<T>(&self, cb: impl FnOnce() -> T) -> T {
-        if matches!(self.0.borrow().as_ref().unwrap(), OpenGLContextState::Current(_)) {
-            cb()
+    pub fn with_current_context<T>(&self, cb: impl FnOnce(&Self) -> T) -> T {
+        if matches!(self.0.borrow().as_ref().unwrap(), OpenGLContextState::Current { .. }) {
+            cb(self)
         } else {
             self.make_current();
-            let result = cb();
+            let result = cb(self);
             self.make_not_current();
             result
         }
@@ -261,7 +268,15 @@ impl OpenGLContext {
 
             let renderer =
                 femtovg::renderer::OpenGl::new_from_html_canvas(&window.canvas()).unwrap();
-            (Self(RefCell::new(Some(OpenGLContextState::Current(window)))), renderer)
+            (Self(RefCell::new(Some(OpenGLContextState::Current { window, canvas }))), renderer)
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn get_proc_address(&self, name: &str) -> *const std::ffi::c_void {
+        match &self.0.borrow().as_ref().unwrap() {
+            OpenGLContextState::NotCurrent(_) => std::ptr::null(),
+            OpenGLContextState::Current(current_ctx) => current_ctx.get_proc_address(name),
         }
     }
 }

--- a/internal/backends/mcu/lib.rs
+++ b/internal/backends/mcu/lib.rs
@@ -123,6 +123,7 @@ mod the_backend {
             _items: &mut dyn Iterator<Item = Pin<sixtyfps_corelib::items::ItemRef<'a>>>,
         ) {
         }
+
         fn show_popup(&self, _popup: &ComponentRc, _position: sixtyfps_corelib::graphics::Point) {
             todo!()
         }

--- a/internal/backends/mcu/simulator.rs
+++ b/internal/backends/mcu/simulator.rs
@@ -224,8 +224,8 @@ impl WinitWindow for SimulatorWindow {
 
         let size = self.opengl_context.window().inner_size();
 
-        self.opengl_context.with_current_context(|| {
-            self.opengl_context.ensure_resized();
+        self.opengl_context.with_current_context(|opengl_context| {
+            opengl_context.ensure_resized();
 
             {
                 let mut canvas = self.canvas.borrow_mut();
@@ -294,7 +294,7 @@ impl WinitWindow for SimulatorWindow {
             canvas.flush();
             canvas.delete_image(image_id);
 
-            self.opengl_context.swap_buffers();
+            opengl_context.swap_buffers();
         });
     }
 

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -119,6 +119,18 @@ impl Window {
     ) -> std::result::Result<(), SetRenderingNotifierError> {
         self.0.set_rendering_notifier(Box::new(callback))
     }
+
+    /// This function issues a request to the windowing system to redraw the contents of the window.
+    pub fn request_redraw(&self) {
+        self.0.request_redraw();
+
+        // When this function is called by the user, we want it to translate to a requestAnimationFrame()
+        // on the web. If called through the rendering notifier (so from within the event loop processing),
+        // unfortunately winit will only do that if set the control flow to Poll. This hack achieves that.
+        #[cfg(target_arch = "wasm32")]
+        crate::animations::CURRENT_ANIMATION_DRIVER
+            .with(|driver| driver.set_has_active_animations());
+    }
 }
 
 impl crate::window::WindowHandleAccess for Window {

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -10,6 +10,83 @@ use std::rc::Rc;
 use crate::component::ComponentVTable;
 use crate::window::WindowRc;
 
+/// This enum describes a low-level access to specific graphcis APIs used
+/// by the renderer.
+#[derive(Clone)]
+#[non_exhaustive]
+pub enum GraphicsAPI<'a> {
+    /// The rendering is done using OpenGL.
+    NativeOpenGL {
+        /// Use this function pointer to obtain access to the OpenGL implementation - similar to `eglGetProcAddress`.
+        get_proc_address: &'a dyn Fn(&str) -> *const std::ffi::c_void,
+    },
+    /// The rendering is done on a HTML Canvas element using WebGL.
+    WebGL {
+        /// The DOM element id of the HTML Canvas element used for rendering.
+        canvas_element_id: &'a str,
+        /// The drawing context type used on the HTML Canvas element for rendering. This is the argument to the
+        /// `getContext` function on the HTML Canvas element.
+        context_type: &'a str,
+    },
+}
+
+impl<'a> std::fmt::Debug for GraphicsAPI<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GraphicsAPI::NativeOpenGL { .. } => write!(f, "GraphicsAPI::NativeOpenGL"),
+            GraphicsAPI::WebGL { context_type, .. } => {
+                write!(f, "GraphicsAPI::WebGL(context_type = {})", context_type)
+            }
+        }
+    }
+}
+
+/// This enum describes the different rendering states, that will be provided
+/// to the parameter of the callback for `set_rendering_notifier` on the `Window`.
+#[derive(Debug, Clone)]
+#[repr(C)]
+#[non_exhaustive]
+pub enum RenderingState {
+    /// The window has been created and the graphics adapter/context initialized. When OpenGL
+    /// is used for rendering, the context will be current.
+    RenderingSetup,
+    /// The scene of items is about to be rendered.  When OpenGL
+    /// is used for rendering, the context will be current.
+    BeforeRendering,
+    /// The scene of items was rendered, but the back buffer was not sent for display presentation
+    /// yet (for example GL swap buffers). When OpenGL is used for rendering, the context will be current.
+    AfterRendering,
+    /// The window will be destroyed and/or graphics resources need to be released due to other
+    /// constraints.
+    RenderingTeardown,
+}
+
+/// Internal trait that's used to map rendering state callbacks to either a Rust-API provided
+/// impl FnMut or a struct that invokes a C callback and implements Drop to release the closure
+/// on the C++ side.
+pub trait RenderingNotifier {
+    /// Called to notify that rendering has reached a certain state.
+    fn notify(&mut self, state: RenderingState, graphics_api: &GraphicsAPI);
+}
+
+impl<F: FnMut(RenderingState, &GraphicsAPI)> RenderingNotifier for F {
+    fn notify(&mut self, state: RenderingState, graphics_api: &GraphicsAPI) {
+        self(state, graphics_api)
+    }
+}
+
+/// This enum describes the different error scenarios that may occur when the applicaton
+/// registers a rendering notifier on a [`sixtyfps::Window`].
+#[derive(Debug, Clone)]
+#[repr(C)]
+#[non_exhaustive]
+pub enum SetRenderingNotifierError {
+    /// The rendering backend does not support rendering notifiers.
+    Unsupported,
+    /// There is already a rendering notifier set, multiple notifiers are not supported.
+    AlreadySet,
+}
+
 /// This type represents a window towards the windowing system, that's used to render the
 /// scene of a component. It provides API to control windowing system specific aspects such
 /// as the position on the screen.
@@ -32,6 +109,15 @@ impl Window {
     /// De-registers the window from the windowing system, therefore hiding it.
     pub fn hide(&self) {
         self.0.hide();
+    }
+
+    /// This function allows registering a callback that's invoked during the different phases of
+    /// rendering. This allows custom rendering on top or below of the scene.
+    pub fn set_rendering_notifier(
+        &self,
+        callback: impl FnMut(RenderingState, &GraphicsAPI) + 'static,
+    ) -> std::result::Result<(), SetRenderingNotifierError> {
+        self.0.set_rendering_notifier(Box::new(callback))
     }
 }
 

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -30,6 +30,15 @@ pub trait PlatformWindow {
     /// implementation typically uses this to free the underlying graphics resources cached via [`crate::graphics::RenderingCache`].
     fn free_graphics_resources<'a>(&self, items: &mut dyn Iterator<Item = Pin<ItemRef<'a>>>);
 
+    /// This function is called through the public API to register a callback that the backend needs to invoke during
+    /// different phases of rendering.
+    fn set_rendering_notifier(
+        &self,
+        _callback: Box<dyn crate::api::RenderingNotifier>,
+    ) -> std::result::Result<(), crate::api::SetRenderingNotifierError> {
+        Err(crate::api::SetRenderingNotifierError::Unsupported)
+    }
+
     /// Show a popup at the given position
     fn show_popup(&self, popup: &ComponentRc, position: Point);
 
@@ -571,6 +580,7 @@ pub mod ffi {
     #![allow(unsafe_code)]
 
     use super::*;
+    use crate::api::{RenderingNotifier, RenderingState, SetRenderingNotifierError};
     use crate::slice::Slice;
 
     #[allow(non_camel_case_types)]
@@ -677,5 +687,46 @@ pub mod ffi {
     pub unsafe extern "C" fn sixtyfps_windowrc_close_popup(handle: *const WindowRcOpaque) {
         let window = &*(handle as *const WindowRc);
         window.close_popup();
+    }
+
+    /// C binding to the set_rendering_notifier() API of Window
+    #[no_mangle]
+    pub unsafe extern "C" fn sixtyfps_windowrc_set_rendering_notifier(
+        handle: *const WindowRcOpaque,
+        callback: extern "C" fn(rendering_state: RenderingState, user_data: *mut c_void),
+        drop_user_data: extern "C" fn(user_data: *mut c_void),
+        user_data: *mut c_void,
+        error: *mut SetRenderingNotifierError,
+    ) -> bool {
+        struct CNotifier {
+            callback: extern "C" fn(rendering_state: RenderingState, user_data: *mut c_void),
+            drop_user_data: extern "C" fn(*mut c_void),
+            user_data: *mut c_void,
+        }
+
+        impl Drop for CNotifier {
+            fn drop(&mut self) {
+                (self.drop_user_data)(self.user_data)
+            }
+        }
+
+        impl RenderingNotifier for CNotifier {
+            fn notify(&mut self, state: RenderingState, _graphics_api: &crate::api::GraphicsAPI) {
+                (self.callback)(state, self.user_data)
+            }
+        }
+
+        let window = &*(handle as *const WindowRc);
+        match window.set_rendering_notifier(Box::new(CNotifier {
+            callback,
+            drop_user_data,
+            user_data,
+        })) {
+            Ok(()) => true,
+            Err(err) => {
+                *error = err;
+                false
+            }
+        }
     }
 }

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -729,4 +729,11 @@ pub mod ffi {
             }
         }
     }
+
+    /// This function issues a request to the windowing system to redraw the contents of the window.
+    #[no_mangle]
+    pub unsafe extern "C" fn sixtyfps_windowrc_request_redraw(handle: *const WindowRcOpaque) {
+        let window = &*(handle as *const WindowRc);
+        window.request_redraw();
+    }
 }


### PR DESCRIPTION
This is the initial merge request for supporting underlay and overlay rendering in Rust and C++.

There are a few caveats:

* Explicit backend and native style selection needs to be implemented for Rust and C++.
  * For C++ I think the style could simply be a string target property and we call back to the "default" (which is not configurable right now, but that's a separate issue).
  * For Rust and C++ we need the ability to select a backend. This could be a "one-time" function `mod sixtyfps { pub fn set_backend(name: &'str) -> std::result::Result<(), String>; `
* There's a hack in the `request_redraw()` API :-(
* The first change in the series adds support for alpha in the Window surface, so in the most extreme case you can write `background: transparent;` on a `Window` and it'll make the background shine through. This works on macOS, Wayland and Windows with the GL backend for me, but somehow not with X11. Also it is not implemented with the Qt backend. This also means that the C++ overlay alpha mask example doesn't work on X11 (not on Windows anyway because of GLES2 headers). I'm not sure how far to go here. Should I try to implement it for Qt? We know that the use-case is limited right now.

The graphics exposure API I tried to keep (a) free of public dependencies (b) flexible for future expansion away from OpenGL and (b) with a life-time attached so that we *can* pass temporaries from the backend to the user-code.


Edit: TODO:

 - [x] Provide a return value for `set_rendering_notifier` that allows error detection. This also captures the backend selection part then.
 - [x] Make the allocation of the ARGB surface an opt-in. This does come at the expense of memory and strictly speaking also GPU performance, so we should make it opt-in for the rare case that it's needed instead of always paying the price for it.