### PR TITLE
Minor fixup to the C++ rendering notifier API

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -164,6 +164,7 @@ fn gen_corelib(
         "IntSize",                   // included in generated_public.h
         "RenderingState",            // included in generated_public.h
         "SetRenderingNotifierError", // included in generated_public.h
+        "GraphicsAPI",               // included in generated_public.h
     ]
     .iter()
     .map(|x| x.to_string())
@@ -328,6 +329,7 @@ fn gen_corelib(
         "IntSize".into(),
         "RenderingState".into(),
         "SetRenderingNotifierError".into(),
+        "GraphicsAPI".into(),
     ];
 
     public_config.export.body.insert(

--- a/api/cpp/include/sixtyfps.h
+++ b/api/cpp/include/sixtyfps.h
@@ -144,8 +144,8 @@ public:
     template<typename F>
     std::optional<SetRenderingNotifierError> set_rendering_notifier(F callback) const
     {
-        auto actual_cb = [](RenderingState state, void *data) {
-            (*reinterpret_cast<F *>(data))(state);
+        auto actual_cb = [](RenderingState state, GraphicsAPI graphics_api, void *data) {
+            (*reinterpret_cast<F *>(data))(state, graphics_api);
         };
         SetRenderingNotifierError err;
         if (cbindgen_private::sixtyfps_windowrc_set_rendering_notifier(

--- a/examples/opengl_underlay/main.cpp
+++ b/examples/opengl_underlay/main.cpp
@@ -44,7 +44,7 @@ class OpenGLUnderlay
 public:
     OpenGLUnderlay(sixtyfps::ComponentWeakHandle<App> app) : app_weak(app) { }
 
-    void operator()(sixtyfps::RenderingState state)
+    void operator()(sixtyfps::RenderingState state, sixtyfps::GraphicsAPI)
     {
         switch (state) {
         case sixtyfps::RenderingState::RenderingSetup:


### PR DESCRIPTION
Add the graphics state enum to the callback, too. When we add support for different backends,
it would be nice if it didn't require an API change.

 It's duplicated from Rust
because it doesn't provide values. The WebLG one doesn't make sense for C++ and
the proc address closure isn't ffi safe.

(It could be manually bridged thought)