### PR TITLE
Rust generator: Fix compilation returning from void callbacks

### DIFF
--- a/tests/cases/callbacks/handler.60
+++ b/tests/cases/callbacks/handler.60
@@ -6,7 +6,13 @@ TestCase := Rectangle {
     callback test_callback2;
     callback test_callback3;
     property<int> callback_emission_count;
-    test_callback => { callback_emission_count += 1; }
+    test_callback => {
+        callback_emission_count += 1;
+        // This returns something despite the callback isn't supposed to return anything.
+        // Maybe one should produce a warning in the future, but at least we shouldn't
+        // result in compilation error in the generated code
+        callback_emission_count
+    }
     test_callback2 => {  callback_emission_count = 88; root.test_callback3(); }
 }
 /*

--- a/tests/cases/callbacks/return_value.60
+++ b/tests/cases/callbacks/return_value.60
@@ -12,6 +12,8 @@ TestCase := Rectangle {
 
     callback dummy() -> int;
     dummy => { 4.4 }
+    callback returns_void;
+    returns_void => { test_func2("haha", 8) }
 
     property <bool> test: test_prop == 4 && test_prop2 == "hello=50";
 }


### PR DESCRIPTION
If a callback returning voids ends in a statement that returns something,
we would have an error in the rust generated code as we end our function
with an expression that is not `()`