### PR TITLE
Fix GL example not updating on Windows

### DIFF
--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -127,7 +127,8 @@ impl Window {
         // When this function is called by the user, we want it to translate to a requestAnimationFrame()
         // on the web. If called through the rendering notifier (so from within the event loop processing),
         // unfortunately winit will only do that if set the control flow to Poll. This hack achieves that.
-        #[cfg(target_arch = "wasm32")]
+        // Similarly, the winit win32 event loop doesn't queue the redraw request and needs a Poll nudge.
+        #[cfg(any(target_arch = "wasm32", target_os = "windows"))]
         crate::animations::CURRENT_ANIMATION_DRIVER
             .with(|driver| driver.set_has_active_animations());
     }


### PR DESCRIPTION
The winit event loop needs a similar Poll nudge as for wasm in order for request_redraw() to work :-(